### PR TITLE
fix: allow hyphens in RPC usernames and fix GRES regex for colon sepa…

### DIFF
--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -17,9 +17,9 @@ var (
 	accountJobSuspended = regexp.MustCompile(`^suspended`)
 
 	// treGPURe matches GPU counts in TRES strings from squeue %b output.
-	// Real formats observed: "gres/gpu:4", "gres/gpu:2", "N/A"
-	// Also handles typed GPUs: "gres/gpu:a100:2", "gres/gpu:nvidia_gb200:4"
-	tresGPURe = regexp.MustCompile(`gres/gpu[^,\s]*[:/=](\d+)`)
+	// Real formats observed: "gres[:/]gpu:4", "gres[:/]gpu:2", "N/A"
+	// Also handles typed GPUs: "gres[:/]gpu:a100:2", "gres[:/]gpu:nvidia_gb200:4"
+	tresGPURe = regexp.MustCompile(`gres[:/]gpu[^,\s]*[:/=](\d+)`)
 )
 
 // parseGPUsFromTRES extracts the GPU count per node from a TRES string.

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -23,7 +23,7 @@ var (
 	schedulerPatternTotalStart  = regexp.MustCompile(`^[\s]+Total backfilled jobs \(since last slurm start\)`)
 	schedulerPatternTotalCycle  = regexp.MustCompile(`^[\s]+Total backfilled jobs \(since last stats cycle start\)`)
 	schedulerPatternTotalHetero = regexp.MustCompile(`^[\s]+Total backfilled heterogeneous job components`)
-	schedulerRPCLineRe          = regexp.MustCompile(`^\s*([A-Za-z0-9_]*).*count:([0-9]*)\s*ave_time:([0-9]*)\s\s*total_time:([0-9]*)\s*$`)
+	schedulerRPCLineRe          = regexp.MustCompile(`^\s*([A-Za-z0-9_-]*).*count:([0-9]*)\s*ave_time:([0-9]*)\s\s*total_time:([0-9]*)\s*$`)
 
 	// Job counters (sdiag "Jobs submitted/started/completed/canceled/failed")
 	schedulerPatternJobsSubmitted = regexp.MustCompile(`^Jobs submitted`)


### PR DESCRIPTION
- **`scheduler.go`**: The RPC stats regex `[A-Za-z0-9_]*` stopped matching at hyphens,
  silently truncating usernames like `username-21` to `username`. Extended the character
  class to `[A-Za-z0-9_-]*`.

- **`accounts.go`**: `tresGPURe` only matched `gres/gpu` (slash separator) but some Slurm
  clusters report GRES as `gres:gpu:N` (colon separator). Broadened the pattern to
  `gres[:/]gpu` to handle both formats.
