### PR TITLE
fix(dashboards): render reservation start/end times as local datetime (#32)

### DIFF
--- a/monitoring/grafana/dashboards/06-slurm-reservations.json
+++ b/monitoring/grafana/dashboards/06-slurm-reservations.json
@@ -37,6 +37,12 @@
     },
     {
       "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "table",
       "name": "Table",
       "version": ""
@@ -280,7 +286,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "type": "timeseries",
+      "type": "stat",
       "id": 20,
       "title": "Reservation Start & End Times",
       "gridPos": {
@@ -290,36 +296,34 @@
         "y": 10
       },
       "options": {
-        "legend": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
           "calcs": [
-            "last",
-            "max"
+            "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "textMode": "auto",
+        "wideLayout": true
       },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "dateTimeAsLocal"
         },
@@ -331,7 +335,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "slurm_reservation_start_time_seconds",
+          "expr": "slurm_reservation_start_time_seconds * 1000",
           "legendFormat": "Start {{reservation_name}}",
           "refId": "A",
           "instant": true
@@ -341,7 +345,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "slurm_reservation_end_time_seconds",
+          "expr": "slurm_reservation_end_time_seconds * 1000",
           "legendFormat": "End {{reservation_name}}",
           "refId": "B",
           "instant": true


### PR DESCRIPTION
Closes #32.

## Summary

The "Reservation Start & End Times" panel on the `06 - Reservations` dashboard was previously a `timeseries` displaying `slurm_reservation_{start,end}_time_seconds` directly — which produced an unreadable line chart of large Unix timestamps. Per @MelJ711's report, this is not a useful visualization for reservation timelines.

This change replaces it with a `stat` panel using Grafana's `dateTimeAsLocal` unit so each reservation's start/end is shown as a readable local datetime.

## Changes

- `monitoring/grafana/dashboards/06-slurm-reservations.json`
  - Panel ID 20: `timeseries` → `stat`
  - `unit`: kept as `dateTimeAsLocal`
  - Queries multiply by `1000`: `dateTimeAsLocal` expects milliseconds, but `slurm_reservation_{start,end}_time_seconds` is in Unix seconds. Without `* 1000`, Grafana renders the value as a 1970-era date.
  - Replaced timeseries `options` (legend, tooltip, custom draw style) with `stat` options (`reduceOptions`, `colorMode: background`, `graphMode: area`).
  - Added `stat` to the dashboard's `__requires` block (only `timeseries`/`table`/`row`/`bargauge` were declared).

No exporter code is touched — the underlying metrics already expose the right values.

## Test plan

- [ ] Import the updated dashboard JSON into a Grafana instance with the slurm_exporter datasource
- [ ] Confirm panel renders as a stat panel showing local datetimes (not 1970 dates)
- [ ] Confirm Start and End values match `scontrol show reservation` output for at least one active reservation