### PR TITLE
chore(dashboards): clean up panel descriptions

### DIFF
--- a/monitoring/grafana/dashboards/03-slurm-nodes.json
+++ b/monitoring/grafana/dashboards/03-slurm-nodes.json
@@ -484,7 +484,7 @@
       "type": "barchart",
       "id": 11,
       "title": "Node States per Partition",
-      "description": "Distribution of node states per partition. Scalable — based on aggregate metrics.",
+      "description": "Distribution of node states per partition.",
       "gridPos": {
         "h": 8,
         "w": 14,
@@ -699,7 +699,7 @@
       "type": "table",
       "id": 12,
       "title": "Partition Summary",
-      "description": "Per-partition node state counts. Always scalable.",
+      "description": "Per-partition node state counts.",
       "gridPos": {
         "h": 8,
         "w": 10,
@@ -908,7 +908,7 @@
       "type": "table",
       "id": 13,
       "title": "Down & Drain Nodes",
-      "description": "Nodes in degraded state. Scalable to any cluster size — only shows problematic nodes. Empty table = healthy cluster.",
+      "description": "Nodes in degraded state. Empty table = healthy cluster.",
       "gridPos": {
         "h": 8,
         "w": 24,

--- a/monitoring/grafana/dashboards/04-slurm-usage.json
+++ b/monitoring/grafana/dashboards/04-slurm-usage.json
@@ -3145,7 +3145,7 @@
       "type": "timeseries",
       "id": 210,
       "title": "User FairShare Over Time",
-      "description": "FairShare factor per user (0=lowest priority, 1=highest). Requires --collector.fairshare.user-metrics=true (default).",
+      "description": "FairShare factor per user (0=lowest priority, 1=highest).",
       "gridPos": {
         "h": 8,
         "w": 12,

--- a/monitoring/grafana/dashboards/05-slurm-scheduler.json
+++ b/monitoring/grafana/dashboards/05-slurm-scheduler.json
@@ -1172,7 +1172,7 @@
       "type": "stat",
       "id": 50,
       "title": "Jobs Submitted",
-      "description": "Jobs submitted to the scheduler since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag. Resets to 0 on reconfigure.",
+      "description": "Jobs submitted since the last slurmctld restart or `scontrol reconfigure`. Resets to 0 on reconfigure.",
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 40 },
       "options": {
         "colorMode": "background",
@@ -1205,7 +1205,7 @@
       "type": "stat",
       "id": 51,
       "title": "Jobs Started",
-      "description": "Jobs started (dispatched) since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "description": "Jobs started (dispatched) since the last slurmctld restart or `scontrol reconfigure`.",
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 40 },
       "options": {
         "colorMode": "background",
@@ -1238,7 +1238,7 @@
       "type": "stat",
       "id": 52,
       "title": "Jobs Completed",
-      "description": "Jobs completed since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "description": "Jobs completed since the last slurmctld restart or `scontrol reconfigure`.",
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 40 },
       "options": {
         "colorMode": "background",
@@ -1271,7 +1271,7 @@
       "type": "stat",
       "id": 53,
       "title": "Jobs Canceled",
-      "description": "Jobs canceled since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "description": "Jobs canceled since the last slurmctld restart or `scontrol reconfigure`.",
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 40 },
       "options": {
         "colorMode": "background",
@@ -1304,7 +1304,7 @@
       "type": "stat",
       "id": 54,
       "title": "Jobs Failed",
-      "description": "Jobs failed since the last slurmctld restart or `scontrol reconfigure`. Source: sdiag.",
+      "description": "Jobs failed since the last slurmctld restart or `scontrol reconfigure`.",
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 40 },
       "options": {
         "colorMode": "background",

--- a/monitoring/grafana/dashboards/06-slurm-reservations.json
+++ b/monitoring/grafana/dashboards/06-slurm-reservations.json
@@ -854,7 +854,7 @@
           "refId": "D"
         }
       ],
-      "description": "License metrics (slurm_license_*) are only emitted when Slurm licenses are configured (scontrol show licenses). Empty = no licenses configured."
+      "description": "Empty = no licenses configured on the cluster."
     },
     {
       "datasource": {
@@ -933,7 +933,7 @@
           "instant": true
         }
       ],
-      "description": "License metrics (slurm_license_*) are only emitted when Slurm licenses are configured (scontrol show licenses). Empty = no licenses configured."
+      "description": "Empty = no licenses configured on the cluster."
     }
   ],
   "refresh": "30s",

--- a/monitoring/grafana/dashboards/09-slurm-exporter-perf.json
+++ b/monitoring/grafana/dashboards/09-slurm-exporter-perf.json
@@ -513,7 +513,7 @@
       "type": "bargauge",
       "id": 11,
       "title": "Call Count per Command (last 5 min)",
-      "description": "Number of Slurm CLI executions per command. sinfo should be ~1/scrape after Axe 2 optimisation.",
+      "description": "Number of Slurm CLI executions per command. `sinfo` should be ~1 per scrape thanks to caching.",
       "gridPos": {
         "h": 8,
         "w": 12,

--- a/monitoring/grafana/dashboards/10-slurm-all-metrics.json
+++ b/monitoring/grafana/dashboards/10-slurm-all-metrics.json
@@ -4567,7 +4567,7 @@
       "type": "timeseries",
       "id": 111,
       "title": "slurm_user_fairshare — FairShare factor per user",
-      "description": "Requires --collector.fairshare.user-metrics=true (default).",
+      "description": "FairShare factor per user (0=lowest priority, 1=highest). Emitted by default; toggle with `--collector.fairshare.user-metrics`.",
       "gridPos": {
         "h": 6,
         "w": 12,


### PR DESCRIPTION
## Summary

Panel descriptions on the bundled Grafana dashboards are user-facing tooltips, but a few were leaking implementation details, internal references, or CLI flag names — not actionable for the person reading the dashboard.

The most notable cleanup: **"Axe 2 optimisation"** in `09-slurm-exporter-perf` was a stale reference to an internal optimisation pass with no meaning to anyone outside the project. Replaced with the actual reason (caching).

No functional change. 6 dashboards, 13 descriptions touched.

## Changes

**Removed dev jargon** — "Scalable / Always scalable" was self-referential development justification, not user info:
- `03-slurm-nodes`: panels [11], [12], [13]

**Removed flag mentions** — when a flag is on by default, repeating it in a tooltip adds noise without value:
- `04-slurm-usage` [210] — dropped `--collector.fairshare.user-metrics=true (default)`

**Removed `Source: sdiag`** — implementation source is irrelevant to the operator reading the panel:
- `05-slurm-scheduler` [50], [51], [52], [53], [54]

**Removed internal metric names** — the title already conveys what the panel is about:
- `06-slurm-reservations` [50], [51] — dropped `slurm_license_*` and `scontrol show licenses`, kept the useful "Empty = no licenses configured" hint

**Removed stale internal reference**:
- `09-slurm-exporter-perf` [11] — "after Axe 2 optimisation" → "thanks to caching"

**Catalogue-style soft flag mention** — `10-slurm-all-metrics` is a metric reference dashboard, so the flag mention is kept but reframed as semantics-first, flag-second:
- `10-slurm-all-metrics` [111]: "Requires --collector.fairshare.user-metrics=true (default)." → "FairShare factor per user (0=lowest priority, 1=highest). Emitted by default; toggle with `--collector.fairshare.user-metrics`."

## Test plan

- [ ] Import each modified dashboard into a Grafana instance
- [ ] Hover each affected panel's title to confirm the new tooltip renders cleanly
- [ ] `python3 -m json.tool` on each file (already done locally — all 6 valid)