### PR TITLE
`slurm_nodes_inval`: add `INVAL` node state

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Provides aggregated metrics on node states for the cluster.
 | `slurm_nodes_err` | Error nodes | `partition`, `active_feature_set` |
 | `slurm_nodes_fail` | Fail nodes | `partition`, `active_feature_set` |
 | `slurm_nodes_idle` | Idle nodes | `partition`, `active_feature_set` |
+| `slurm_nodes_inval` | Inval nodes | `partition`, `active_feature_set` |
 | `slurm_nodes_maint` | Maint nodes | `partition`, `active_feature_set` |
 | `slurm_nodes_mix` | Mix nodes | `partition`, `active_feature_set` |
 | `slurm_nodes_resv` | Reserved nodes | `partition`, `active_feature_set` |

--- a/internal/collector/nodes_test.go
+++ b/internal/collector/nodes_test.go
@@ -28,4 +28,5 @@ func TestNodesMetrics(t *testing.T) {
 	assert.Equal(t, 24, int(nm.other["feature_a"]))
 	assert.Equal(t, 3, int(nm.planned["feature_a"]))
 	assert.Equal(t, 5, int(nm.planned["feature_b"]))
+	assert.Equal(t, 7, int(nm.inval["null"]))
 }

--- a/test_data/sinfo.txt
+++ b/test_data/sinfo.txt
@@ -7,4 +7,5 @@
 24|foo_bar_baz|feature_a
 3|planned|feature_a
 5|planned|feature_b
+7|inval|(null)
 


### PR DESCRIPTION
From https://slurm.schedmd.com/sinfo.html#OPT_INVAL,

> The node did not register correctly with the controller. This happens when a node registers with less resources than configured in the slurm.conf file. The node will clear from this state with a valid registration (i.e. a slurmd restart is required).