### PR TITLE
fix(dashboards): handle empty node states in PromQL expressions

### DIFF
--- a/dashboards_grafana/slurm-all-metrics.json
+++ b/dashboards_grafana/slurm-all-metrics.json
@@ -699,7 +699,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -761,7 +761,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1674,7 +1674,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) or vector(0)",
           "legendFormat": "Alloc",
           "refId": "A"
         }
@@ -1732,7 +1732,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"})) or vector(0)",
           "legendFormat": "Idle",
           "refId": "A"
         }
@@ -1790,7 +1790,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"})) or vector(0)",
           "legendFormat": "Mix",
           "refId": "A"
         }
@@ -1848,7 +1848,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "legendFormat": "Down",
           "refId": "A"
         }
@@ -1906,7 +1906,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "Drain",
           "refId": "A"
         }
@@ -1964,7 +1964,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"})) or vector(0)",
           "legendFormat": "Maint",
           "refId": "A"
         }
@@ -2022,7 +2022,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"comp.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"comp.*\"})) or vector(0)",
           "legendFormat": "Comp",
           "refId": "A"
         }
@@ -2080,7 +2080,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"err.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"err.*\"})) or vector(0)",
           "legendFormat": "Err",
           "refId": "A"
         }
@@ -2138,7 +2138,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"fail.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"fail.*\"})) or vector(0)",
           "legendFormat": "Fail",
           "refId": "A"
         }
@@ -2196,7 +2196,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"inval.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"inval.*\"})) or vector(0)",
           "legendFormat": "Inval",
           "refId": "A"
         }
@@ -2254,7 +2254,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"plan.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"plan.*\"})) or vector(0)",
           "legendFormat": "Planned",
           "refId": "A"
         }
@@ -2312,7 +2312,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"resv.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"resv.*\"})) or vector(0)",
           "legendFormat": "Resv",
           "refId": "A"
         }
@@ -2369,7 +2369,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) or vector(0)",
           "legendFormat": "Alloc",
           "refId": "A"
         },
@@ -2378,7 +2378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"})) or vector(0)",
           "legendFormat": "Idle",
           "refId": "B"
         },
@@ -2387,7 +2387,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"})) or vector(0)",
           "legendFormat": "Mix",
           "refId": "C"
         },
@@ -2396,7 +2396,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "legendFormat": "Down",
           "refId": "D"
         },
@@ -2405,7 +2405,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "Drain",
           "refId": "E"
         },
@@ -2414,7 +2414,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"})) or vector(0)",
           "legendFormat": "Maint",
           "refId": "F"
         },
@@ -2423,7 +2423,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"resv.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"resv.*\"})) or vector(0)",
           "legendFormat": "Resv",
           "refId": "G"
         },
@@ -2432,7 +2432,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"comp.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"comp.*\"})) or vector(0)",
           "legendFormat": "Comp",
           "refId": "H"
         }

--- a/dashboards_grafana/slurm-nodes.json
+++ b/dashboards_grafana/slurm-nodes.json
@@ -144,7 +144,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"})) or vector(0)",
           "legendFormat": "Idle",
           "refId": "A",
           "instant": true
@@ -203,7 +203,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"})) or vector(0)",
           "legendFormat": "Mixed",
           "refId": "A",
           "instant": true
@@ -262,7 +262,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) or vector(0)",
           "legendFormat": "Allocated",
           "refId": "A",
           "instant": true
@@ -325,7 +325,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "legendFormat": "Down",
           "refId": "A",
           "instant": true
@@ -388,7 +388,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "Drain",
           "refId": "A",
           "instant": true

--- a/dashboards_grafana/slurm-overview.json
+++ b/dashboards_grafana/slurm-overview.json
@@ -149,7 +149,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) + count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*|mix.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Active",
           "refId": "A"
@@ -410,7 +410,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) + count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*|drain.*\"})) or vector(0)",
           "instant": false,
           "legendFormat": "Down+Drain",
           "refId": "A"
@@ -558,7 +558,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) + count(count by(node)(slurm_node_status{status=~\"mix.*\"}))) / sum(slurm_nodes_total) * 100",
+          "expr": "(count(count by(node)(slurm_node_status{status=~\"alloc.*|mix.*\"})) or vector(0)) / clamp_min(sum(slurm_nodes_total), 1) * 100",
           "instant": true,
           "legendFormat": "Node %",
           "refId": "A"
@@ -865,7 +865,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Idle",
           "refId": "A"
@@ -875,7 +875,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Mixed",
           "refId": "B"
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Allocated",
           "refId": "C"
@@ -895,7 +895,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Drain",
           "refId": "D"
@@ -905,7 +905,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Down",
           "refId": "E"
@@ -915,7 +915,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"maint.*\"})) or vector(0)",
           "instant": true,
           "legendFormat": "Maint",
           "refId": "F"
@@ -1039,7 +1039,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"idle.*\"})) or vector(0)",
           "legendFormat": "Idle",
           "refId": "A"
         },
@@ -1048,7 +1048,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"mix.*\"})) or vector(0)",
           "legendFormat": "Mixed",
           "refId": "B"
         },
@@ -1057,7 +1057,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"alloc.*\"})) or vector(0)",
           "legendFormat": "Allocated",
           "refId": "C"
         },
@@ -1066,7 +1066,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"down.*\"})) or vector(0)",
           "legendFormat": "Down",
           "refId": "D"
         },
@@ -1075,7 +1075,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "Drain",
           "refId": "E"
         }

--- a/dashboards_grafana/slurm-usage.json
+++ b/dashboards_grafana/slurm-usage.json
@@ -162,7 +162,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*\"})) + count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"mix.*\"}))) / sum(slurm_nodes_total{instance=~\"$instance\"}) * 100",
+          "expr": "(count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*|mix.*\"})) or vector(0)) / clamp_min(sum(slurm_nodes_total{instance=~\"$instance\"}), 1) * 100",
           "legendFormat": "Node %",
           "refId": "A",
           "instant": true
@@ -433,7 +433,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg_over_time(((count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*\"})) + count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"mix.*\"}))) / sum(slurm_nodes_total{instance=~\"$instance\"}) * 100)[1h:5m])",
+          "expr": "avg_over_time(((count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*|mix.*\"})) or vector(0)) / clamp_min(sum(slurm_nodes_total{instance=~\"$instance\"}), 1) * 100)[1h:5m])",
           "legendFormat": "Avg",
           "refId": "A"
         }
@@ -1121,7 +1121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"idle.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"idle.*\"})) or vector(0)",
           "legendFormat": "Idle",
           "refId": "A"
         },
@@ -1130,7 +1130,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"mix.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"mix.*\"})) or vector(0)",
           "legendFormat": "Mixed",
           "refId": "B"
         },
@@ -1139,7 +1139,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*\"})) or vector(0)",
           "legendFormat": "Allocated",
           "refId": "C"
         },
@@ -1148,7 +1148,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"down.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"down.*\"})) or vector(0)",
           "legendFormat": "Down",
           "refId": "D"
         },
@@ -1157,7 +1157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"drain.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"drain.*\"})) or vector(0)",
           "legendFormat": "Drain",
           "refId": "E"
         }
@@ -1306,7 +1306,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*\"})) + count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"comp.*\"}))",
+          "expr": "count(count by(node)(slurm_node_status{instance=~\"$instance\",status=~\"alloc.*|comp.*\"})) or vector(0)",
           "legendFormat": "Allocated+Completing",
           "refId": "A"
         },


### PR DESCRIPTION
## Summary

- Fix 6 expressions where `count(stateA) + count(stateB)` silently returned "No data" whenever either state was empty
- Add `or vector(0)` fallback to 43 isolated `count(slurm_node_status{...})` panels so empty states render as `0` instead of "No data"

## Root cause

PromQL's `count()` over an empty instant vector returns **no samples**, not `0`. So `count(empty) + count(value)` produces an empty result because there is nothing to vector-match. This is exactly the bug observed in the overview dashboard:

```promql
# Broken — returns nothing if no nodes are in alloc OR no nodes are in mix
count(count by(node)(slurm_node_status{status=~"alloc.*"}))
  + count(count by(node)(slurm_node_status{status=~"mix.*"}))

# Fixed — single regex, plus or vector(0) fallback
count(count by(node)(slurm_node_status{status=~"alloc.*|mix.*"})) or vector(0)
```

The single-regex form is also semantically better: in a multi-partition cluster, a node listed both as `alloc` (in partition X) and `mix` (in partition Y) is no longer double-counted.

## Critical fixes (6)

| File | Panel |
|---|---|
| slurm-overview.json | Active (alloc+mix) |
| slurm-overview.json | Down+Drain |
| slurm-overview.json | Node % |
| slurm-usage.json | Node % |
| slurm-usage.json | Avg Node % (1h) |
| slurm-usage.json | Allocated+Completing |

## UX fixes (43)

Isolated `count(count by(node)(slurm_node_status{status=~"X.*"}))` panels in:
- slurm-overview.json (11)
- slurm-nodes.json (5)
- slurm-all-metrics.json (22)
- slurm-usage.json (5)

Now display `0` instead of "No data" when no node is in the given state.

## Test plan

- [x] All 10 dashboards parse as valid JSON
- [x] `make redeploy-dashboards` reimports cleanly (10/10 ok)
- [x] Live test on slurm-docker-cluster (10 nodes):
  - `count(count by(node)(slurm_node_status{status=~"err.*"})) or vector(0)` → `0` (was: no data)
  - `count(count by(node)(slurm_node_status{status=~"alloc.*|mix.*"})) or vector(0)` → numeric value
- [x] Bug reproduction confirmed:
  - Old form `count(down)+count(err)` (err empty) → `[]` ❌
  - New form `count(down|err) or vector(0)` → `1` ✅
- [x] `make node-fail` / `make node-restore` smoke test