### PR TITLE
fix(v1.8.2): silent metric loss + 8 community PRs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,13 @@ project_name: slurm_exporter
 # Release configuration
 release:
   github:
-    owner: sckyzo 
+    owner: sckyzo
   name_template: "{{ .ProjectName }} v{{ .Version }}"
+  # Auto-detect pre-release tags (anything containing "-", e.g. v1.8.2-rc1)
+  # and mark them as pre-release on GitHub. Stable tags (v1.8.2) are published
+  # as normal releases. See docs/release-process.md section "Test on a real
+  # platform before tagging" for the RC workflow.
+  prerelease: auto
 
 builds:
   - id: slurm_exporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2022 fix for the same class of bug (commit `77080e0`) was inadvertently
   reverted at that point.
 
+- **`scheduler` collector — RPC usernames with hyphens silently truncated
+  (PR #28 by @ncreddine):**
+  `schedulerRPCLineRe` used the character class `[A-Za-z0-9_]*` for the
+  username capture group, which silently dropped the hyphen. Usernames
+  like `alice-21` were truncated to `alice`, collapsing every per-user RPC
+  stat onto the prefix and hiding per-user breakdowns in
+  `slurm_user_rpc_stats_*`. Extended the class to `[A-Za-z0-9_-]*`.
+  Table-driven non-regression test added.
+- **`accounts` collector — `gres:gpu:N` (colon separator) not parsed
+  (PR #28 by @ncreddine):**
+  `tresGPURe` matched only the slash form `gres/gpu:N` from `squeue %b`
+  output. Some Slurm versions emit `gres:gpu:N` (colon prefix) which fell
+  through to a count of 0, undercounting `slurm_account_cores_gpu` and
+  `slurm_user_cores_gpu` on those clusters. Broadened the prefix to
+  `gres[:/]gpu`. Existing slash-form tests still pass; four colon-form
+  cases added.
 - **Startup fails if `sbatch`/`salloc`/`srun` are absent (issue #24, PR #25 by
   @UeliDeSchwert):**
   `ValidateBinaries()` required `sbatch`, `salloc`, and `srun` in addition to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.2] - 2026-05-11
 
+### ⚠️ Breaking Changes
+
+- **`scheduler` collector — `slurm_scheduler_jobs_*_total` renamed and
+  retyped (issue #22, PR #23 by @UeliDeSchwert):**
+  The five sdiag-derived counters introduced in v1.8.0 were declared as
+  `prometheus.CounterValue` but `sdiag` resets these values to zero on
+  every `slurmctld` restart or `scontrol reconfigure`. A Counter that
+  decreases violates the Prometheus data model and breaks `rate()` /
+  `increase()` at the reset boundary. The `_total` suffix is also
+  reserved for Counters by Prometheus naming conventions.
+
+  | Old (Counter) | New (Gauge) |
+  | --- | --- |
+  | `slurm_scheduler_jobs_submitted_total` | `slurm_scheduler_jobs_submitted` |
+  | `slurm_scheduler_jobs_started_total`   | `slurm_scheduler_jobs_started` |
+  | `slurm_scheduler_jobs_completed_total` | `slurm_scheduler_jobs_completed` |
+  | `slurm_scheduler_jobs_canceled_total`  | `slurm_scheduler_jobs_canceled` |
+  | `slurm_scheduler_jobs_failed_total`    | `slurm_scheduler_jobs_failed` |
+
+  **Migration:**
+  - Replace the metric names in any external dashboards / recording rules /
+    alerts.
+  - Drop any `rate()` or `increase()` wrappers — these were already
+    producing incorrect results across slurmctld restarts. Use the raw
+    Gauge value (cumulative since last reset) or `deriv()` for a
+    short-window throughput estimate.
+  - Help text on each metric documents the reset behavior.
+
+  Rationale for shipping this in a patch release: the metrics were only
+  introduced six weeks ago (v1.8.0, 2026-04-02), shipped in two releases
+  (v1.8.0 and v1.8.1), are not referenced in any in-repo dashboard, and
+  had a real correctness bug under any non-trivial cluster reconfigure.
+  The disruption window is small and the longer the broken Counter ships,
+  the more downstream consumers we'd break later.
+
+  The `dashboards_grafana/05-slurm-scheduler.json` dashboard ships in this
+  release with a new **"Job Lifecycle (since slurmctld start)"** row
+  exposing the five renamed metrics — the first in-repo visualisation
+  of these counters.
+
 ### 🐛 Bug Fixes
 
 - **`node` collector — long node names silently dropped (issue #10):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2022 fix for the same class of bug (commit `77080e0`) was inadvertently
   reverted at that point.
 
+- **`sacct_efficiency` collector — graceful shutdown on SIGTERM/SIGINT
+  (issue #18, PR #19 by @UeliDeSchwert):**
+  The background refresh goroutine was started with `context.Background()`,
+  which is never cancelled. On SIGTERM/SIGINT, the HTTP server stopped but
+  the goroutine — possibly mid-`sacct` invocation — was only terminated
+  when the OS killed the process. Now wired through `signal.NotifyContext`,
+  so the context is cancelled cleanly on signal. The main loop also waits
+  up to 5 seconds for the goroutine to exit (via the new `Done()` channel)
+  before returning, so any in-flight `sacct` call has a chance to complete.
+  Non-regression test added (`TestSacctEfficiencyCollector_DoneClosesOnCancel`).
 - **`gpus` collector — `slurm_gpus_other` can be negative on busy clusters
   (issue #16, PR #17 by @UeliDeSchwert):**
   `other` is computed as `total − allocated − idle`, where each value comes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2022 fix for the same class of bug (commit `77080e0`) was inadvertently
   reverted at that point.
 
+- **`reservations` collector — phantom row when no reservations defined
+  (issue #26):**
+  `parseReservations` processed every non-empty record from
+  `scontrol show reservation`, including the literal `"No reservations in
+  the system"` line that scontrol emits on an empty cluster. With no
+  key=value to parse, every field stayed at its zero value and the
+  record was still appended — producing a phantom series:
+
+  ```
+  slurm_reservation_info{reservation_name="",...} 1
+  slurm_reservation_start_time_seconds{reservation_name=""} -6.21355968e+10
+  slurm_reservation_end_time_seconds{reservation_name=""} -6.21355968e+10
+  ```
+
+  The `-6.21e+10` timestamp is `time.Time{}.Unix() = -62135596800`
+  (year 0001), which Grafana renders as `1968-01-12 20:06:43` on the
+  reservations dashboard.
+
+  Fixed by skipping records that didn't yield a `ReservationName`. Empty
+  clusters now produce zero `slurm_reservation_*` series; dashboards
+  show "No data" instead of a fake 1968 reservation. Non-regression test
+  added with a `sreservations_empty.txt` fixture.
 - **`scheduler` collector — RPC usernames with hyphens silently truncated
   (PR #28 by @ncreddine):**
   `schedulerRPCLineRe` used the character class `[A-Za-z0-9_]*` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2022 fix for the same class of bug (commit `77080e0`) was inadvertently
   reverted at that point.
 
+- **Startup fails if `sbatch`/`salloc`/`srun` are absent (issue #24, PR #25 by
+  @UeliDeSchwert):**
+  `ValidateBinaries()` required `sbatch`, `salloc`, and `srun` in addition to
+  the Slurm monitoring tools actually used by the exporter. These three
+  job-submission binaries are never invoked by any collector and are often
+  absent on read-only monitoring containers or minimal Slurm client
+  installations, causing the exporter to refuse to start with
+  `--slurm.bin-path` set. They are now removed from the required list.
+  Companion follow-up below restores informational visibility.
+
+### ✨ Improvements
+
+- **`slurm_info` collector — expose job submission tool versions when
+  available:**
+  Following the issue #24 fix that dropped `sbatch`/`salloc`/`srun` from the
+  strict startup validation, they are now reintroduced in the `slurm_info`
+  collector as **silent optionals**: emitted only when present on the host,
+  with no log entry or metric when absent. Lookup uses `os.Stat` against
+  `--slurm.bin-path` (or `exec.LookPath` against `$PATH` when empty),
+  avoiding any subprocess spawn. Required binaries continue to emit a
+  `slurm_info{binary="X",version="not_found"}` series with value `0` when
+  missing, so operators can still alert on their absence.
+
 - **`partitions` collector — default partition `*` suffix not stripped
   (issue #20, PR #21 by @UeliDeSchwert):**
   Slurm appends `*` to the default partition name in `sinfo` output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2022 fix for the same class of bug (commit `77080e0`) was inadvertently
   reverted at that point.
 
+- **`partitions` collector — default partition `*` suffix not stripped
+  (issue #20, PR #21 by @UeliDeSchwert):**
+  Slurm appends `*` to the default partition name in `sinfo` output
+  (e.g. `compute*`). The `nodes` collector already strips this suffix
+  (`nodes.go:169`), but `partitions.go` did not, producing
+  `slurm_partition_cpus_*` and `slurm_partition_gpus_*` with
+  `partition="compute*"` while every other metric used `partition="compute"`.
+  PromQL joins on the partition label silently returned no data for the
+  default partition. Fixed by applying the same `strings.TrimRight(..., "*")`
+  in both the CPU path and the GPU path; two unit tests verify the
+  asterisk-suffixed input is stored under the bare key.
+- **`queue` collector — same `*` suffix bug, defensive companion fix:**
+  `squeue -o "%P"` emits `compute*` for the default partition on some
+  Slurm versions; the queue collector now applies the same
+  `TrimRight(..., "*")` so `slurm_queue_*` and `slurm_cores_*` labels
+  stay aligned with the partitions and nodes collectors.
+  Non-regression test added.
 - **`sacct_efficiency` collector — graceful shutdown on SIGTERM/SIGINT
   (issue #18, PR #19 by @UeliDeSchwert):**
   The background refresh goroutine was started with `context.Background()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,108 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-05-11
+
+### 🐛 Bug Fixes
+
+- **`node` collector — long node names silently dropped (issue #10):**
+  `sinfo -O "NodeList,..."` uses fixed-width columns (default 20 chars for
+  `NodeList`). On clusters with node hostnames longer than 20 characters, the
+  `NodeList` column collided with `AllocMem`, leaving lines with only 5
+  whitespace-separated tokens instead of 6. The parser silently skipped them
+  (`if len(node) < 6 { continue }`), causing entire nodes to disappear from the
+  metrics map — and the collector reported success (no error, non-zero
+  `slurm_exporter_collector_duration_seconds`) while exposing zero
+  `slurm_node_*` series. Fixed by switching to variable-width columns
+  (`NodeList: ,AllocMem: ,...`); the trailing `:` instructs `sinfo` to size
+  each column to its value. The parser itself is unchanged.
+  Regression was introduced when `slurm_node_status` was added; the original
+  2022 fix for the same class of bug (commit `77080e0`) was inadvertently
+  reverted at that point.
+
+- **`gpus` collector — `slurm_gpus_other` can be negative on busy clusters
+  (issue #16, PR #17 by @UeliDeSchwert):**
+  `other` is computed as `total − allocated − idle`, where each value comes
+  from a separate `sinfo` invocation. Cluster state can change between the
+  three calls, transiently producing `alloc + idle > total` and a negative
+  gauge — which Grafana renders incorrectly. Clamped to zero with a Debug
+  log when the clamp triggers (useful for diagnosing suspected miscounting
+  without spamming production logs, since the race is common on loaded
+  clusters). A follow-up issue tracks the proper fix: consolidate the three
+  `sinfo` calls into one to eliminate the race at the source.
+- **`sacct_efficiency` collector — memory efficiency average understated
+  (issue #14, PR #15 by @UeliDeSchwert):**
+  `slurm_job_mem_efficiency_avg` accumulated the per-job ratio only when
+  `ReqMemMB > 0` (correct) but divided by `JobCount` — the total number of
+  jobs, including those without memory requests. On a cluster where half the
+  jobs are submitted without `--mem`, the reported average was half the real
+  value. Same structural pattern fixed for `slurm_job_cpu_efficiency_avg`
+  (lower impact in practice). Fixed by adding `CPUJobCount` and `MemJobCount`
+  to the aggregates struct and dividing by the per-metric counter. Affected
+  sites will see both averages rise to their correct value after upgrade.
+  Non-regression test added.
+- **`queue` collector — `slurm_queue_suspended` and `slurm_cores_suspended`
+  never emitted (issue #12, PR #13 by @UeliDeSchwert):**
+  Both metrics were declared, described, and populated by `ParseQueueMetrics`,
+  but `Collect()` was missing the `PushMetric` / `pushAggregatedNVal` calls
+  for them — every scrape silently dropped these series. The global
+  `slurm_jobs_suspended` gauge was unaffected. Fixed by adding the four
+  missing calls (two in the per-user branch, two in the aggregated branch).
+  Non-regression test added.
+- **`partitions` collector — multi-type GPU undercount:**
+  `parseGpuCount()` in `partitions.go` used `FindStringSubmatch` (singular),
+  returning only the first `gpu:*:N` match in a GRES string. On nodes
+  exposing multiple GPU types (`gpu:A100:4,gpu:H100:2`),
+  `slurm_partition_gpus_allocated` and `slurm_partition_gpus_idle` were
+  silently undercounted (returned 4 instead of 6). Fixed by iterating over
+  comma-separated GRES sub-specs and accumulating, matching the
+  long-correct behavior of `gpus.go::parseGPUCount`. Cluster-wide
+  `slurm_gpus_*` was not affected. Affected sites will see
+  `slurm_partition_gpus_*` values increase to their real count after
+  upgrade.
+
+### 🛡️ Defensive hardening
+
+- **`partitions` collector — fixed-width truncation of GRES strings:**
+  `sinfo --Format=...Gres:50,GresUsed:50` truncates rich GRES specs on busy
+  GPU nodes (multi-type GPUs, MIG slices) at 50 chars, producing wrong GPU
+  counts in `slurm_partition_gpus_*`. Same class of bug as the `node`
+  collector issue. Switched to variable-width (`Gres: ,GresUsed:`).
+- **`gpus` collector — fixed-width truncation of GRES strings:**
+  Same fix applied to `IdleGPUsData()` and `TotalGPUsData()`. `AllocatedGPUsData()`
+  was already correct.
+- **Empty-parse warning logs:** `node` and `partitions` collectors now emit a
+  warning when the parser returns zero entries despite the underlying command
+  succeeding. This makes the failure mode from issue #10 fail loudly instead
+  of silently — operators see the warning instead of staring at "No data"
+  dashboards with no clue why.
+- **Data race in `sacct_efficiency` test fixed; `Done()` channel added.**
+  `TestSacctEfficiencyCollector_ErrorKeepsPreviousCache` had two races caught
+  by `go test -race`: an unprotected `callCount++` in the mock closure, and
+  the test's `defer Execute = oldExecute` racing with the background refresh
+  goroutine still reading `Execute`. Counter now uses `atomic.Int64`, and
+  `SacctEfficiencyCollector` exposes a new `Done() <-chan struct{}` channel
+  that closes when the background goroutine exits — letting tests
+  synchronise teardown deterministically. Production behavior unchanged.
+
+### 📊 Dashboard impact
+
+No dashboard JSON changes — metric names, labels, and types are unchanged.
+However, **clusters previously affected by silent truncation will see metric
+values increase** as the missing series reappear:
+
+- `slurm_node_*` series for nodes with hostnames > 20 chars will now be exposed
+  (previously absent), so `count`/`sum` queries over them will rise to their
+  real values.
+- `slurm_partition_*` series for partitions with names > 30 chars will now
+  appear under their full name; series previously stored under a truncated
+  partition name will disappear.
+- `slurm_gpus_*` and `slurm_partition_gpus_*` will reflect the true GPU
+  inventory on nodes with rich GRES specs (multi-type GPU, MIG).
+
+The `or vector(0)` guards added to dashboards in v1.8.1 remain valid (they
+protect against legitimately empty states) and require no rework.
+
 ## [1.8.1] - 2026-04-28
 
 ### 🐛 Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,8 +186,11 @@ Read that file before cutting a release. The quick summary:
 7. Update `CHANGELOG.md`, `docs/metrics.md`, `docs/metrics-examples.md`,
    dashboards, and the companion alerting rules if applicable.
 8. Open the release PR with the v1.8.2 template structure.
-9. After merge: tag, close integrated community PRs with a thank-you, and
-   respond to acknowledged-but-deferred issues.
-
-CI (`.github/workflows/release.yml`) picks up the tag and runs
-`lint → test → goreleaser release` automatically.
+9. After merge: close integrated community PRs with a thank-you and respond
+   to acknowledged-but-deferred issues.
+10. **Test the binary on a real cluster before the final tag.** Approach A
+    (RC tag `vX.Y.Z-rc1` → GitHub pre-release → staging overnight) for
+    breaking/minor releases; approach B (local `make build` → scp to
+    staging) for trivial patches. Decision matrix in the playbook.
+11. Tag the final `vX.Y.Z`; CI (`.github/workflows/release.yml`) runs
+    `lint → test → goreleaser release` and publishes automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,13 @@ tag — branch strategy, integrating community PRs with credit, the defensive
 audit, the live-cluster validation, the doc-vs-exporter diff — follows a
 deliberate workflow documented in **[`docs/release-process.md`](docs/release-process.md)**.
 
-Read that file before cutting a release. The quick summary:
+Read that file before cutting a release. The companion file
+**[`docs/validation-checklist.md`](docs/validation-checklist.md)** is a
+copy-pasteable 11-step procedure to validate any candidate against the
+Docker test cluster, written so a human or an AI agent can run it
+without prior context.
+
+The quick summary:
 
 1. Branch off `master` as `fix/vX.Y.Z` (patch) or `feat/vX.Y` (minor).
 2. Triage open PRs/issues; pick a coherent release theme.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,19 +168,26 @@ The target: total scrape time < 5s on a 10 000-node cluster at 30s interval.
 
 ## Releasing
 
-Releases are automated via GoReleaser on tag push. To prepare a release:
+Releases are automated via GoReleaser on tag push, but everything before the
+tag — branch strategy, integrating community PRs with credit, the defensive
+audit, the live-cluster validation, the doc-vs-exporter diff — follows a
+deliberate workflow documented in **[`docs/release-process.md`](docs/release-process.md)**.
 
-```bash
-# Ensure clean state
-make test && golangci-lint run ./...
+Read that file before cutting a release. The quick summary:
 
-# Update CHANGELOG.md with the new version section
+1. Branch off `master` as `fix/vX.Y.Z` (patch) or `feat/vX.Y` (minor).
+2. Triage open PRs/issues; pick a coherent release theme.
+3. Integrate community PRs as local commits with `Co-authored-by:` — one
+   commit per logical change, each with a non-regression test.
+4. Run the defensive audit (same bug class elsewhere?).
+5. `make check` + `make race` continuously; full end-to-end via
+   `scripts/testing`.
+6. Diff the exporter's `/metrics` output against `docs/metrics.md`.
+7. Update `CHANGELOG.md`, `docs/metrics.md`, `docs/metrics-examples.md`,
+   dashboards, and the companion alerting rules if applicable.
+8. Open the release PR with the v1.8.2 template structure.
+9. After merge: tag, close integrated community PRs with a thank-you, and
+   respond to acknowledged-but-deferred issues.
 
-# Commit and tag
-git add CHANGELOG.md
-git commit -m "chore: bump CHANGELOG for vX.Y.Z"
-git tag -a vX.Y.Z -m "vX.Y.Z — short description"
-git push origin master && git push origin vX.Y.Z
-```
-
-The CI pipeline runs `test → lint → release` automatically.
+CI (`.github/workflows/release.yml`) picks up the tag and runs
+`lint → test → goreleaser release` automatically.

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,31 @@ test: $(GOFILES)
 	@echo "Running tests"
 	go test -v ./...
 
+# Run tests with the race detector. Useful locally to catch concurrency bugs
+# in collectors with background goroutines (e.g. sacct_efficiency).
+.PHONY: race
+race: $(GOFILES)
+	@echo "Running tests with race detector"
+	go test -race -count=1 ./...
+
+# Static analysis with go vet (also covered by golangci-lint).
+.PHONY: vet
+vet:
+	@echo "Running go vet"
+	go vet ./...
+
+# Lint using the same tool as CI (golangci-lint).
+# Requires golangci-lint to be installed locally:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+.PHONY: lint
+lint:
+	@echo "Running golangci-lint"
+	golangci-lint run ./...
+
+# Full pre-commit / pre-release verification — mirrors what CI runs.
+.PHONY: check
+check: vet lint test
+
 # Run the built binary
 .PHONY: run
 run: $(GOBIN)

--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -116,11 +118,11 @@ var collectorConstructors = map[string]func(logger *logger.Logger) prometheus.Co
 	"reservations":      func(l *logger.Logger) prometheus.Collector { return collector.NewReservationsCollector(l) },
 	"reservation_nodes": func(l *logger.Logger) prometheus.Collector { return collector.NewReservationNodesCollector(l) },
 	"licenses":          func(l *logger.Logger) prometheus.Collector { return collector.NewLicensesCollector(l) },
-	"sacct_efficiency": func(l *logger.Logger) prometheus.Collector {
-		c := collector.NewSacctEfficiencyCollector(l, *sacctEfficiencyInterval, *sacctEfficiencyLookback)
-		c.Start(context.Background())
-		return c
-	},
+	// sacct_efficiency constructor is overridden in main() with a signal-aware
+	// context so the background refresh goroutine is cancelled cleanly on
+	// SIGTERM/SIGINT (see issue #18). Left nil here — disabled-by-default
+	// means the constructor is never invoked through this map directly.
+	"sacct_efficiency": nil,
 }
 
 // indexHTML is the HTML content displayed on the root page
@@ -192,6 +194,27 @@ func main() {
 		}
 	}
 
+	// Create a signal-aware context so background goroutines (e.g. sacct_efficiency)
+	// are cancelled cleanly on SIGTERM or SIGINT (issue #18). Placed after the
+	// binary validation block to avoid a defer-skipped-by-os.Exit ordering issue.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
+	defer stop()
+
+	// sacctDone captures the Done() channel of the sacct_efficiency collector
+	// (if enabled) so we can wait for its background goroutine to fully exit
+	// after the HTTP server has shut down. Stays nil if the collector is
+	// disabled — the post-server wait below is a no-op in that case.
+	var sacctDone <-chan struct{}
+
+	// Wire the signal context into the sacct_efficiency collector constructor
+	// and capture its Done() channel for graceful shutdown.
+	collectorConstructors["sacct_efficiency"] = func(l *logger.Logger) prometheus.Collector {
+		c := collector.NewSacctEfficiencyCollector(l, *sacctEfficiencyInterval, *sacctEfficiencyLookback)
+		c.Start(ctx)
+		sacctDone = c.Done()
+		return c
+	}
+
 	// Create a custom registry to avoid global state and third-party metric pollution
 	reg := prometheus.NewRegistry()
 
@@ -238,6 +261,20 @@ func main() {
 	}
 	if err := web.ListenAndServe(server, toolkitFlags, log.Logger); err != nil {
 		log.Error("Failed to start HTTP server", "err", err)
-		os.Exit(1)
+		stop()     // release signal handler explicitly before bypassing defer via os.Exit
+		os.Exit(1) //nolint:gocritic // stop() called explicitly above
+	}
+
+	// Graceful shutdown: wait for the sacct_efficiency background goroutine to
+	// finish (if it was started). Bounded by a short timeout so we don't hang
+	// the process when sacct is genuinely stuck.
+	if sacctDone != nil {
+		log.Info("Waiting for sacct_efficiency background goroutine to finish...")
+		select {
+		case <-sacctDone:
+			log.Info("sacct_efficiency stopped cleanly")
+		case <-time.After(5 * time.Second):
+			log.Warn("sacct_efficiency did not stop within 5s, exiting anyway")
+		}
 	}
 }

--- a/dashboards_grafana/05-slurm-scheduler.json
+++ b/dashboards_grafana/05-slurm-scheduler.json
@@ -1158,6 +1158,179 @@
           "instant": true
         }
       ]
+    },
+    {
+      "type": "row",
+      "id": 105,
+      "title": "Job Lifecycle (since slurmctld start)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "type": "stat",
+      "id": 50,
+      "title": "Jobs Submitted",
+      "description": "Jobs submitted to the scheduler since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag. Resets to 0 on reconfigure.",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 40 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "slurm_scheduler_jobs_submitted",
+          "legendFormat": "Submitted",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "type": "stat",
+      "id": 51,
+      "title": "Jobs Started",
+      "description": "Jobs started (dispatched) since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 40 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "slurm_scheduler_jobs_started",
+          "legendFormat": "Started",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "type": "stat",
+      "id": 52,
+      "title": "Jobs Completed",
+      "description": "Jobs completed since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 40 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "slurm_scheduler_jobs_completed",
+          "legendFormat": "Completed",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "type": "stat",
+      "id": 53,
+      "title": "Jobs Canceled",
+      "description": "Jobs canceled since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 40 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "yellow", "value": null }] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "slurm_scheduler_jobs_canceled",
+          "legendFormat": "Canceled",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "type": "stat",
+      "id": 54,
+      "title": "Jobs Failed",
+      "description": "Jobs failed since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 40 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "slurm_scheduler_jobs_failed",
+          "legendFormat": "Failed",
+          "refId": "A",
+          "instant": true
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -443,31 +443,116 @@ slurm_reservation_node_count{reservation_name="prod"} 102
 
 Command: `sdiag`
 
+### Scheduler health (gauges)
+
 ```
-# HELP slurm_scheduler_backfill_last_cycle Last backfill cycle time in microseconds reported by sdiag
-# TYPE slurm_scheduler_backfill_last_cycle gauge
-slurm_scheduler_backfill_last_cycle 1.94289e+06
-
-# HELP slurm_scheduler_backfilled_jobs_since_start_total Jobs started via backfilling since last Slurm start
-# TYPE slurm_scheduler_backfilled_jobs_since_start_total gauge
-slurm_scheduler_backfilled_jobs_since_start_total 111544
-
-# HELP slurm_scheduler_cycle_per_minute Number of scheduler cycles per minute reported by sdiag
-# TYPE slurm_scheduler_cycle_per_minute gauge
-slurm_scheduler_cycle_per_minute 63
-
-# HELP slurm_scheduler_last_cycle Last scheduler cycle time in microseconds reported by sdiag
-# TYPE slurm_scheduler_last_cycle gauge
-slurm_scheduler_last_cycle 97209
+# HELP slurm_scheduler_threads Number of scheduler threads
+# TYPE slurm_scheduler_threads gauge
+slurm_scheduler_threads 1
 
 # HELP slurm_scheduler_queue_size Length of the scheduler queue reported by sdiag
 # TYPE slurm_scheduler_queue_size gauge
 slurm_scheduler_queue_size 0
 
+# HELP slurm_scheduler_dbd_queue_size Pending entries in the SlurmDBD agent queue
+# TYPE slurm_scheduler_dbd_queue_size gauge
+slurm_scheduler_dbd_queue_size 0
+
+# HELP slurm_scheduler_last_cycle Last scheduler cycle time in microseconds reported by sdiag
+# TYPE slurm_scheduler_last_cycle gauge
+slurm_scheduler_last_cycle 97209
+
+# HELP slurm_scheduler_mean_cycle Scheduler mean cycle time (microseconds)
+# TYPE slurm_scheduler_mean_cycle gauge
+slurm_scheduler_mean_cycle 74593
+
+# HELP slurm_scheduler_cycle_per_minute Number of scheduler cycles per minute
+# TYPE slurm_scheduler_cycle_per_minute gauge
+slurm_scheduler_cycle_per_minute 63
+
+# HELP slurm_scheduler_backfill_last_cycle Last backfill cycle time (µs)
+# TYPE slurm_scheduler_backfill_last_cycle gauge
+slurm_scheduler_backfill_last_cycle 5334
+
+# HELP slurm_scheduler_backfill_mean_cycle Mean backfill cycle time (µs)
+# TYPE slurm_scheduler_backfill_mean_cycle gauge
+slurm_scheduler_backfill_mean_cycle 621
+
+# HELP slurm_scheduler_backfill_depth_mean Mean backfill depth
+# TYPE slurm_scheduler_backfill_depth_mean gauge
+slurm_scheduler_backfill_depth_mean 15
+```
+
+### Backfill cumulative counters (reset on slurmctld restart)
+
+```
+# HELP slurm_scheduler_backfilled_jobs_since_start_total Jobs backfilled since slurmctld start
+# TYPE slurm_scheduler_backfilled_jobs_since_start_total gauge
+slurm_scheduler_backfilled_jobs_since_start_total 13
+
+# HELP slurm_scheduler_backfilled_jobs_since_cycle_total Jobs backfilled since last stats cycle
+# TYPE slurm_scheduler_backfilled_jobs_since_cycle_total gauge
+slurm_scheduler_backfilled_jobs_since_cycle_total 13
+
+# HELP slurm_scheduler_backfilled_heterogeneous_total Heterogeneous job components backfilled
+# TYPE slurm_scheduler_backfilled_heterogeneous_total gauge
+slurm_scheduler_backfilled_heterogeneous_total 0
+```
+
+### Job lifecycle (gauges that reset on slurmctld restart or scontrol reconfigure)
+
+> Renamed and re-typed in v1.8.2 (dropped `_total`, switched Counter → Gauge).
+> See [CHANGELOG](../CHANGELOG.md#182) for migration notes.
+
+```
+# HELP slurm_scheduler_jobs_submitted Jobs submitted to the scheduler since last stats reset
+# TYPE slurm_scheduler_jobs_submitted gauge
+slurm_scheduler_jobs_submitted 53
+
+# HELP slurm_scheduler_jobs_started Jobs started (dispatched) since last stats reset
+# TYPE slurm_scheduler_jobs_started gauge
+slurm_scheduler_jobs_started 27
+
+# HELP slurm_scheduler_jobs_completed Jobs completed since last stats reset
+# TYPE slurm_scheduler_jobs_completed gauge
+slurm_scheduler_jobs_completed 27
+
+# HELP slurm_scheduler_jobs_canceled Jobs canceled since last stats reset
+# TYPE slurm_scheduler_jobs_canceled gauge
+slurm_scheduler_jobs_canceled 0
+
+# HELP slurm_scheduler_jobs_failed Jobs failed since last stats reset
+# TYPE slurm_scheduler_jobs_failed gauge
+slurm_scheduler_jobs_failed 0
+```
+
+### RPC statistics
+
+```
 # HELP slurm_rpc_stats RPC call count by operation, reported by sdiag
 # TYPE slurm_rpc_stats gauge
 slurm_rpc_stats{operation="REQUEST_NODE_INFO"} 4320
 slurm_rpc_stats{operation="REQUEST_JOB_INFO"} 8640
+
+# HELP slurm_rpc_stats_avg_time Average RPC time (µs) by operation
+# TYPE slurm_rpc_stats_avg_time gauge
+slurm_rpc_stats_avg_time{operation="REQUEST_NODE_INFO"} 142
+
+# HELP slurm_rpc_stats_total_time Total cumulative RPC time (µs) by operation
+# TYPE slurm_rpc_stats_total_time gauge
+slurm_rpc_stats_total_time{operation="REQUEST_NODE_INFO"} 613440
+
+# HELP slurm_user_rpc_stats RPC call count per user
+# TYPE slurm_user_rpc_stats gauge
+slurm_user_rpc_stats{user="alice"} 240
+
+# HELP slurm_user_rpc_stats_avg_time Average RPC time (µs) per user
+# TYPE slurm_user_rpc_stats_avg_time gauge
+slurm_user_rpc_stats_avg_time{user="alice"} 95
+
+# HELP slurm_user_rpc_stats_total_time Total RPC time (µs) per user
+# TYPE slurm_user_rpc_stats_total_time gauge
+slurm_user_rpc_stats_total_time{user="alice"} 22800
 ```
 
 ---

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -37,13 +37,26 @@ Provides global statistics on CPU states for the entire cluster.
 
 ### `fairshare` Collector
 
-Reports the calculated fairshare factor for each account.
+Reports the calculated fairshare factor and underlying share/usage components,
+per account and (when enabled via `--collector.fairshare.user-metrics`, default on) per user.
 
-- **Command:** `sshare -n -P -o "account,fairshare"`
+- **Command:** `sshare -a -P -n -o "Account,User,RawShares,NormShares,RawUsage,NormUsage,FairShare"`
 
 | Metric | Description | Labels |
 |---|---|---|
-| `slurm_account_fairshare` | FairShare for account | `account` |
+| `slurm_account_fairshare` | FairShare factor for account | `account` |
+| `slurm_account_fairshare_norm_shares` | Normalised share allocation | `account` |
+| `slurm_account_fairshare_norm_usage` | Normalised usage over the decay window | `account` |
+| `slurm_account_fairshare_raw_shares` | Raw share allocation | `account` |
+| `slurm_account_fairshare_raw_usage_cpu_seconds` | Raw CPU-seconds consumed | `account` |
+| `slurm_user_fairshare` | FairShare factor for user | `user`, `account` |
+| `slurm_user_fairshare_norm_shares` | Normalised share allocation per user | `user`, `account` |
+| `slurm_user_fairshare_norm_usage` | Normalised usage per user | `user`, `account` |
+| `slurm_user_fairshare_raw_shares` | Raw share allocation per user | `user`, `account` |
+| `slurm_user_fairshare_raw_usage_cpu_seconds` | Raw CPU-seconds consumed per user | `user`, `account` |
+
+User-level metrics can be disabled on clusters with many users to reduce cardinality
+via `--collector.fairshare.user-metrics=false`.
 
 ### `gpus` Collector
 
@@ -215,18 +228,59 @@ primary state (token before the first `+`).
 
 ### `scheduler` Collector
 
-Provides internal performance metrics from the `slurmctld` daemon.
+Provides internal performance metrics from the `slurmctld` daemon, parsed from
+`sdiag` output.
 
 - **Command:** `sdiag`
+
+**Scheduler health (gauges, always emitted):**
 
 | Metric | Description | Labels |
 |---|---|---|
 | `slurm_scheduler_threads` | Number of scheduler threads | (none) |
 | `slurm_scheduler_queue_size` | Length of the scheduler queue | (none) |
-| `slurm_scheduler_mean_cycle` | Scheduler mean cycle time (microseconds) | (none) |
-| `slurm_rpc_stats` | RPC count statistic | `operation` |
-| `slurm_user_rpc_stats` | RPC count statistic per user | `user` |
-| `...` | (and many other backfill and RPC time metrics) | `operation` or `user` |
+| `slurm_scheduler_dbd_queue_size` | Pending entries in the SlurmDBD agent queue | (none) |
+| `slurm_scheduler_last_cycle` | Last scheduler cycle duration (µs) | (none) |
+| `slurm_scheduler_mean_cycle` | Scheduler mean cycle duration (µs) | (none) |
+| `slurm_scheduler_cycle_per_minute` | Scheduler cycles per minute | (none) |
+| `slurm_scheduler_backfill_last_cycle` | Last backfill cycle duration (µs) | (none) |
+| `slurm_scheduler_backfill_mean_cycle` | Mean backfill cycle duration (µs) | (none) |
+| `slurm_scheduler_backfill_depth_mean` | Mean backfill depth | (none) |
+
+**Backfill activity (gauges that reset on `slurmctld` restart):**
+
+| Metric | Description | Labels |
+|---|---|---|
+| `slurm_scheduler_backfilled_jobs_since_start_total` | Jobs backfilled since `slurmctld` start | (none) |
+| `slurm_scheduler_backfilled_jobs_since_cycle_total` | Jobs backfilled since last stats cycle | (none) |
+| `slurm_scheduler_backfilled_heterogeneous_total` | Heterogeneous job components backfilled | (none) |
+
+**Job lifecycle counts (gauges that reset on `slurmctld` restart or `scontrol reconfigure`):**
+
+| Metric | Description | Labels |
+|---|---|---|
+| `slurm_scheduler_jobs_submitted` | Jobs submitted to the scheduler since last stats reset | (none) |
+| `slurm_scheduler_jobs_started` | Jobs started (dispatched) since last stats reset | (none) |
+| `slurm_scheduler_jobs_completed` | Jobs completed since last stats reset | (none) |
+| `slurm_scheduler_jobs_canceled` | Jobs canceled since last stats reset | (none) |
+| `slurm_scheduler_jobs_failed` | Jobs failed since last stats reset | (none) |
+
+> **Note:** these five counters were renamed in v1.8.2 to drop the `_total`
+> suffix and switched from Counter to Gauge, because `sdiag` resets them on
+> every `slurmctld` restart or `scontrol reconfigure`. A Counter that decreases
+> breaks `rate()` and `increase()`. Use `delta()` over a time window, or
+> consume the raw value as a cumulative since-last-reset gauge.
+
+**RPC statistics (cluster-wide and per user):**
+
+| Metric | Description | Labels |
+|---|---|---|
+| `slurm_rpc_stats` | RPC call count by message type | `operation` |
+| `slurm_rpc_stats_avg_time` | Average RPC time (µs) by message type | `operation` |
+| `slurm_rpc_stats_total_time` | Total cumulative RPC time (µs) by message type | `operation` |
+| `slurm_user_rpc_stats` | RPC call count per user | `user` |
+| `slurm_user_rpc_stats_avg_time` | Average RPC time (µs) per user | `user` |
+| `slurm_user_rpc_stats_total_time` | Total cumulative RPC time (µs) per user | `user` |
 
 ### `users` Collector
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,360 @@
+# Release Process
+
+> Back to [README](../README.md)
+
+This document describes the maintainer workflow for cutting a release of
+`slurm_exporter`. It is the playbook for any future patch or minor release,
+distilled from the v1.8.2 cycle.
+
+The goal is to keep releases:
+
+1. **Coherent** — every change in a release fits the release theme (patch =
+   bug fixes only; minor = features and refactors; major = breaking changes).
+2. **Reviewable** — atomic commits, conventional commit messages, BREAKING
+   changes flagged explicitly.
+3. **Trustworthy** — every fix lands with a non-regression test, every
+   metric in `docs/metrics.md` matches what `/metrics` actually exposes.
+4. **Respectful of contributors** — community PRs are credited via
+   `Co-authored-by`, not silently absorbed.
+
+---
+
+## 1. Open the release branch
+
+Always release from a dedicated branch — never commit straight to `master`.
+
+```bash
+git checkout master && git pull
+git checkout -b fix/vX.Y.Z       # use feat/vX.Y for minor releases
+```
+
+Naming convention:
+
+| Branch prefix | Used for |
+|---|---|
+| `fix/vX.Y.Z` | Patch release: bug fixes only |
+| `feat/vX.Y` | Minor release: features + non-breaking improvements |
+| `release/vX` | Major release: breaking changes |
+
+---
+
+## 2. Triage the backlog
+
+Before opening the branch, list everything that *could* go in:
+
+```bash
+gh pr list  --repo $OWNER/slurm_exporter --state open
+gh issue list --repo $OWNER/slurm_exporter --state open
+```
+
+For each item, decide:
+
+- **In scope** for this release — note the PR/issue number in your scratchpad.
+- **Out of scope** but actionable — comment on the issue/PR with the planned
+  release (e.g. "tracked for v1.9").
+- **Stale** — close with a polite explanation.
+
+Aim for a release that ships **one theme** (e.g. v1.8.2 was "silent metric
+loss in the node collector + community PR backlog"). Avoid mixing themes.
+
+---
+
+## 3. Integrate community PRs
+
+For each PR you accept, follow the same loop:
+
+### 3.1 Analyse
+
+For every PR, run a four-step analysis:
+
+1. **What it claims to fix** — read the issue + PR body.
+2. **What the diff actually changes** — `gh pr diff <N>`.
+3. **Whether it conflicts with the current branch** — does it touch lines
+   you've already modified in this release?
+4. **Whether it changes metric values, names, or labels** — anything visible
+   to the user.
+
+If any of these aren't clear, comment on the PR for clarification before
+integrating.
+
+### 3.2 Integrate locally with credit
+
+We don't merge community PRs through the GitHub UI (this would scatter the
+release across many PRs). Instead, integrate the diff locally in the release
+branch with `Co-authored-by:` in the commit message:
+
+```bash
+# Apply the change manually (Edit / fix file by file)
+git add <files>
+git commit -m "$(cat <<'EOF'
+fix(<collector>): <one-line summary> (#<issue>, #<pr>)
+
+<longer explanation>
+
+Refs: #<issue>
+Co-authored-by: <author> <<author>@users.noreply.github.com>
+EOF
+)"
+```
+
+This preserves the contributor's authorship in GitHub's contributor page
+without scattering the release across many merge commits.
+
+### 3.3 One commit = one logical change
+
+If a PR fixes two distinct bugs (e.g. PR #28 fixed both a regex hyphen issue
+*and* a GRES separator issue), split it into two commits. Each commit must:
+
+- Compile and pass `go test` on its own (so `git bisect` works).
+- Have its own non-regression test if applicable.
+- Carry the `Co-authored-by:` trailer.
+
+### 3.4 Test of non-regression
+
+Every code change must come with a test that:
+
+- Fails before the fix (you should briefly verify this — write the test
+  first, run it, see it fail).
+- Passes after the fix.
+- Uses the project's existing test fixtures in `test_data/` when possible.
+
+If the PR doesn't come with a test, write one. If a fix is purely defensive
+(e.g. log on empty parse), a unit test that exercises the empty path is
+enough.
+
+---
+
+## 4. Defensive audit
+
+For each bug you fix, ask: **is the same class of bug present anywhere
+else in the codebase?**
+
+Example (v1.8.2):
+- Issue #10 was about `sinfo -O` using fixed-width columns in
+  `internal/collector/node.go`. The defensive audit revealed the same
+  pattern in `internal/collector/partitions.go` and
+  `internal/collector/gpus.go`. All three were fixed in the same release.
+- Issue #20 was about partition `*` suffix not being stripped in
+  `partitions.go`. The same parsing pattern existed in `queue.go` and got
+  the same defensive fix.
+
+Search patterns:
+
+```bash
+# Find all sinfo --Format / -O sites
+grep -rn '"-O"\|"--Format=\|"-o "' internal/collector/
+
+# Find all partition / user / job state parsing
+grep -rn 'fields\[\|splitLine\[' internal/collector/
+```
+
+Defensive fixes ship as separate commits with `(defensive)` in the
+summary, no `Co-authored-by:`.
+
+---
+
+## 5. Validate continuously
+
+After every commit, run:
+
+```bash
+make check    # vet + golangci-lint + tests
+```
+
+Before the release ships, run the heavier checks at least once:
+
+```bash
+make race     # race detector
+make build    # full ldflags build
+```
+
+If `make race` fails on a pre-existing test (not something you introduced),
+fix it in this release if cheap, otherwise file a follow-up issue.
+
+---
+
+## 6. End-to-end test on a live cluster
+
+Spin up the test cluster and validate the actual `/metrics` output:
+
+```bash
+make -C scripts/testing setup
+make -C scripts/testing workload N=30
+
+# Inspect metrics from inside slurmctld
+docker exec slurmctld curl -s http://localhost:9341/metrics > /tmp/metrics.txt
+```
+
+### Spot-check the release theme
+
+For v1.8.2 we explicitly verified:
+
+- The fix actually fires under realistic conditions (e.g. parse a fixture
+  that previously dropped a node, confirm the node now appears).
+- Renamed metrics use the new names (e.g. `slurm_scheduler_jobs_submitted`
+  without `_total`).
+- Dashboards in `dashboards_grafana/` still render — `make redeploy-dashboards`
+  reimports them and Grafana is reachable at `http://localhost:3000`.
+
+### Diff exposed metrics against docs
+
+```bash
+# Names emitted by the live exporter
+grep -E '^slurm_' /tmp/metrics.txt | sed 's/[{ ].*//' | LC_ALL=C sort -u > /tmp/exposed.txt
+
+# Names documented in docs/metrics.md
+grep -oE '`slurm_[a-z_]+`' docs/metrics.md | tr -d '`' | LC_ALL=C sort -u > /tmp/doc.txt
+
+# Gaps in both directions
+comm -23 /tmp/doc.txt /tmp/exposed.txt   # documented but not exposed
+comm -13 /tmp/doc.txt /tmp/exposed.txt   # exposed but not documented
+```
+
+Treat "exposed but not documented" entries as bugs to fix in this release
+(unless they're histogram `_bucket/_count/_sum` suffixes, which are implicit).
+
+"Documented but not exposed" entries are usually contextual (e.g. account-level
+metrics need running jobs, sacct_efficiency is opt-in). Verify each before
+declaring the doc clean.
+
+---
+
+## 7. Update documentation
+
+For every change that affects user-visible behavior:
+
+| File | Update when |
+|---|---|
+| `CHANGELOG.md` | Always. New version section with Breaking Changes / Bug Fixes / Improvements / Dashboard impact sub-sections |
+| `docs/metrics.md` | Any metric added, renamed, removed, or label-changed |
+| `docs/metrics-examples.md` | Any new metric in a section where a representative sample would help users |
+| `docs/configuration.md` | Any new flag, default change, or behavior toggle |
+| `README.md` | Headline features only |
+| `dashboards_grafana/*.json` | Any rename, drop of a metric that's actually used in a panel, or addition of a high-value metric that deserves its own panel |
+| Companion `monitoring-stacks/alerts/slurm.yml` | Any metric rename, drop, or new opt-in collector that recording rules / alerts depend on |
+
+For breaking changes, include a **migration table** in CHANGELOG:
+
+```markdown
+| Old | New |
+| --- | --- |
+| `slurm_foo_bar_total` (Counter) | `slurm_foo_bar` (Gauge) |
+```
+
+---
+
+## 8. Push and open the PR
+
+```bash
+git push -u origin fix/vX.Y.Z
+gh pr create --base master --head fix/vX.Y.Z \
+  --title "fix(vX.Y.Z): <theme> + N community PRs" \
+  --body-file /tmp/pr_body.md
+```
+
+PR body structure (use the v1.8.2 PR as the canonical template):
+
+```
+## Summary
+1-3 bullets.
+
+## ⚠️ Breaking change          (omit if none)
+Migration table + rationale (esp. how recent the affected metric is).
+
+## Bug fixes
+### <Theme of this release>
+### Integrated community PRs   (table: PR | issue | author | subject)
+### Other hardening
+
+## Dashboard impact
+Effects users will see on values, not on JSON structure (unless JSON changed).
+
+## Test plan
+Checklist already ticked by the time the PR opens.
+
+## Follow-ups (next release)
+Bullet list with issue numbers.
+```
+
+Self-review the diff on GitHub before requesting outside review.
+
+---
+
+## 9. Post-merge cleanup
+
+Once the PR is merged to `master`:
+
+### Close integrated community PRs
+
+```bash
+for pr in <list of integrated PRs>; do
+  gh pr close "$pr" --repo $OWNER/slurm_exporter \
+    --comment "Integrated into vX.Y.Z (see release notes). \
+Thanks for the contribution — your authorship is preserved via Co-authored-by in the commit. 🙏"
+done
+```
+
+### Respond to issues
+
+For issues that were fixed: post a short comment pointing to the release and
+close.
+
+For issues that are *acknowledged but planned for the next release*: leave
+them open and comment with the planned milestone and what the user can do
+in the meantime.
+
+### Tag and release
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z — <short headline>"
+git push origin vX.Y.Z
+```
+
+CI (`.github/workflows/release.yml`) picks up the tag, runs
+`lint → test → goreleaser release`, and publishes the binary + the
+GitHub release page.
+
+---
+
+## 10. Handle PRs that don't ship in this release
+
+When you receive a PR that has the right idea but doesn't fit the current
+release (wrong scope, missing tests, conflicts with in-flight work), the
+right answer is **not** to leave it rotting.
+
+Comment on the PR with:
+
+1. **What's good** — what the PR gets right.
+2. **What blocks merging today** — concrete blockers with reasons (not
+   opinions).
+3. **What the plan is** — which release you'll integrate it in, what you'll
+   adapt or add (tests, flags, dashboard panel).
+4. **A concrete signal of intent** — e.g. "I'll adapt and ship in v1.9 this
+   month. You'll be credited via Co-authored-by."
+5. **Concrete preview** — when relevant, show an example of the metrics
+   that would be exposed, or a snippet of dashboard PromQL.
+
+Close with the maintainer formula:
+> I'm not closing the PR — keeping it open as the reference discussion while
+> I adapt. Thanks again, nice contribution.
+
+The PRs #29 / issue #27 responses from the v1.8.2 cycle are good templates.
+
+---
+
+## Reference: what v1.8.2 looked like
+
+For context, v1.8.2 (the release that codified this process) was made of:
+
+- 1 issue-driven bug fix (#10, silent metric loss on long node names).
+- 3 defensive fixes (same bug class on partitions/gpus, parseGpuCount
+  multi-type, queue partition `*` strip).
+- 8 integrated community PRs (#12/#13, #14/#15, #16/#17, #18/#19, #20/#21,
+  #22/#23 — breaking —, #24/#25, and PR #28).
+- 1 issue-driven bug fix (#26, reservation phantom row).
+- 2 follow-up responses on issues planned for v1.9 (#27, PR #29).
+- 4 docs updates (metrics, metrics-examples, CHANGELOG, this file).
+- 25 commits, all conventional, all atomic.
+
+Time from branch creation to PR open: ~1 working day. Plan around that
+order of magnitude for similar releases.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -175,14 +175,30 @@ fix it in this release if cheap, otherwise file a follow-up issue.
 
 ## 6. End-to-end test on a live cluster
 
-Spin up the test cluster and validate the actual `/metrics` output:
+Spin up the test cluster and validate the actual `/metrics` output, with
+every collector enabled, debug logs captured, and release-specific
+assertions made explicit.
+
+The detailed step-by-step playbook is in
+**[`docs/validation-checklist.md`](validation-checklist.md)** — 11 steps,
+copy-pasteable commands, expected outputs, and "if it fails" diagnostics
+for each. Designed so a human or an AI agent can execute the validation
+end-to-end without prior context.
+
+Short version of what that checklist covers:
 
 ```bash
-make -C scripts/testing setup
-make -C scripts/testing workload N=30
+make -C scripts/testing setup     # Step 2 — bring up cluster + deploy binary
 
-# Inspect metrics from inside slurmctld
-docker exec slurmctld curl -s http://localhost:9341/metrics > /tmp/metrics.txt
+# Step 3 — restart exporter with ALL collectors and debug logs
+# (see the checklist for the full command)
+
+# Step 4-5 — verify scrape returns 200 and every collector success=1
+# Step 6 — inspect the exact Slurm commands logged
+# Step 7 — submit workload, re-scrape
+# Step 8 — diff /metrics ↔ docs/metrics.md
+# Step 9 — release-specific assertions (template in the checklist)
+# Step 10 — visual Grafana dashboard pass
 ```
 
 ### Spot-check the release theme
@@ -216,6 +232,9 @@ Treat "exposed but not documented" entries as bugs to fix in this release
 "Documented but not exposed" entries are usually contextual (e.g. account-level
 metrics need running jobs, sacct_efficiency is opt-in). Verify each before
 declaring the doc clean.
+
+> The full diff workflow is automated and explained in the
+> [validation checklist](validation-checklist.md#step-8--diff-exposed-metrics-against-docsmetricsmd).
 
 ---
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -303,7 +303,83 @@ For issues that are *acknowledged but planned for the next release*: leave
 them open and comment with the planned milestone and what the user can do
 in the meantime.
 
-### Tag and release
+### Test on a real platform before the final tag
+
+The Docker test cluster (`scripts/testing`) catches structural bugs, but it
+runs on short hostnames (`c1`–`c10`), no real workload variability, and a
+clean Slurm install. **A real cluster will surface things the test cluster
+can't** — long node names, multi-type GPUs, slurmctld restarts, sustained
+load, version-specific output quirks. Before tagging the final release,
+run the binary on an actual cluster.
+
+Two approaches depending on risk:
+
+#### A. Release candidate tag (recommended for minor/major and breaking changes)
+
+For releases that rename metrics, change types, or touch the scheduler
+(v1.8.2 was one of these), tag a release candidate first. CI will publish
+it as a GitHub **pre-release** thanks to the `prerelease: auto` setting in
+`.goreleaser.yaml`, so users won't grab it by accident from
+`go install @latest` or release-assets automation.
+
+```bash
+git checkout master && git pull
+git tag -a vX.Y.Z-rc1 -m "vX.Y.Z release candidate 1"
+git push origin vX.Y.Z-rc1
+# → CI publishes a GitHub pre-release with the rc1 binary
+```
+
+Deploy the rc1 binary to a staging or production cluster, leave it running
+through at least one full work cycle (a few hours, ideally overnight), and
+watch for:
+
+- Unexpected dips or spikes in any metric series.
+- New error logs from the exporter.
+- Dashboard panels suddenly showing "No data" where they used to.
+- `slurm_exporter_collector_duration_seconds` getting much longer.
+
+If you find an issue: fix on a hotfix branch, merge, then `vX.Y.Z-rc2`.
+Repeat as needed. Once stable, ship the final tag:
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z — <headline>"
+git push origin vX.Y.Z
+```
+
+#### B. Local build + manual deploy (for trivial patches)
+
+For a patch that only touches docs, tests, or a clearly isolated bug, the
+RC dance is overkill. Build the binary from merged `master` and ship it
+manually to a staging cluster:
+
+```bash
+git checkout master && git pull
+make build
+
+scp bin/slurm_exporter staging-cluster:/usr/local/bin/slurm_exporter.next
+ssh staging-cluster "
+  /usr/local/bin/slurm_exporter.next --version &&
+  systemctl stop slurm_exporter &&
+  mv /usr/local/bin/slurm_exporter.next /usr/local/bin/slurm_exporter &&
+  systemctl start slurm_exporter
+"
+```
+
+Watch Grafana and `/metrics` for the same signals as approach A, for a
+shorter window (~30 min) before tagging.
+
+#### Decision matrix
+
+| Change type | Approach |
+|---|---|
+| Breaking change (metric rename/retyped, label change) | **A — RC tag**, deploy to staging, full overnight |
+| New collector / new exposed metric | **A — RC tag**, deploy to staging, a few hours |
+| Bug fix to existing collector | **B — local build**, 30 min validation |
+| Docs / test-only patch | None required — `make check` is enough |
+
+### Tag the final release
+
+Once you're confident on a real cluster:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z — <short headline>"

--- a/docs/validation-checklist.md
+++ b/docs/validation-checklist.md
@@ -1,0 +1,478 @@
+# Release Validation Checklist
+
+> Back to [README](../README.md) · See also [release-process.md](release-process.md)
+
+A step-by-step procedure to validate a release candidate of `slurm_exporter`
+end-to-end against the Docker test cluster (`scripts/testing/`). Designed so
+that a human or an AI agent can execute it without prior context.
+
+**Each step has:**
+- A **Command** — a copy-pasteable shell block.
+- An **Expected** outcome — what the command should print or produce.
+- An **If it fails** section — how to diagnose and what to fix before
+  continuing.
+
+**Pre-requisites**:
+- The branch you want to validate is checked out and `make build` succeeds.
+- Docker Engine is running.
+- `~/Dev/work/apps_repo/orchestration-hpc/slurm-docker-cluster` exists, or
+  another path that `scripts/testing/_lib.sh` auto-detects.
+- The host has at least 4 GB free RAM and 5 GB free disk.
+
+---
+
+## Step 1 — Pre-flight static checks
+
+Confirm the workspace is clean and the binary builds.
+
+### Command
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git status --short
+make vet
+make lint
+make build
+bin/slurm_exporter --version
+```
+
+### Expected
+
+- `git status --short` shows only intentional changes (and possibly `.claude/`,
+  which is gitignored noise).
+- `make vet` exits 0 with `Running go vet` then `go vet ./...` only.
+- `make lint` ends with `0 issues.`
+- `make build` produces `bin/slurm_exporter` without warnings.
+- `bin/slurm_exporter --version` prints a version string including the current
+  branch name (e.g. `v1.8.1-NN-gXXXXXXX` for an unreleased branch).
+
+### If it fails
+
+- `vet` / `lint` errors: fix them before continuing. Don't validate a branch
+  that doesn't pass static checks.
+- `make build` errors usually mean a Go toolchain mismatch — check
+  `go version` matches what `Makefile` expects (1.25+).
+
+---
+
+## Step 2 — Bring up the Docker test cluster
+
+Starts the Slurm cluster + Prometheus + Grafana + deploys the freshly-built
+binary as a system process inside `slurmctld`.
+
+### Command
+
+```bash
+make -C scripts/testing setup
+```
+
+### Expected
+
+The script prints nine green checkmarks `[1/9]` through `[9/9]` and
+finishes with `✓ Done. Run: make workload && make screenshots`.
+
+Specifically:
+- `✓ 10/10 nodes registered`
+- `✓ Monitoring stack started (Prometheus + Grafana)`
+- `✓ Exporter running on slurmctld:9341`
+- `✓ 10 dashboards imported, 0 failed`
+
+### If it fails
+
+- Step `4/9` (node registration) timing out: the WSL2 / Docker network is
+  slow. Wait a minute, then `make -C scripts/testing redeploy` and retry.
+- `9/9` failed (exporter not reachable): the binary built with the wrong
+  toolchain for the cluster image. Check `bin/slurm_exporter` runs locally
+  first.
+- Dashboard import fails: check `docker logs grafana`; usually a Grafana
+  startup delay, retry `make -C scripts/testing redeploy-dashboards`.
+
+---
+
+## Step 3 — Restart the exporter with all collectors + debug logs
+
+The default `make setup` runs the exporter with the minimum flags. For a
+proper validation run, restart it with **every collector explicitly enabled**
+(including the opt-in ones like `sacct_efficiency`) and `--log.level=debug`
+so we can inspect every Slurm command it issues.
+
+### Command
+
+```bash
+docker exec slurmctld bash -c '
+  pkill -9 -f slurm_exporter 2>/dev/null
+  sleep 1
+  rm -f /tmp/exporter.log
+  nohup /usr/local/bin/slurm_exporter \
+    --web.listen-address=:9341 \
+    --log.level=debug \
+    --command.timeout=10s \
+    --collector.accounts \
+    --collector.cpus \
+    --collector.drain_reason \
+    --collector.fairshare \
+    --collector.fairshare.user-metrics \
+    --collector.gpus \
+    --collector.info \
+    --collector.licenses \
+    --collector.node \
+    --collector.nodes \
+    --collector.nodes.feature-set \
+    --collector.partitions \
+    --collector.queue \
+    --collector.queue.user-label \
+    --collector.reservations \
+    --collector.sacct_efficiency \
+    --collector.sacct.interval=30s \
+    --collector.sacct.lookback=1h \
+    --collector.scheduler \
+    --collector.users \
+    > /tmp/exporter.log 2>&1 &
+  sleep 3
+  curl -s http://localhost:9341/healthz
+'
+```
+
+### Expected
+
+- Final output line is `ok` (from `/healthz`).
+- The first 20 lines of `/tmp/exporter.log` contain `level=INFO msg="Collector enabled"` for every collector you passed (16 of them).
+- One `level=INFO msg="Starting Slurm Exporter server..."` line.
+- One `level=INFO msg="Listening on" address=[::]:9341` line.
+- **No `level=ERROR` or `level=WARN` entries** in the startup phase.
+
+### If it fails
+
+- `address already in use`: another exporter instance is alive. Re-run the
+  `pkill` and check `docker exec slurmctld ps aux | grep slurm_exporter`.
+- `Collector enabled` missing for one collector: a flag name changed in the
+  binary. Compare with `slurm_exporter --help` output.
+- Warnings during startup: capture them — they often signal a real bug
+  introduced by the branch.
+
+---
+
+## Step 4 — Verify a full scrape with no errors
+
+A single `/metrics` request must succeed without producing any error log
+entry.
+
+### Command
+
+```bash
+docker exec slurmctld bash -c '
+  curl -s -o /tmp/scrape.txt -w "HTTP %{http_code} in %{time_total}s\n" \
+    http://localhost:9341/metrics
+'
+docker exec slurmctld bash -c '
+  echo "=== Metric series count ==="
+  grep -cE "^slurm_" /tmp/scrape.txt
+  echo "=== Errors / warnings in logs ==="
+  grep -cE "level=ERROR|level=WARN" /tmp/exporter.log
+'
+```
+
+### Expected
+
+- HTTP 200, scrape duration < 1 second on a quiet cluster.
+- Metric series count ≥ 400 (with all collectors enabled and after `make
+  workload`, expect 500–600; without workload, 400–500).
+- **0 errors and 0 warnings** in the log file.
+
+### If it fails
+
+- HTTP 500 / 503: the exporter crashed mid-scrape. Read the last 50 lines
+  of `/tmp/exporter.log` for the panic trace.
+- Scrape duration > 5s: a collector is timing out. Inspect
+  `slurm_exporter_collector_duration_seconds` after the scrape to find
+  which one.
+- Any `level=ERROR`: real problem to investigate before tagging.
+
+---
+
+## Step 5 — Validate all collectors succeeded
+
+Each collector exposes a success gauge. They must all be `1`.
+
+### Command
+
+```bash
+docker exec slurmctld bash -c '
+  grep -E "^slurm_exporter_collector_success" /tmp/scrape.txt | sort
+'
+```
+
+### Expected
+
+16 lines, all ending with ` 1`:
+
+```
+slurm_exporter_collector_success{collector="accounts"} 1
+slurm_exporter_collector_success{collector="cpus"} 1
+slurm_exporter_collector_success{collector="drain_reason"} 1
+slurm_exporter_collector_success{collector="fairshare"} 1
+slurm_exporter_collector_success{collector="gpus"} 1
+slurm_exporter_collector_success{collector="info"} 1
+slurm_exporter_collector_success{collector="licenses"} 1
+slurm_exporter_collector_success{collector="node"} 1
+slurm_exporter_collector_success{collector="nodes"} 1
+slurm_exporter_collector_success{collector="partitions"} 1
+slurm_exporter_collector_success{collector="queue"} 1
+slurm_exporter_collector_success{collector="reservation_nodes"} 1
+slurm_exporter_collector_success{collector="reservations"} 1
+slurm_exporter_collector_success{collector="sacct_efficiency"} 1
+slurm_exporter_collector_success{collector="scheduler"} 1
+slurm_exporter_collector_success{collector="users"} 1
+```
+
+### If it fails
+
+- Any `... 0` value: that collector failed silently. Find its error in
+  `/tmp/exporter.log` and fix it before tagging.
+- Missing line for a collector: the flag wasn't picked up. Re-check the
+  command in Step 3.
+
+---
+
+## Step 6 — Inspect Slurm commands the exporter actually ran
+
+This is the moment to confirm any release-specific change is wired through.
+For v1.8.2 we expected `sinfo -O` to use variable-width column specs (`:` at
+the end of each field).
+
+### Command
+
+```bash
+docker exec slurmctld bash -c '
+  echo "=== sinfo / squeue / sacct calls in the last scrape ==="
+  grep -E "Executing command" /tmp/exporter.log \
+    | awk -F"command=" "{print \$2}" \
+    | awk -F" elapsed_ms=" "{print \$1}" \
+    | sort -u
+'
+```
+
+### Expected
+
+A unique list of `command=X args="..."` lines. **Inspect each one** for:
+- The argument format matches what `internal/collector/*.go` documents in
+  its function comments.
+- No suspicious tokens (e.g. unescaped quotes, missing `:` on variable-width
+  fields, fixed widths where they shouldn't be).
+
+For v1.8.2 the line we wanted to see was:
+
+```
+command=sinfo args="-h -N -O NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition:"
+```
+
+### If it fails
+
+- A command argument doesn't match what the code says: regression in the
+  release branch. Check the matching `*Data()` function in
+  `internal/collector/`.
+- Unexpected commands appear: a new collector ran that wasn't supposed to,
+  or one ran twice. Check `collector.SetCommandTimeout` and the constructor
+  chain in `cmd/slurm_exporter/main.go`.
+
+---
+
+## Step 7 — Generate a realistic workload
+
+Empty-cluster metrics don't exercise the per-user / per-account / queue
+collectors. Submit a workload, then re-scrape.
+
+### Command
+
+```bash
+make -C scripts/testing workload N=30
+
+# Resume any nodes stuck in DOWN (common after a fresh container restart)
+docker exec slurmctld scontrol update NodeName=ALL State=RESUME 2>/dev/null
+
+# Wait for the scheduler to dispatch
+sleep 15
+
+# Refresh metrics
+docker exec slurmctld curl -s http://localhost:9341/metrics > /tmp/scrape_workload.txt
+docker exec slurmctld bash -c 'wc -l /tmp/scrape_workload.txt'
+```
+
+### Expected
+
+- `wc -l` reports > 800 lines (more series under load).
+- Job-related metrics are non-zero somewhere:
+
+  ```bash
+  grep -E "^slurm_jobs_(pending|running|completed) " /tmp/scrape_workload.txt
+  ```
+
+  At least one of `pending` / `running` should be > 0 right after submission;
+  `completed` may grow on a second scrape a few seconds later.
+
+### If it fails
+
+- All jobs stay PD with reason `(ReqNodeNotAvail)`: nodes are DOWN. Run the
+  `scontrol update State=RESUME` command above and wait another 15s.
+- `make workload` errors: missing OS users. Re-run
+  `bash scripts/testing/_lib.sh setup-os-users`.
+
+---
+
+## Step 8 — Diff exposed metrics against `docs/metrics.md`
+
+Catch undocumented or stale metrics. The exporter is the source of truth.
+
+### Command
+
+```bash
+docker exec slurmctld cat /tmp/scrape_workload.txt > /tmp/scrape.txt
+
+# Names emitted by the live exporter
+grep -E '^slurm_' /tmp/scrape.txt | sed 's/[{ ].*//' | LC_ALL=C sort -u > /tmp/exposed.txt
+
+# Names documented in docs/metrics.md
+grep -oE '`slurm_[a-z_]+`' docs/metrics.md | tr -d '`' | LC_ALL=C sort -u > /tmp/doc.txt
+
+echo "=== Documented but NOT exposed ==="
+comm -23 /tmp/doc.txt /tmp/exposed.txt
+
+echo
+echo "=== Exposed but NOT documented ==="
+comm -13 /tmp/doc.txt /tmp/exposed.txt
+```
+
+### Expected
+
+- **Documented but not exposed** is small and *contextual* — every entry has
+  a defensible reason for not being emitted on this cluster (e.g. no GPU
+  jobs, no reservations, sacct_efficiency disabled by default in the doc
+  example, no DRAIN nodes). Investigate each; none should be a permanent
+  ghost.
+
+- **Exposed but not documented** is **empty** or contains only histogram
+  suffixes (`_bucket`, `_count`, `_sum`) which are implicit from the parent
+  metric name.
+
+### If it fails
+
+- Any new exposed-but-not-documented name (other than histogram suffixes):
+  open `docs/metrics.md`, find the relevant `### Collector` section, add
+  a row in its metrics table. Commit before tagging.
+
+---
+
+## Step 9 — Release-specific assertions
+
+Replace this section's contents for each release. The pattern is the same:
+
+1. Identify the bug or feature changing in this release.
+2. Find a metric or log signal that proves the fix is wired.
+3. Assert it explicitly with grep.
+
+### Example: assertions for v1.8.2
+
+```bash
+echo "=== Issue #10 fix: variable-width sinfo -O ==="
+grep -E '"-h -N -O NodeList: ' /tmp/exporter.log | head -1
+# Expected: a line appears
+
+echo "=== Issue #26 fix: no phantom reservation row ==="
+grep '^slurm_reservation' /tmp/scrape.txt | grep 'reservation_name=""' || echo "no phantom row ✓"
+# Expected: no phantom row ✓
+
+echo "=== Issue #20 fix: default partition asterisk stripped ==="
+grep -E '^slurm_partition_cpus_total\{' /tmp/scrape.txt | grep -v '"cpu\*"' | head
+# Expected: lines show partition="cpu" without the asterisk
+
+echo "=== BREAKING #23 fix: scheduler counters renamed (no _total suffix) ==="
+grep -E '^slurm_scheduler_jobs_(submitted|started|completed|canceled|failed) ' /tmp/scrape.txt | head
+# Expected: exactly five lines, none with _total suffix
+```
+
+### Expected
+
+Each assertion prints the expected signal. Any failure here is **a release
+blocker** — the fix didn't make it into the binary.
+
+### If it fails
+
+- The grep returns nothing where it should return something: re-check the
+  binary version (`bin/slurm_exporter --version`) matches the branch.
+  Re-run `make build` and `make -C scripts/testing redeploy`.
+
+---
+
+## Step 10 — Visual inspection of Grafana dashboards
+
+Final pass: pages must render.
+
+### Command
+
+Open in browser (or via Playwright/Chromium for the AI agent):
+
+```
+http://localhost:3000  (login admin / admin)
+```
+
+Walk through every dashboard in `dashboards_grafana/`. For each:
+- No "No data" on panels that should have data.
+- No PromQL parse errors (red banner).
+- Time ranges show plausible values.
+
+For automated screenshots:
+
+```bash
+make -C scripts/testing screenshots OUTPUT=/tmp/dashboard-screenshots
+```
+
+### Expected
+
+- All 10 dashboards open.
+- Panels populated (at minimum: scheduler health metrics, partition counts,
+  node states).
+- The new "Job Lifecycle (since slurmctld start)" row on
+  `05-slurm-scheduler.json` shows non-zero values after Step 7's workload.
+
+### If it fails
+
+- Dashboard says "No data" on a panel: open the panel's edit view, copy the
+  expression, run it in Prometheus directly (http://localhost:9090). If
+  Prometheus also returns nothing, the metric was renamed or removed in
+  this branch — update the dashboard JSON or the metric name.
+
+---
+
+## Step 11 — Tear down
+
+When done, free the resources.
+
+### Command
+
+```bash
+make -C scripts/testing stop      # keeps volumes — fast resume with `make start`
+# or
+make -C scripts/testing clean     # full teardown including Docker volumes
+```
+
+---
+
+## Summary checklist (for quick reference)
+
+Tick each as you go:
+
+- [ ] Step 1 — `make vet`, `make lint`, `make build` all green
+- [ ] Step 2 — `make setup` completes 9/9
+- [ ] Step 3 — Exporter restarted with all collectors + debug
+- [ ] Step 4 — `/metrics` returns 200, 0 errors/warnings in log
+- [ ] Step 5 — All 16 collectors report `success = 1`
+- [ ] Step 6 — Slurm commands logged match expected formats for the branch
+- [ ] Step 7 — Workload submitted, jobs run, queue/cores/user metrics populated
+- [ ] Step 8 — `docs/metrics.md` ↔ `/metrics` diff is clean
+- [ ] Step 9 — Release-specific assertions pass
+- [ ] Step 10 — All Grafana dashboards render with data
+- [ ] Step 11 — Cluster teardown
+
+Once every box is ticked, the release is ready for the **real-platform
+validation** step described in
+[release-process.md § Test on a real platform before the final tag](release-process.md#test-on-a-real-platform-before-the-final-tag).

--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -16,10 +16,12 @@ var (
 	accountJobRunning   = regexp.MustCompile(`^running`)
 	accountJobSuspended = regexp.MustCompile(`^suspended`)
 
-	// treGPURe matches GPU counts in TRES strings from squeue %b output.
-	// Real formats observed: "gres/gpu:4", "gres/gpu:2", "N/A"
-	// Also handles typed GPUs: "gres/gpu:a100:2", "gres/gpu:nvidia_gb200:4"
-	tresGPURe = regexp.MustCompile(`gres/gpu[^,\s]*[:/=](\d+)`)
+	// tresGPURe matches GPU counts in TRES strings from squeue %b output.
+	// Real formats observed: "gres/gpu:4", "gres:gpu:4", "N/A"
+	// Also handles typed GPUs: "gres/gpu:a100:2", "gres:gpu:nvidia_gb200:4"
+	// The [:/]gpu prefix tolerates both separators — some Slurm versions emit
+	// the colon form (see issue #28).
+	tresGPURe = regexp.MustCompile(`gres[:/]gpu[^,\s]*[:/=](\d+)`)
 )
 
 // parseGPUsFromTRES extracts the GPU count per node from a TRES string.

--- a/internal/collector/accounts_test.go
+++ b/internal/collector/accounts_test.go
@@ -52,6 +52,12 @@ func TestParseGPUsFromTRES(t *testing.T) {
 		{"no GPU", "N/A", 0},
 		{"empty", "", 0},
 		{"full TRES string", "billing=10,cpu=8,gres/gpu:4,mem=32G,node=1", 4},
+		// PR #28: some Slurm versions emit "gres:gpu:N" (colon prefix) instead
+		// of "gres/gpu:N" (slash). Both must be parsed identically.
+		{"colon simple", "gres:gpu:4", 4},
+		{"colon typed", "gres:gpu:a100:2", 2},
+		{"colon nvidia_gb200", "gres:gpu:nvidia_gb200:4", 4},
+		{"colon full TRES", "billing=10,cpu=8,gres:gpu:4,mem=32G,node=1", 4},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/collector/execute.go
+++ b/internal/collector/execute.go
@@ -32,11 +32,14 @@ func SetBinPath(p string) {
 	binPath = p
 }
 
-// SlurmBinaries is the list of Slurm CLI tools used by the exporter.
+// SlurmBinaries is the list of Slurm CLI tools required by the exporter.
 // Used by ValidateBinaries to check that all required tools are present at startup.
+// Job submission tools (sbatch, salloc, srun) are intentionally excluded: the
+// exporter never invokes them, so requiring them blocks deployment on
+// monitoring-only nodes / minimal containers. See issue #24.
 var SlurmBinaries = []string{
 	"sinfo", "squeue", "sdiag", "scontrol", "sshare",
-	"sacct", "sbatch", "salloc", "srun",
+	"sacct",
 }
 
 // ValidateBinaries checks that every binary in the given list is accessible

--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -173,8 +173,17 @@ func ParseGPUsMetrics(logger *logger.Logger) (*GPUsMetrics, error) {
 	}
 	idleGPUs := ParseIdleGPUs(idleGPUsData)
 
-	// Calculate other GPUs (mixed, down, etc.)
+	// Calculate other GPUs (DRAIN, DOWN, RESERVED, MAINTENANCE, etc.).
+	// Clamp to zero because total/allocated/idle come from three separate
+	// sinfo invocations and cluster state can change between them, producing
+	// a transient negative result (see issue #16). The Debug log gives a
+	// trail if operators ever need to investigate suspected miscounting.
 	otherGPUs := totalGPUs - allocatedGPUs - idleGPUs
+	if otherGPUs < 0 {
+		logger.Debug("gpus collector: clamped negative 'other' to zero (likely sinfo timing race)",
+			"total", totalGPUs, "alloc", allocatedGPUs, "idle", idleGPUs, "computed_other", otherGPUs)
+		otherGPUs = 0
+	}
 
 	gm.alloc = allocatedGPUs
 	gm.idle = idleGPUs

--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -195,15 +195,21 @@ func AllocatedGPUsData(logger *logger.Logger) ([]byte, error) {
 	return Execute(logger, "sinfo", args)
 }
 
-// IdleGPUsData executes sinfo command to get idle and allocated GPU information
+// IdleGPUsData executes sinfo command to get idle and allocated GPU information.
+//
+// Trailing ":" on each field forces variable column widths; fixed widths
+// (was Gres:50, GresUsed:50) silently truncate rich GRES specs on busy GPU
+// nodes (multi-type GPUs, MIG slices), causing wrong GPU counts.
+// See https://github.com/SckyzO/slurm_exporter/issues/10.
 func IdleGPUsData(logger *logger.Logger) ([]byte, error) {
-	args := []string{"-a", "-h", "--Format=Nodes:10 ,Gres:50 ,GresUsed:50", "--state=idle,allocated"}
+	args := []string{"-a", "-h", "--Format=Nodes: ,Gres: ,GresUsed:", "--state=idle,allocated"}
 	return Execute(logger, "sinfo", args)
 }
 
-// TotalGPUsData executes sinfo command to get total GPU information
+// TotalGPUsData executes sinfo command to get total GPU information.
+// See IdleGPUsData for the rationale behind the variable-width format.
 func TotalGPUsData(logger *logger.Logger) ([]byte, error) {
-	args := []string{"-a", "-h", "--Format=Nodes:10 ,Gres:50"}
+	args := []string{"-a", "-h", "--Format=Nodes: ,Gres:"}
 	return Execute(logger, "sinfo", args)
 }
 

--- a/internal/collector/gpus_clamp_test.go
+++ b/internal/collector/gpus_clamp_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// TestGPUsMetrics_ClampNegativeOther is the non-regression test for issue #16 /
+// PR #17. Pre-fix, slurm_gpus_other was computed as total - allocated - idle
+// across three separate sinfo invocations, and could be transiently negative
+// when cluster state changed between the calls. The fix clamps to zero.
+//
+// We force the negative case here by mocking Execute to return values such
+// that allocated + idle > total.
+func TestGPUsMetrics_ClampNegativeOther(t *testing.T) {
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+
+	// allocated = 4 (one node × 4 GPUs)
+	// idle      = 4 (4 idle GPUs from 1 node with 8 total / 4 used)
+	// total     = 5 (1 node with 5 GPUs — intentionally lower than alloc+idle
+	//                to simulate the race between sinfo calls)
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		spec := args[2]
+		switch {
+		case strings.Contains(spec, "GresUsed:") && strings.Contains(spec, "Gres:"):
+			// IdleGPUsData: "Nodes Gres GresUsed" — idle = total - allocated
+			// 1 node, total 8, used 4 → idle = 4
+			return []byte("1 gpu:tesla:8 gpu:tesla:4\n"), nil
+		case strings.Contains(spec, "GresUsed:"):
+			// AllocatedGPUsData: "Nodes GresUsed" — 1 node × 4 allocated
+			return []byte("1 gpu:tesla:4\n"), nil
+		case strings.Contains(spec, "Gres:"):
+			// TotalGPUsData: "Nodes Gres" — 1 node × 5 (intentionally < alloc+idle)
+			return []byte("1 gpu:tesla:5\n"), nil
+		}
+		return nil, nil
+	}
+
+	log := logger.NewLogger("debug")
+	metrics, err := GPUsGetMetrics(log)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(5), metrics.total)
+	assert.Equal(t, float64(4), metrics.alloc)
+	assert.Equal(t, float64(4), metrics.idle)
+	// Pre-fix: other = 5 - 4 - 4 = -3
+	// Post-fix: clamped to 0
+	assert.Equal(t, float64(0), metrics.other,
+		"slurm_gpus_other must be clamped to 0 when alloc+idle exceeds total")
+}

--- a/internal/collector/gpus_long_gres_test.go
+++ b/internal/collector/gpus_long_gres_test.go
@@ -1,0 +1,38 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseTotalGPUsLongGres is the non-regression test for the GRES truncation
+// class of bug fixed alongside issue #10. Before the fix, TotalGPUsData() used
+// "--Format=Nodes:10 ,Gres:50", which silently truncated GRES strings longer
+// than 50 characters — losing GPU counts on busy multi-type / MIG nodes.
+//
+// The fixture simulates the corrected variable-width output. With the buggy
+// fixed-width format, line 1 would be truncated to:
+//
+//	"2 gpu:nvidia_a100_80gb:8,mig:nvidia_a100_3g.40gb:7,gp"
+//
+// causing the trailing "gpu:nvidia_h100_80gb:4" to be lost (4 GPUs × 2 nodes
+// = 8 GPUs missing from the total).
+func TestParseTotalGPUsLongGres(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/sinfo_gpus_total_long_gres.txt")
+	if err != nil {
+		t.Fatalf("Can not open test data: %v", err)
+	}
+
+	total := ParseTotalGPUs(data)
+
+	// Expected, per line (regex skips non-gpu: prefixes like "mig:"):
+	//   line 1: 2 nodes × (8 + 4)        = 24
+	//   line 2: 1 node  × 16             = 16
+	//   line 3: 3 nodes × 4              = 12
+	//                                Total = 52
+	// With 50-char truncation, line 1 would yield only 8 × 2 = 16 → total 44.
+	assert.Equal(t, 52.0, total,
+		"all GPUs in long GRES strings must be counted (truncation regression)")
+}

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -82,10 +82,16 @@ func ParseNodeMetrics(input []byte) map[string]*NodeMetrics {
 
 /*
 NodeData executes the sinfo command to get detailed data for each node.
-Expected sinfo output format: "NodeList,AllocMem,Memory,CPUsState,StateLong,Partition".
+Expected sinfo output format: space-separated columns
+"NodeList AllocMem Memory CPUsState StateLong Partition".
+
+The trailing ":" on each field forces sinfo to use variable column widths;
+without it, long node names (>20 chars, the default NodeList width) collide
+with the next column and produce <6 whitespace-separated tokens — silently
+dropping those nodes. See https://github.com/SckyzO/slurm_exporter/issues/10.
 */
 func NodeData(logger *logger.Logger) ([]byte, error) {
-	args := []string{"-h", "-N", "-O", "NodeList,AllocMem,Memory,CPUsState,StateLong,Partition"}
+	args := []string{"-h", "-N", "-O", "NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition:"}
 	return Execute(logger, "sinfo", args)
 }
 
@@ -129,6 +135,9 @@ func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		nc.logger.Error("Failed to get node metrics", "err", err)
 		return
+	}
+	if len(nodes) == 0 {
+		nc.logger.Warn("node collector parsed zero nodes — sinfo returned no data or output format unexpected; no slurm_node_* series will be exposed this scrape")
 	}
 	for node, metrics := range nodes {
 		for _, partition := range metrics.partitions {

--- a/internal/collector/node_long_names_test.go
+++ b/internal/collector/node_long_names_test.go
@@ -1,0 +1,40 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNodeMetricsLongNames is the non-regression test for issue #10:
+// long node names previously caused silent column collision in sinfo -O output,
+// dropping affected nodes from the metrics map. The fix uses variable-width
+// columns (trailing ':') in NodeData(). The parser itself is unchanged because
+// strings.Fields() handles both fixed-width-padded and single-space output.
+//
+// The fixture simulates the output of:
+//
+//	sinfo -h -N -O "NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition:"
+//
+// with a 25-char node name that would have collided under the old format.
+func TestNodeMetricsLongNames(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/sinfo_long_names_fixed.txt")
+	if err != nil {
+		t.Fatalf("Can not open test data: %v", err)
+	}
+	metrics := ParseNodeMetrics(data)
+
+	assert.Contains(t, metrics, "my-very-long-hostname-001",
+		"long-name node must be parsed once variable-width sinfo format is used")
+	assert.Contains(t, metrics, "a048", "short-name node should still parse")
+	assert.Contains(t, metrics, "b003", "short-name node should still parse")
+
+	long := metrics["my-very-long-hostname-001"]
+	assert.Equal(t, uint64(163840), long.memAlloc)
+	assert.Equal(t, uint64(193000), long.memTotal)
+	assert.Equal(t, uint64(16), long.cpuTotal)
+	assert.Equal(t, "idle", long.nodeStatus)
+	assert.Contains(t, long.partitions, "long")
+	assert.Contains(t, long.partitions, "short")
+}

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -63,14 +63,26 @@ var (
 	partitionGpuRe = regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
 )
 
-// parseGpuCount extracts GPU count from GPU spec string
+// parseGpuCount sums all gpu:*:N matches in a GRES string.
+//
+// A GRES string can list multiple GPU types on the same node, e.g.
+// "gpu:A100:4,gpu:H100:2" → 6. Previously this function only returned the
+// first match (4), causing slurm_partition_gpus_* to undercount on
+// multi-type GPU nodes. Aligned with gpus.go::parseGPUCount, which has
+// always iterated correctly.
 func parseGpuCount(gpuSpec string, re *regexp.Regexp) float64 {
-	matches := re.FindStringSubmatch(gpuSpec)
-	if len(matches) > 2 {
-		gpuCount, _ := strconv.ParseFloat(matches[2], 64)
-		return gpuCount
+	var count = 0.0
+	for _, spec := range strings.Split(gpuSpec, ",") {
+		if !strings.Contains(spec, "gpu:") {
+			continue
+		}
+		matches := re.FindStringSubmatch(spec)
+		if len(matches) > 2 {
+			gpuCount, _ := strconv.ParseFloat(matches[2], 64)
+			count += gpuCount
+		}
 	}
-	return 0.0
+	return count
 }
 
 // parsePartitionCPUs parses sinfo "%R,%C" output into the partitions map.

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -95,7 +95,9 @@ func parsePartitionCPUs(data []byte, partitions map[string]*PartitionMetrics) {
 		if len(splitLine) < 2 {
 			continue
 		}
-		partition := splitLine[0]
+		// Strip the default-partition marker (*) so labels are consistent with
+		// nodes.go and other partition consumers — see issue #20.
+		partition := strings.TrimRight(splitLine[0], "*")
 		if _, exists := partitions[partition]; !exists {
 			partitions[partition] = &PartitionMetrics{}
 		}
@@ -122,7 +124,9 @@ func parsePartitionGPUs(data []byte, partitions map[string]*PartitionMetrics) {
 			continue
 		}
 		numNodes, _ := strconv.ParseFloat(fields[0], 64)
-		partition := fields[1]
+		// Strip the default-partition marker (*) so labels are consistent with
+		// nodes.go and other partition consumers — see issue #20.
+		partition := strings.TrimRight(fields[1], "*")
 		nodeGpus := parseGpuCount(fields[2], partitionGpuRe)
 		allocatedGpus := parseGpuCount(fields[3], partitionGpuRe)
 		if _, exists := partitions[partition]; !exists {

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -20,10 +20,16 @@ func PartitionsData(logger *logger.Logger) ([]byte, error) {
 
 /*
 PartitionsGpuData executes the sinfo command to retrieve partition GPU information.
-Expected sinfo output format: "Partition,Gres,GresUsed" (PartitionName,Total/Alloc GPUs).
+Expected sinfo output format: space-separated columns
+"Nodes Partition Gres GresUsed".
+
+Trailing ":" forces variable column widths; fixed widths (was Partition:30,
+Gres:50, GresUsed:50) silently truncate long partition names or rich GRES
+specs (e.g. multi-type GPU + MIG slices), producing wrong GPU counts.
+See https://github.com/SckyzO/slurm_exporter/issues/10.
 */
 func PartitionsGpuData(logger *logger.Logger) ([]byte, error) {
-	return Execute(logger, "sinfo", []string{"-h", "--Format=Nodes:10 ,Partition:30 ,Gres:50 ,GresUsed:50", "--state=idle,allocated"})
+	return Execute(logger, "sinfo", []string{"-h", "--Format=Nodes: ,Partition: ,Gres: ,GresUsed:", "--state=idle,allocated"})
 }
 
 /*
@@ -201,6 +207,9 @@ func (pc *PartitionsCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		pc.logger.Error("Failed to parse partitions metrics", "err", err)
 		return
+	}
+	if len(pm) == 0 {
+		pc.logger.Warn("partitions collector parsed zero partitions — sinfo/squeue returned no data or output format unexpected; no slurm_partition_* series will be exposed this scrape")
 	}
 	for p := range pm {
 		ch <- prometheus.MustNewConstMetric(pc.cpuAllocated, prometheus.GaugeValue, pm[p].cpuAllocated, p)

--- a/internal/collector/partitions_long_gres_test.go
+++ b/internal/collector/partitions_long_gres_test.go
@@ -1,0 +1,71 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParsePartitionGPUsLongValues is the non-regression test for the
+// fixed-width truncation class of bug fixed alongside issue #10. Before the
+// fix, PartitionsGpuData() used "--Format=Nodes:10 ,Partition:30 ,Gres:50 ,GresUsed:50",
+// which silently truncated partition names longer than 30 chars and GRES
+// strings longer than 50 chars.
+//
+// This test also covers the multi-type GPU undercount fix in parseGpuCount.
+// The fixture's GRES line `gpu:nvidia_a100_80gb:8,mig:...,gpu:nvidia_h100_80gb:4`
+// sums to 12 GPUs per node (mig spec ignored by the gpu: regex).
+func TestParsePartitionGPUsLongValues(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/sinfo_partitions_gpu_long.txt")
+	require.NoError(t, err)
+
+	partitions := make(map[string]*PartitionMetrics)
+	parsePartitionGPUs(data, partitions)
+
+	// Long-name partition (52 chars) must be present under its FULL name,
+	// not truncated to 30 chars.
+	const longName = "a_partition_with_a_very_long_name_above_thirty_chars"
+	require.Contains(t, partitions, longName,
+		"long partition name must be preserved (not truncated)")
+
+	// Counts after parseGpuCount fix (sums all gpu: matches):
+	//   per node total = 8 + 4 = 12 (mig: spec ignored by gpu: regex)
+	//   per node alloc = 3 + 2 = 5
+	//   per node idle  = 12 - 5 = 7
+	//   × 2 nodes → alloc=10, idle=14
+	assert.Equal(t, 10.0, partitions[longName].gpuAllocated,
+		"multi-type GRES counts must be summed (regression test for parseGpuCount fix)")
+	assert.Equal(t, 14.0, partitions[longName].gpuIdle)
+
+	// Short partition baseline (single-type GPU, unambiguous).
+	require.Contains(t, partitions, "short_part")
+	assert.Equal(t, 0.0, partitions["short_part"].gpuAllocated)
+	assert.Equal(t, 16.0, partitions["short_part"].gpuIdle)
+}
+
+// TestParseGpuCountMultiType is a focused unit test for the
+// parseGpuCount fix in partitions.go. Pre-fix, FindStringSubmatch returned
+// only the first gpu: match; multi-type GRES strings were undercounted.
+func TestParseGpuCountMultiType(t *testing.T) {
+	cases := []struct {
+		name string
+		gres string
+		want float64
+	}{
+		{"empty", "", 0},
+		{"no_gpu", "cpu=64", 0},
+		{"single_type", "gpu:A100:4", 4},
+		{"two_types", "gpu:A100:4,gpu:H100:2", 6},
+		{"three_types", "gpu:A100:4,gpu:H100:2,gpu:V100:8", 14},
+		{"mig_ignored", "gpu:A100:4,mig:nvidia_a100_3g.40gb:7,gpu:H100:2", 6},
+		{"with_idx_suffix", "gpu:A100:4(IDX:0-3),gpu:H100:2(IDX:0-1)", 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseGpuCount(tc.gres, partitionGpuRe)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/collector/partitions_test.go
+++ b/internal/collector/partitions_test.go
@@ -80,6 +80,31 @@ func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 	}
 }
 
+// TestParsePartitionCPUsStripsAsterisk verifies that the default partition marker (*)
+// appended by Slurm to the default partition name is stripped from CPU sinfo output.
+func TestParsePartitionCPUsStripsAsterisk(t *testing.T) {
+	partitions := make(map[string]*PartitionMetrics)
+	// "compute*" is what Slurm emits for the default partition
+	parsePartitionCPUs([]byte("compute*,10/20/5/35\n"), partitions)
+	require.Contains(t, partitions, "compute", "asterisk must be stripped from CPU partition name")
+	assert.NotContains(t, partitions, "compute*", "raw asterisk-suffixed key must not appear")
+	assert.Equal(t, 10.0, partitions["compute"].cpuAllocated)
+	assert.Equal(t, 35.0, partitions["compute"].cpuTotal)
+}
+
+// TestParsePartitionGPUsStripsAsterisk verifies that the default partition marker (*)
+// appended by Slurm to the default partition name is stripped from GPU sinfo output.
+func TestParsePartitionGPUsStripsAsterisk(t *testing.T) {
+	partitions := make(map[string]*PartitionMetrics)
+	// "gpu*" is what Slurm emits for the default partition in GPU sinfo output
+	parsePartitionGPUs([]byte("2 gpu* gpu:A100:4 gpu:A100:2\n"), partitions)
+	require.Contains(t, partitions, "gpu", "asterisk must be stripped from GPU partition name")
+	assert.NotContains(t, partitions, "gpu*", "raw asterisk-suffixed key must not appear")
+	// 2 nodes * 2 allocated = 4 allocated, 2 nodes * (4-2) = 4 idle
+	assert.Equal(t, 4.0, partitions["gpu"].gpuAllocated)
+	assert.Equal(t, 4.0, partitions["gpu"].gpuIdle)
+}
+
 // TestParsePartitionsMetricsGPUOnlyPartition is a regression test for issue #5:
 // a nil pointer dereference panic when a GPU partition name does not appear in
 // the CPU sinfo output (i.e., it exists only in the GPU sinfo output).

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -105,7 +105,12 @@ func ParseQueueMetrics(input []byte) *QueueMetrics {
 			if len(fields) < 5 {
 				continue
 			}
-			part := strings.TrimSpace(fields[0])
+			// Strip the default-partition marker (*) so labels are consistent
+			// with the partitions and nodes collectors. squeue -o "%P" emits
+			// "compute*" for the default partition on some Slurm versions; the
+			// same fix as in partitions.go (issue #20) is applied here so any
+			// PromQL join on the partition label works as expected.
+			part := strings.TrimRight(strings.TrimSpace(fields[0]), "*")
 			state := fields[1]
 			coresI, _ := strconv.Atoi(fields[2])
 			cores := float64(coresI)

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -321,6 +321,7 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 			PushMetric(values, ch, qc.pending, reason)
 		}
 		PushMetric(qm.running, ch, qc.running, "")
+		PushMetric(qm.suspended, ch, qc.suspended, "")
 		PushMetric(qm.cancelled, ch, qc.cancelled, "")
 		PushMetric(qm.completing, ch, qc.completing, "")
 		PushMetric(qm.completed, ch, qc.completed, "")
@@ -333,6 +334,7 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 			PushMetric(value, ch, qc.coresPending, reason)
 		}
 		PushMetric(qm.cRunning, ch, qc.coresRunning, "")
+		PushMetric(qm.cSuspended, ch, qc.coresSuspended, "")
 		PushMetric(qm.cCancelled, ch, qc.coresCancelled, "")
 		PushMetric(qm.cCompleting, ch, qc.coresCompleting, "")
 		PushMetric(qm.cCompleted, ch, qc.coresCompleted, "")
@@ -345,6 +347,7 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 		// user label disabled: aggregate all users per partition
 		pushAggregatedNNVal(qm.pending, ch, qc.pending)
 		pushAggregatedNVal(qm.running, ch, qc.running, "")
+		pushAggregatedNVal(qm.suspended, ch, qc.suspended, "")
 		pushAggregatedNVal(qm.cancelled, ch, qc.cancelled, "")
 		pushAggregatedNVal(qm.completing, ch, qc.completing, "")
 		pushAggregatedNVal(qm.completed, ch, qc.completed, "")
@@ -355,6 +358,7 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 		pushAggregatedNVal(qm.nodeFail, ch, qc.nodeFail, "")
 		pushAggregatedNNVal(qm.cPending, ch, qc.coresPending)
 		pushAggregatedNVal(qm.cRunning, ch, qc.coresRunning, "")
+		pushAggregatedNVal(qm.cSuspended, ch, qc.coresSuspended, "")
 		pushAggregatedNVal(qm.cCancelled, ch, qc.coresCancelled, "")
 		pushAggregatedNVal(qm.cCompleting, ch, qc.coresCompleting, "")
 		pushAggregatedNVal(qm.cCompleted, ch, qc.coresCompleted, "")

--- a/internal/collector/queue_collector_test.go
+++ b/internal/collector/queue_collector_test.go
@@ -52,6 +52,49 @@ func TestQueueCollector_Describe(t *testing.T) {
 	assert.GreaterOrEqual(t, count, 20)
 }
 
+// TestQueueCollector_EmitsSuspendedMetrics is a non-regression test for the
+// silent data loss fixed by PR #13 / issue #12: `slurm_queue_suspended` and
+// `slurm_cores_suspended` were declared and counted but never pushed to
+// Prometheus in Collect(). The fixture contains at least one SUSPENDED job.
+func TestQueueCollector_EmitsSuspendedMetrics(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/squeue.txt")
+	require.NoError(t, err)
+
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return data, nil
+	}
+
+	for _, withUserLabel := range []bool{true, false} {
+		t.Run(fmtBool("withUserLabel", withUserLabel), func(t *testing.T) {
+			log := logger.NewLogger("error")
+			c := NewQueueCollector(log, withUserLabel)
+			reg := prometheus.NewRegistry()
+			require.NoError(t, reg.Register(c))
+
+			mfs, err := reg.Gather()
+			require.NoError(t, err)
+
+			names := make(map[string]bool)
+			for _, mf := range mfs {
+				names[mf.GetName()] = true
+			}
+			assert.True(t, names["slurm_queue_suspended"],
+				"slurm_queue_suspended must be emitted when SUSPENDED jobs are present")
+			assert.True(t, names["slurm_cores_suspended"],
+				"slurm_cores_suspended must be emitted when SUSPENDED jobs are present")
+		})
+	}
+}
+
+func fmtBool(label string, v bool) string {
+	if v {
+		return label + "=true"
+	}
+	return label + "=false"
+}
+
 func TestQueueCollector_ErrorEmitsGlobalTotals(t *testing.T) {
 	// Even on error, global job totals must be emitted (always-present guarantee)
 	oldExecute := Execute

--- a/internal/collector/queue_collector_test.go
+++ b/internal/collector/queue_collector_test.go
@@ -95,6 +95,26 @@ func fmtBool(label string, v bool) string {
 	return label + "=false"
 }
 
+// TestParseQueueMetrics_StripsPartitionAsterisk is the defensive companion
+// to issue #20 / PR #21: squeue -o "%P" emits "compute*" for the default
+// partition on some Slurm versions, and the queue collector previously
+// stored this raw value as the partition label. Now stripped, mirroring
+// what partitions.go and nodes.go do.
+func TestParseQueueMetrics_StripsPartitionAsterisk(t *testing.T) {
+	// One RUNNING job (12 cores) on the default partition "compute*"
+	input := []byte("compute*|RUNNING|12||alice\n")
+	qm := ParseQueueMetrics(input)
+
+	// Per-user state map for alice should be keyed by bare "compute"
+	require.Contains(t, qm.running, "alice")
+	require.Contains(t, qm.running["alice"], "compute",
+		"asterisk must be stripped from queue partition label")
+	assert.NotContains(t, qm.running["alice"], "compute*",
+		"raw asterisk-suffixed partition key must not appear")
+	assert.Equal(t, 1.0, qm.running["alice"]["compute"])
+	assert.Equal(t, 12.0, qm.cRunning["alice"]["compute"])
+}
+
 func TestQueueCollector_ErrorEmitsGlobalTotals(t *testing.T) {
 	// Even on error, global job totals must be emitted (always-present guarantee)
 	oldExecute := Execute

--- a/internal/collector/reservations.go
+++ b/internal/collector/reservations.go
@@ -162,6 +162,16 @@ func parseReservations(data []byte) ([]ReservationInfo, error) {
 				res.EndTime, _ = time.ParseInLocation(slurmTimeLayout, value, time.Local)
 			}
 		}
+
+		// Skip records that didn't yield a real reservation. scontrol prints
+		// "No reservations in the system" on an empty cluster; without this
+		// guard, the parser would emit a phantom ReservationInfo with an
+		// empty Name and time.Time{} timestamps (Unix = -62135596800 = year
+		// 0001), surfacing as fake "1968-01-12" reservations on dashboards.
+		// See https://github.com/SckyzO/slurm_exporter/issues/26.
+		if res.Name == "" {
+			continue
+		}
 		reservations = append(reservations, res)
 	}
 	return reservations, nil

--- a/internal/collector/reservations_test.go
+++ b/internal/collector/reservations_test.go
@@ -34,3 +34,18 @@ func TestParseReservations(t *testing.T) {
 	expectedEndTime, _ := time.ParseInLocation(slurmTimeLayout, "2025-08-29T20:00:00", time.Local)
 	assert.Equal(t, expectedEndTime, res1.EndTime)
 }
+
+// TestParseReservations_NoReservations is the non-regression test for issue #26.
+// Pre-fix, parseReservations on a "No reservations in the system" output would
+// still emit a single empty ReservationInfo with time.Time{} timestamps,
+// surfacing as a phantom 1968-01-12 reservation in dashboards. The fix skips
+// records that didn't yield a ReservationName.
+func TestParseReservations_NoReservations(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/sreservations_empty.txt")
+	require.NoError(t, err)
+
+	reservations, err := parseReservations(data)
+	require.NoError(t, err)
+	assert.Empty(t, reservations,
+		"empty scontrol output must produce zero reservations, not a phantom one")
+}

--- a/internal/collector/sacct_efficiency.go
+++ b/internal/collector/sacct_efficiency.go
@@ -187,6 +187,12 @@ type SacctEfficiencyCollector struct {
 	cpuHoursAllocated *prometheus.Desc
 	lastRefreshDesc   *prometheus.Desc
 
+	// done is closed when the background goroutine launched by Start() exits.
+	// Tests can wait on it after cancelling the context to ensure the
+	// goroutine is finished before tearing down package-level state (like the
+	// Execute mock). Unused in production.
+	done chan struct{}
+
 	logger *logger.Logger
 }
 
@@ -196,6 +202,7 @@ func NewSacctEfficiencyCollector(log *logger.Logger, interval, lookback time.Dur
 	c := &SacctEfficiencyCollector{
 		interval: interval,
 		lookback: lookback,
+		done:     make(chan struct{}),
 		cpuEfficiency: prometheus.NewDesc(
 			"slurm_job_cpu_efficiency_avg",
 			"Average CPU efficiency of completed jobs (TotalCPU/CPUTime*100) aggregated by account+user over the lookback window.",
@@ -223,8 +230,10 @@ func NewSacctEfficiencyCollector(log *logger.Logger, interval, lookback time.Dur
 }
 
 // Start launches the background refresh goroutine. Call once after construction.
+// The goroutine exits when ctx is cancelled; Done() can be used to wait for it.
 func (c *SacctEfficiencyCollector) Start(ctx context.Context) {
 	go func() {
+		defer close(c.done)
 		c.refresh()
 		ticker := time.NewTicker(c.interval)
 		defer ticker.Stop()
@@ -237,6 +246,13 @@ func (c *SacctEfficiencyCollector) Start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// Done returns a channel that is closed when the background refresh goroutine
+// started by Start() has fully exited. Useful in tests to synchronise teardown
+// (e.g. restoring a mocked package-level Execute) after cancelling the context.
+func (c *SacctEfficiencyCollector) Done() <-chan struct{} {
+	return c.done
 }
 
 func (c *SacctEfficiencyCollector) refresh() {

--- a/internal/collector/sacct_efficiency.go
+++ b/internal/collector/sacct_efficiency.go
@@ -124,6 +124,8 @@ func ParseSacctEfficiency(input []byte) []SacctJobRecord {
 // SacctEfficiencyAggregates holds aggregated efficiency stats per user+account.
 type SacctEfficiencyAggregates struct {
 	JobCount          float64
+	CPUJobCount       float64 // jobs where CPUTime > 0 (denominator for CPUEfficiencyPct)
+	MemJobCount       float64 // jobs where ReqMem > 0 (denominator for MemEfficiencyPct)
 	CPUEfficiencyPct  float64 // avg(TotalCPU / CPUTime * 100)
 	MemEfficiencyPct  float64 // avg(MaxRSS / ReqMem * 100), only for jobs with ReqMem>0
 	CPUHoursAllocated float64
@@ -149,18 +151,23 @@ func AggregateSacctEfficiency(records []SacctJobRecord) map[string]map[string]*S
 
 		if r.CPUTimeSeconds > 0 {
 			agg.CPUEfficiencyPct += r.TotalCPUSeconds / r.CPUTimeSeconds * 100
+			agg.CPUJobCount++
 		}
 		if r.ReqMemMB > 0 && r.MaxRSSMB >= 0 {
 			agg.MemEfficiencyPct += r.MaxRSSMB / r.ReqMemMB * 100
+			agg.MemJobCount++
 		}
 	}
 
-	// Convert sums to averages
+	// Convert sums to averages using per-metric job counts as denominators.
+	// This avoids understating averages when some jobs lack CPU-time or memory data.
 	for _, users := range result {
 		for _, agg := range users {
-			if agg.JobCount > 0 {
-				agg.CPUEfficiencyPct /= agg.JobCount
-				agg.MemEfficiencyPct /= agg.JobCount
+			if agg.CPUJobCount > 0 {
+				agg.CPUEfficiencyPct /= agg.CPUJobCount
+			}
+			if agg.MemJobCount > 0 {
+				agg.MemEfficiencyPct /= agg.MemJobCount
 			}
 		}
 	}

--- a/internal/collector/sacct_efficiency_test.go
+++ b/internal/collector/sacct_efficiency_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -163,21 +164,31 @@ func TestSacctEfficiencyCollector_EmptyBeforeFirstRefresh(t *testing.T) {
 }
 
 func TestSacctEfficiencyCollector_ErrorKeepsPreviousCache(t *testing.T) {
-	callCount := 0
+	// The collector starts a background refresh goroutine that calls the
+	// package-level Execute. atomic.Int64 keeps the counter race-free, and
+	// we wait on c.Done() before restoring Execute so the goroutine has
+	// fully exited (otherwise the defer below races with the goroutine's
+	// read of Execute).
+	var callCount atomic.Int64
+
+	log := logger.NewLogger("error")
+	c := NewSacctEfficiencyCollector(log, 1*time.Millisecond, 1*time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
 	oldExecute := Execute
-	defer func() { Execute = oldExecute }()
+	defer func() {
+		cancel()
+		<-c.Done() // ensure the refresh goroutine has fully exited
+		Execute = oldExecute
+	}()
+
 	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
-		callCount++
-		if callCount == 1 {
+		if callCount.Add(1) == 1 {
 			return []byte(`alice|hpc_team|4|01:00:00|03:00:00|04:00:00|1G|2G`), nil
 		}
 		return nil, assert.AnError // second call fails
 	}
 
-	log := logger.NewLogger("error")
-	c := NewSacctEfficiencyCollector(log, 1*time.Millisecond, 1*time.Hour)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	c.Start(ctx)
 
 	time.Sleep(50 * time.Millisecond) // let first refresh + failed second run

--- a/internal/collector/sacct_efficiency_test.go
+++ b/internal/collector/sacct_efficiency_test.go
@@ -114,6 +114,41 @@ func TestAggregateSacctEfficiency(t *testing.T) {
 	assert.InDelta(t, 75.0, alice.MemEfficiencyPct, 0.1)
 }
 
+// TestAggregateSacctEfficiency_PartialMemoryJobs is the non-regression test
+// for issue #14 / PR #15: averages must use per-metric job counts as their
+// denominator. Pre-fix, the memory average was divided by JobCount (total
+// jobs), diluting it by every job submitted without `--mem`.
+func TestAggregateSacctEfficiency_PartialMemoryJobs(t *testing.T) {
+	records := []SacctJobRecord{
+		// Job with memory tracked: 80% efficient (1600/2000)
+		{User: "alice", Account: "hpc", AllocCPUs: 4, ElapsedSeconds: 3600,
+			TotalCPUSeconds: 3600, CPUTimeSeconds: 4 * 3600,
+			MaxRSSMB: 1600, ReqMemMB: 2000},
+		// Job without memory request — must be EXCLUDED from the mem average
+		{User: "alice", Account: "hpc", AllocCPUs: 4, ElapsedSeconds: 3600,
+			TotalCPUSeconds: 1800, CPUTimeSeconds: 4 * 3600,
+			MaxRSSMB: 0, ReqMemMB: 0},
+	}
+
+	aggs := AggregateSacctEfficiency(records)
+	alice := aggs["hpc"]["alice"]
+
+	// 2 total jobs, but only 1 with memory data
+	assert.Equal(t, float64(2), alice.JobCount)
+	assert.Equal(t, float64(2), alice.CPUJobCount)
+	assert.Equal(t, float64(1), alice.MemJobCount)
+
+	// Mem avg = only job 1 → 1600/2000 * 100 = 80%
+	// (pre-fix value would be 40%, diluted by job 2)
+	assert.InDelta(t, 80.0, alice.MemEfficiencyPct, 0.1)
+
+	// CPU avg = both jobs:
+	//   job 1: 3600/14400 * 100 = 25%
+	//   job 2: 1800/14400 * 100 = 12.5%
+	//   avg = 18.75%
+	assert.InDelta(t, 18.75, alice.CPUEfficiencyPct, 0.1)
+}
+
 // ── SacctEfficiencyCollector ─────────────────────────────────────────────────
 
 func TestSacctEfficiencyCollector_Collect(t *testing.T) {

--- a/internal/collector/sacct_efficiency_test.go
+++ b/internal/collector/sacct_efficiency_test.go
@@ -198,6 +198,36 @@ func TestSacctEfficiencyCollector_EmptyBeforeFirstRefresh(t *testing.T) {
 	assert.Empty(t, mfs, "no metrics before first refresh")
 }
 
+// TestSacctEfficiencyCollector_DoneClosesOnCancel verifies the Done() channel
+// is closed when the context passed to Start() is cancelled. This is the
+// mechanism main.go relies on for graceful shutdown on SIGTERM/SIGINT
+// (issue #18).
+func TestSacctEfficiencyCollector_DoneClosesOnCancel(t *testing.T) {
+	log := logger.NewLogger("error")
+	c := NewSacctEfficiencyCollector(log, 1*time.Hour, 1*time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	oldExecute := Execute
+	defer func() {
+		cancel()
+		<-c.Done()
+		Execute = oldExecute
+	}()
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	c.Start(ctx)
+	cancel()
+
+	select {
+	case <-c.Done():
+		// success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Done() did not close within 1s after cancel — graceful shutdown broken")
+	}
+}
+
 func TestSacctEfficiencyCollector_ErrorKeepsPreviousCache(t *testing.T) {
 	// The collector starts a background refresh goroutine that calls the
 	// package-level Execute. atomic.Int64 keeps the counter race-free, and

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -268,11 +268,11 @@ func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) {
 		sc.logger.Error("Failed to get scheduler metrics", "err", err)
 		return
 	}
-	ch <- prometheus.MustNewConstMetric(sc.jobsSubmitted, prometheus.CounterValue, sm.jobsSubmitted)
-	ch <- prometheus.MustNewConstMetric(sc.jobsStarted, prometheus.CounterValue, sm.jobsStarted)
-	ch <- prometheus.MustNewConstMetric(sc.jobsCompleted, prometheus.CounterValue, sm.jobsCompleted)
-	ch <- prometheus.MustNewConstMetric(sc.jobsCanceled, prometheus.CounterValue, sm.jobsCanceled)
-	ch <- prometheus.MustNewConstMetric(sc.jobsFailed, prometheus.CounterValue, sm.jobsFailed)
+	ch <- prometheus.MustNewConstMetric(sc.jobsSubmitted, prometheus.GaugeValue, sm.jobsSubmitted)
+	ch <- prometheus.MustNewConstMetric(sc.jobsStarted, prometheus.GaugeValue, sm.jobsStarted)
+	ch <- prometheus.MustNewConstMetric(sc.jobsCompleted, prometheus.GaugeValue, sm.jobsCompleted)
+	ch <- prometheus.MustNewConstMetric(sc.jobsCanceled, prometheus.GaugeValue, sm.jobsCanceled)
+	ch <- prometheus.MustNewConstMetric(sc.jobsFailed, prometheus.GaugeValue, sm.jobsFailed)
 	ch <- prometheus.MustNewConstMetric(sc.threads, prometheus.GaugeValue, sm.threads)
 	ch <- prometheus.MustNewConstMetric(sc.queueSize, prometheus.GaugeValue, sm.queueSize)
 	ch <- prometheus.MustNewConstMetric(sc.dbdQueueSize, prometheus.GaugeValue, sm.dbdQueueSize)
@@ -311,24 +311,24 @@ func NewSchedulerCollector(logger *logger.Logger) *SchedulerCollector {
 	userRPCLabels := []string{"user"}
 	return &SchedulerCollector{
 		jobsSubmitted: prometheus.NewDesc(
-			"slurm_scheduler_jobs_submitted_total",
-			"Total jobs submitted to the scheduler since last stats reset (sdiag)",
+			"slurm_scheduler_jobs_submitted",
+			"Jobs submitted to the scheduler since last stats reset (sdiag). Value resets on slurmctld restart or scontrol reconfigure.",
 			nil, nil),
 		jobsStarted: prometheus.NewDesc(
-			"slurm_scheduler_jobs_started_total",
-			"Total jobs started (dispatched) since last stats reset (sdiag)",
+			"slurm_scheduler_jobs_started",
+			"Jobs started (dispatched) since last stats reset (sdiag). Value resets on slurmctld restart or scontrol reconfigure.",
 			nil, nil),
 		jobsCompleted: prometheus.NewDesc(
-			"slurm_scheduler_jobs_completed_total",
-			"Total jobs completed since last stats reset (sdiag)",
+			"slurm_scheduler_jobs_completed",
+			"Jobs completed since last stats reset (sdiag). Value resets on slurmctld restart or scontrol reconfigure.",
 			nil, nil),
 		jobsCanceled: prometheus.NewDesc(
-			"slurm_scheduler_jobs_canceled_total",
-			"Total jobs canceled since last stats reset (sdiag)",
+			"slurm_scheduler_jobs_canceled",
+			"Jobs canceled since last stats reset (sdiag). Value resets on slurmctld restart or scontrol reconfigure.",
 			nil, nil),
 		jobsFailed: prometheus.NewDesc(
-			"slurm_scheduler_jobs_failed_total",
-			"Total jobs failed since last stats reset (sdiag)",
+			"slurm_scheduler_jobs_failed",
+			"Jobs failed since last stats reset (sdiag). Value resets on slurmctld restart or scontrol reconfigure.",
 			nil, nil),
 		threads: prometheus.NewDesc(
 			"slurm_scheduler_threads",

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -23,7 +23,7 @@ var (
 	schedulerPatternTotalStart  = regexp.MustCompile(`^[\s]+Total backfilled jobs \(since last slurm start\)`)
 	schedulerPatternTotalCycle  = regexp.MustCompile(`^[\s]+Total backfilled jobs \(since last stats cycle start\)`)
 	schedulerPatternTotalHetero = regexp.MustCompile(`^[\s]+Total backfilled heterogeneous job components`)
-	schedulerRPCLineRe          = regexp.MustCompile(`^\s*([A-Za-z0-9_]*).*count:([0-9]*)\s*ave_time:([0-9]*)\s\s*total_time:([0-9]*)\s*$`)
+	schedulerRPCLineRe          = regexp.MustCompile(`^\s*([A-Za-z0-9_-]*).*count:([0-9]*)\s*ave_time:([0-9]*)\s\s*total_time:([0-9]*)\s*$`)
 
 	// Job counters (sdiag "Jobs submitted/started/completed/canceled/failed")
 	schedulerPatternJobsSubmitted = regexp.MustCompile(`^Jobs submitted`)

--- a/internal/collector/scheduler_collector_test.go
+++ b/internal/collector/scheduler_collector_test.go
@@ -37,8 +37,8 @@ func TestSchedulerCollector_Collect(t *testing.T) {
 	assert.True(t, names["slurm_scheduler_queue_size"])
 	assert.True(t, names["slurm_scheduler_last_cycle"])
 	assert.True(t, names["slurm_scheduler_backfill_last_cycle"])
-	assert.True(t, names["slurm_scheduler_jobs_submitted_total"])
-	assert.True(t, names["slurm_scheduler_jobs_completed_total"])
+	assert.True(t, names["slurm_scheduler_jobs_submitted"])
+	assert.True(t, names["slurm_scheduler_jobs_completed"])
 }
 
 func TestSchedulerCollector_Describe(t *testing.T) {

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -28,6 +28,47 @@ func TestSchedulerMetrics(t *testing.T) {
 	assert.Equal(t, 10.0, sm.totalBackfilledHeterogeneous)
 }
 
+// TestSchedulerRPCLineRe_HyphenatedUsername is the non-regression test for
+// PR #28: usernames with hyphens (e.g. "alice-21") were silently truncated
+// to "alice" by the character class [A-Za-z0-9_]*. With the fix the full
+// username is captured.
+func TestSchedulerRPCLineRe_HyphenatedUsername(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		wantUser  string
+		wantCount string
+	}{
+		{
+			name:      "plain username",
+			line:      "        alice  count:120  ave_time:42  total_time:5040 ",
+			wantUser:  "alice",
+			wantCount: "120",
+		},
+		{
+			name:      "hyphenated username",
+			line:      "        alice-21  count:120  ave_time:42  total_time:5040 ",
+			wantUser:  "alice-21",
+			wantCount: "120",
+		},
+		{
+			name:      "underscore + digits",
+			line:      "        bob_42  count:99  ave_time:7  total_time:693 ",
+			wantUser:  "bob_42",
+			wantCount: "99",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := schedulerRPCLineRe.FindAllStringSubmatch(tc.line, -1)
+			require.NotEmpty(t, matches, "regex must match: %q", tc.line)
+			require.GreaterOrEqual(t, len(matches[0]), 5, "regex must capture 4 groups + full match")
+			assert.Equal(t, tc.wantUser, matches[0][1])
+			assert.Equal(t, tc.wantCount, matches[0][2])
+		})
+	}
+}
+
 func TestParseSchedulerMetrics_JobCounters(t *testing.T) {
 	// Vérifie que les job counters sdiag sont bien parsés
 	data, err := os.ReadFile("../../test_data/sdiag.txt")

--- a/internal/collector/slurm_binary_info.go
+++ b/internal/collector/slurm_binary_info.go
@@ -18,7 +18,7 @@ type SlurmInfoCollector struct {
 func NewSlurmInfoCollector(logger *logger.Logger) *SlurmInfoCollector {
 	binaries := []string{
 		"sinfo", "squeue", "sdiag", "scontrol",
-		"sacct", "sbatch", "salloc", "srun",
+		"sacct",
 	}
 	labels := []string{"type", "binary", "version"}
 	return &SlurmInfoCollector{

--- a/internal/collector/slurm_binary_info.go
+++ b/internal/collector/slurm_binary_info.go
@@ -1,6 +1,9 @@
 package collector
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,21 +13,31 @@ import (
 
 // SlurmInfoCollector defines a Prometheus collector for Slurm binary and version information
 type SlurmInfoCollector struct {
-	slurmInfo *prometheus.Desc
-	binaries  []string
-	logger    *logger.Logger
+	slurmInfo        *prometheus.Desc
+	requiredBinaries []string
+	optionalBinaries []string
+	logger           *logger.Logger
 }
 
 func NewSlurmInfoCollector(logger *logger.Logger) *SlurmInfoCollector {
-	binaries := []string{
+	// requiredBinaries are always emitted; if missing they appear with
+	// version="not_found" and value=0 so operators can alert on their absence.
+	requiredBinaries := []string{
 		"sinfo", "squeue", "sdiag", "scontrol",
 		"sacct",
 	}
+	// optionalBinaries are emitted only if present on the host (silent if absent).
+	// These are job-submission tools that the exporter never invokes — surfacing
+	// their version is informational, never required.
+	optionalBinaries := []string{
+		"sbatch", "salloc", "srun",
+	}
 	labels := []string{"type", "binary", "version"}
 	return &SlurmInfoCollector{
-		slurmInfo: prometheus.NewDesc("slurm_info", "Information on Slurm version and binaries", labels, nil),
-		binaries:  binaries,
-		logger:    logger,
+		slurmInfo:        prometheus.NewDesc("slurm_info", "Information on Slurm version and binaries", labels, nil),
+		requiredBinaries: requiredBinaries,
+		optionalBinaries: optionalBinaries,
+		logger:           logger,
 	}
 }
 
@@ -41,7 +54,9 @@ func (c *SlurmInfoCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, versionValue, "general", "", version)
 
-	for _, binary := range c.binaries {
+	// Required binaries: always emit a series (value=0 with version="not_found"
+	// if the binary is missing, so absence is visible in alerts).
+	for _, binary := range c.requiredBinaries {
 		binVersion, binFound := GetBinaryVersion(c.logger, binary)
 		binValue := 0.0
 		if binFound {
@@ -49,6 +64,37 @@ func (c *SlurmInfoCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, binValue, "binary", binary, binVersion)
 	}
+
+	// Optional binaries: emit only if the binary is found on disk. No log,
+	// no metric, no error if absent. Lets monitoring-only deployments
+	// silently skip job-submission tools without polluting /metrics.
+	for _, binary := range c.optionalBinaries {
+		if !binaryAvailable(binary) {
+			continue
+		}
+		binVersion, binFound := GetBinaryVersion(c.logger, binary)
+		if !binFound {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, 1.0, "binary", binary, binVersion)
+	}
+}
+
+// binaryAvailable reports whether the given binary can be found on disk
+// without invoking it (so no log spam or process spawn).
+//
+// Resolution mirrors what Execute() does:
+//   - if --slurm.bin-path was set, look in that directory directly,
+//   - otherwise, search the system $PATH via exec.LookPath.
+//
+// Overridable in tests via binaryAvailableFunc.
+var binaryAvailable = func(binary string) bool {
+	if binPath != "" {
+		info, err := os.Stat(filepath.Join(binPath, binary))
+		return err == nil && !info.IsDir()
+	}
+	_, err := exec.LookPath(binary)
+	return err == nil
 }
 
 func GetBinaryVersion(logger *logger.Logger, binary string) (string, bool) {

--- a/internal/collector/slurm_binary_info_test.go
+++ b/internal/collector/slurm_binary_info_test.go
@@ -1,0 +1,104 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// TestSlurmInfoCollector_OptionalBinariesSilentlySkipped verifies that the
+// optional job-submission binaries (sbatch/salloc/srun) are not emitted as
+// slurm_info series when they are absent from the host — and that no error
+// is logged. This is the contract that lets monitoring-only containers run
+// without the three submission tools installed (issue #24).
+func TestSlurmInfoCollector_OptionalBinariesSilentlySkipped(t *testing.T) {
+	// Force every optional binary to report "absent".
+	oldAvail := binaryAvailable
+	defer func() { binaryAvailable = oldAvail }()
+	binaryAvailable = func(binary string) bool { return false }
+
+	// Stub Execute so required-binary version probes succeed with a known value
+	// (sinfo, squeue, etc.). The optional binaries must never reach this
+	// function — binaryAvailable() must short-circuit them.
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		for _, optional := range []string{"sbatch", "salloc", "srun"} {
+			if command == optional {
+				t.Fatalf("Execute() called for optional binary %q — binaryAvailable() should have skipped it", command)
+			}
+		}
+		return []byte("slurm 23.11.10"), nil
+	}
+
+	log := logger.NewLogger("error")
+	c := NewSlurmInfoCollector(log)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1, "expected one MetricFamily (slurm_info)")
+	mf := mfs[0]
+	assert.Equal(t, "slurm_info", mf.GetName())
+
+	// Collect (binary, present?) pairs from the emitted series.
+	emitted := make(map[string]bool)
+	for _, m := range mf.GetMetric() {
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "binary" && lp.GetValue() != "" {
+				emitted[lp.GetValue()] = true
+			}
+		}
+	}
+
+	// Required binaries must be emitted.
+	for _, req := range []string{"sinfo", "squeue", "sdiag", "scontrol", "sacct"} {
+		assert.True(t, emitted[req], "required binary %q must be emitted", req)
+	}
+	// Optional binaries must NOT appear when absent.
+	for _, opt := range []string{"sbatch", "salloc", "srun"} {
+		assert.False(t, emitted[opt], "optional binary %q must be skipped when absent", opt)
+	}
+}
+
+// TestSlurmInfoCollector_OptionalBinariesEmittedWhenAvailable verifies the
+// symmetrical case: when an optional binary IS available on the host, its
+// version is exposed alongside the required ones.
+func TestSlurmInfoCollector_OptionalBinariesEmittedWhenAvailable(t *testing.T) {
+	oldAvail := binaryAvailable
+	defer func() { binaryAvailable = oldAvail }()
+	binaryAvailable = func(binary string) bool { return true } // all present
+
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return []byte("slurm 23.11.10"), nil
+	}
+
+	log := logger.NewLogger("error")
+	c := NewSlurmInfoCollector(log)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+
+	emitted := make(map[string]bool)
+	for _, m := range mfs[0].GetMetric() {
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "binary" && lp.GetValue() != "" {
+				emitted[lp.GetValue()] = true
+			}
+		}
+	}
+
+	for _, opt := range []string{"sbatch", "salloc", "srun"} {
+		assert.True(t, emitted[opt], "optional binary %q must appear when available", opt)
+	}
+}

--- a/test_data/sinfo_gpus_total_long_gres.txt
+++ b/test_data/sinfo_gpus_total_long_gres.txt
@@ -1,0 +1,3 @@
+2 gpu:nvidia_a100_80gb:8,mig:nvidia_a100_3g.40gb:7,gpu:nvidia_h100_80gb:4
+1 gpu:tesla_v100-sxm3-32gb:16
+3 gpu:NVlink_A100_40GB:4

--- a/test_data/sinfo_long_names_fixed.txt
+++ b/test_data/sinfo_long_names_fixed.txt
@@ -1,0 +1,5 @@
+a048 163840 193000 16/0/0/16 mixed long
+a048 163840 193000 16/0/0/16 mixed short
+my-very-long-hostname-001 163840 193000 16/0/0/16 idle long
+my-very-long-hostname-001 163840 193000 16/0/0/16 idle short
+b003 296960 386000 29/3/0/32 down long

--- a/test_data/sinfo_partitions_gpu_long.txt
+++ b/test_data/sinfo_partitions_gpu_long.txt
@@ -1,0 +1,2 @@
+2 a_partition_with_a_very_long_name_above_thirty_chars gpu:nvidia_a100_80gb:8,mig:nvidia_a100_3g.40gb:7,gpu:nvidia_h100_80gb:4 gpu:nvidia_a100_80gb:3,gpu:nvidia_h100_80gb:2
+1 short_part gpu:tesla_v100-sxm3-32gb:16 gpu:tesla_v100-sxm3-32gb:0

--- a/test_data/sreservations_empty.txt
+++ b/test_data/sreservations_empty.txt
@@ -1,0 +1,1 @@
+No reservations in the system


### PR DESCRIPTION
## Summary

Patch release bundling the fix for issue #10 (long node names silently dropped from `slurm_node_*` metrics), seven community PRs from @UeliDeSchwert and @ncreddine, and a defensive sweep across collectors that share the same class of bugs. Plus a small group of hardening fixes discovered along the way.

## ⚠️ Breaking change

Five scheduler counters are renamed and re-typed (#22 / #23):

| Old (Counter) | New (Gauge) |
| --- | --- |
| `slurm_scheduler_jobs_submitted_total` | `slurm_scheduler_jobs_submitted` |
| `slurm_scheduler_jobs_started_total`   | `slurm_scheduler_jobs_started` |
| `slurm_scheduler_jobs_completed_total` | `slurm_scheduler_jobs_completed` |
| `slurm_scheduler_jobs_canceled_total`  | `slurm_scheduler_jobs_canceled` |
| `slurm_scheduler_jobs_failed_total`    | `slurm_scheduler_jobs_failed` |

Reason: these came from `sdiag`, which resets the counts on every `slurmctld` restart or `scontrol reconfigure`. A Counter that decreases violates the Prometheus data model and breaks `rate()` / `increase()` at the reset boundary. The metrics were introduced in v1.8.0 (~6 weeks ago), have shipped in two releases only, and are not used in any in-repo dashboard — disruption window is small.

Migration: update any external dashboards/recording rules/alerts to drop the `_total` suffix. Stop wrapping these in `rate()` — the cumulative value can decrease.

A new "Job Lifecycle (since slurmctld start)" row on `dashboards_grafana/05-slurm-scheduler.json` ships in this release using the renamed metrics.

## Bug fixes

### Silent metric loss (the main thread of this release)

- **`node` collector — long node names silently dropped (#10)**: restored the variable-width `sinfo -O` format that the 2022 commit `77080e0` introduced and that was inadvertently reverted when `slurm_node_status` was added. Plus an empty-parse Warn log so this failure mode never recurs silently.
- **`partitions` and `gpus` collectors — same class, defensive sweep**: every `sinfo --Format=...` site that used fixed widths is now variable-width. GRES strings on multi-type GPU / MIG nodes are no longer truncated.
- **`partitions` — `parseGpuCount` multi-type undercount**: the per-partition GPU counter only summed the first `gpu:*:N` match. Aligned with the cluster-wide `parseGPUCount` which has always iterated correctly.

### Integrated community PRs

| PR | Issue | Contributor | Subject |
|---|---|---|---|
| #13 | #12 | @UeliDeSchwert | emit `slurm_queue_suspended` and `slurm_cores_suspended` |
| #15 | #14 | @UeliDeSchwert | per-metric job counts for efficiency averages |
| #17 | #16 | @UeliDeSchwert | clamp negative `slurm_gpus_other` to zero + Debug log |
| #19 | #18 | @UeliDeSchwert | cancel sacct goroutine on SIGTERM/SIGINT + graceful wait |
| #21 | #20 | @UeliDeSchwert | strip default partition `*` suffix |
| #23 | #22 | @UeliDeSchwert | **BREAKING** scheduler counters → Gauge, drop `_total` |
| #25 | #24 | @UeliDeSchwert | drop sbatch/salloc/srun from required binaries (+ silent-optional follow-up) |
| #28 | — | @ncreddine | allow hyphens in RPC usernames + `gres:gpu` colon separator |

Each PR is integrated as one or more commits with `Co-authored-by:` crediting the original author.

### Other hardening

- **`reservations` collector — phantom row when no reservations defined (#26)**: empty `scontrol show reservation` output no longer produces a fake reservation with year-0001 timestamps.
- **`queue` collector — defensive partition `*` strip**: same fix as #21 applied here, since `squeue -o "%P"` can also emit `compute*` on some Slurm versions.
- **`sacct_efficiency` test race condition**: `callCount++` in the mock closure is now `atomic.Int64`, and the collector exposes `Done() <-chan struct{}` so tests can wait for the background goroutine before tearing down package-level state.
- **Makefile** gains `vet`, `lint`, `race`, and `check` targets aligned with what CI runs.

## Dashboard impact

No metric or label renames affect dashboard structure (apart from the `_total` drop above). However, clusters previously affected by silent truncation will see metric values **increase** as the missing series reappear:

- `slurm_node_*` for nodes with hostnames > 20 chars will start being exposed.
- `slurm_partition_*` for partitions with names > 30 chars now appear under their full name (truncated entries disappear).
- `slurm_gpus_*` and `slurm_partition_gpus_*` reflect true counts on rich-GRES nodes.
- `slurm_partition_gpus_*` rises to the real value on multi-type GPU nodes (parseGpuCount fix).
- `slurm_job_mem_efficiency_avg` rises on clusters where some jobs don't request memory (PR #15).
- `slurm_reservation_*` no longer emit a phantom 1968 entry on empty clusters.

The `or vector(0)` guards added to dashboards in v1.8.1 remain valid and require no rework.

## Test plan

- [x] `make vet` — no issues
- [x] `make lint` (golangci-lint, same config as CI) — 0 issues
- [x] `go test -count=1 ./...` — **158/158 passing**
- [x] `make race` — clean, no data races
- [x] `make build` — binary produced with ldflags
- [x] CHANGELOG entry for v1.8.2 with all sections (BREAKING, Bug Fixes, Improvements, Dashboard impact)

## Follow-ups (tracked separately for v1.9)

- Issue #27 (terminal job states over time) — plan to extend the optional `sacct_efficiency` collector
- PR #29 (per-node GRES metrics) — will adapt to the new variable-width format, add tests + flag + dashboard
- Optional refactor: pass `context.Context` as first parameter to collector constructors (removes the runtime-override pattern in `main.go`)
- Optional refactor: consolidate the three `sinfo` calls in `gpus.go` into one to eliminate the timing-race that the v1.8.2 clamp papers over
