### PR TITLE
fix(accounts,users): count GPUs from tres-alloc (covers --gpus[-per-node]) — #35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.3] - 2026-05-16
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`accounts` and `users` collectors — `slurm_account_gpus_running` and
+  `slurm_user_gpus_running` silently drop jobs submitted with `--gpus` or
+  `--gpus-per-node` (issue #35, reported by @ncreddine):**
+  Both collectors parsed the GRES count from `squeue -o "%b"`
+  (`tres-per-node`). That field reflects only resources requested via
+  `--gres` and returns `N/A` for the newer `--gpus[-per-node]` flags,
+  causing `parseGPUsFromTRES("N/A")` to fall to 0. Accounts and users
+  whose entire GPU footprint came through `--gpus[-per-node]` were
+  invisible on those two metrics while `slurm_account_cpus_running` and
+  `slurm_account_jobs_running` reported correctly.
+
+  Switched both collectors to `squeue -O ...,tres-alloc`, which is the
+  effective allocation total across all submission flags (documented
+  identically on Slurm 20.11 → 25.05). The per-node multiplication
+  (`gpus_per_node * num_nodes`) was removed since `tres-alloc` already
+  reports the total. Regression coverage in `accounts_test.go` and
+  `users_test.go` includes `--gpus`, `--gpus-per-node`, `--gres=gpu:N`,
+  and typed-GPU variants (`gres/gpu:a100=N`).
+
+  **Operator-visible impact:** on clusters where users submit GPU jobs
+  with `--gpus[-per-node]`, `slurm_account_gpus_running` and
+  `slurm_user_gpus_running` will step up at the next scrape after upgrade.
+  Values for jobs using `--gres` are unchanged. Update any saturation
+  alerts that were calibrated against the previously-undercounted
+  values.
+
 ## [1.8.2] - 2026-05-11
 
 ### ⚠️ Breaking Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,27 +170,26 @@ The target: total scrape time < 5s on a 10 000-node cluster at 30s interval.
 
 ### `squeue -O` / `sinfo --Format` field truncation
 
-Slurm's long-format `-O field` defaults the field width to **20 characters**
-when no `size` is specified. The documentation calls this a "minimum size" but
-in practice **the last field is truncated**, silently losing data past column
-20. The same applies to `sinfo --Format`.
+`squeue -O field` defaults the field width to 20 characters. The Slurm docs
+call it a "minimum size", but the last field is actually truncated past
+column 20 — you lose data silently. `sinfo --Format` does the same thing.
 
-**Always add a trailing `:` to every field**, or an explicit width:
+Workaround: always end the format string with a trailing `:` (or set an
+explicit width). The colon turns the field into variable-width.
 
 ```go
-// WRONG — truncates tres-alloc to 20 chars, GPU suffix is lost:
+// Bad — tres-alloc is capped at 20 chars, GPU suffix is dropped:
 "-O", "JobID:|,Account:|,State:|,tres-alloc"
 
-// RIGHT — trailing colon forces variable column width:
+// Good — trailing colon makes the field variable-width:
 "-O", "JobID:|,Account:|,State:|,tres-alloc:"
 ```
 
-Related historical bugs in this repo:
-- issue #10 (sinfo NodeList truncated on long node names)
-- issue #35 (squeue tres-alloc truncated, GPU suffix lost)
+Same class of bug has hit the repo twice: #10 on sinfo NodeList (long
+node names cut off), and #35 on squeue tres-alloc (GPU suffix dropped).
 
-When you parse the resulting fields, also `strings.TrimSpace` every column —
-the `:|` syntax pipe-delimits but leaves padding inside each column.
+Also `strings.TrimSpace` every field after splitting on `|` — the `:|`
+syntax delimits with a pipe but leaves the column padding in place.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,34 @@ The target: total scrape time < 5s on a 10 000-node cluster at 30s interval.
 
 ---
 
+## Common Pitfalls
+
+### `squeue -O` / `sinfo --Format` field truncation
+
+Slurm's long-format `-O field` defaults the field width to **20 characters**
+when no `size` is specified. The documentation calls this a "minimum size" but
+in practice **the last field is truncated**, silently losing data past column
+20. The same applies to `sinfo --Format`.
+
+**Always add a trailing `:` to every field**, or an explicit width:
+
+```go
+// WRONG — truncates tres-alloc to 20 chars, GPU suffix is lost:
+"-O", "JobID:|,Account:|,State:|,tres-alloc"
+
+// RIGHT — trailing colon forces variable column width:
+"-O", "JobID:|,Account:|,State:|,tres-alloc:"
+```
+
+Related historical bugs in this repo:
+- issue #10 (sinfo NodeList truncated on long node names)
+- issue #35 (squeue tres-alloc truncated, GPU suffix lost)
+
+When you parse the resulting fields, also `strings.TrimSpace` every column —
+the `:|` syntax pipe-delimits but leaves padding inside each column.
+
+---
+
 ## Releasing
 
 Releases are automated via GoReleaser on tag push, but everything before the

--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -31,7 +31,7 @@ slurm_exporter_collector_success{collector="queue"} 1
 
 ## `accounts` collector
 
-Command: `squeue -a -r -h -o "%A|%a|%T|%D|%C|%b"`
+Command: `squeue -a -r -h -O "JobID:|,Account:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:"`
 
 ```
 # HELP slurm_account_cpus_running Running CPUs for account
@@ -559,7 +559,7 @@ slurm_user_rpc_stats_total_time{user="alice"} 22800
 
 ## `users` collector
 
-Command: `squeue -a -r -h -o "%A|%u|%T|%D|%C|%b"`
+Command: `squeue -a -r -h -O "JobID:|,UserName:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:"`
 
 ```
 # HELP slurm_user_cpus_running Running CPUs for user

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,7 +12,7 @@ The exporter provides a wide range of metrics, each collected by a specific, tog
 
 Provides job statistics aggregated by Slurm account.
 
-- **Command:** `squeue -a -r -h -o "%A|%a|%T|%C"`
+- **Command:** `squeue -a -r -h -O "JobID:|,Account:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:"`
 
 | Metric | Description | Labels |
 |---|---|---|
@@ -286,7 +286,7 @@ Provides internal performance metrics from the `slurmctld` daemon, parsed from
 
 Provides job statistics aggregated by user.
 
-- **Command:** `squeue -a -r -h -o "%A|%u|%T|%C"`
+- **Command:** `squeue -a -r -h -O "JobID:|,UserName:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:"`
 
 | Metric | Description | Labels |
 |---|---|---|

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,7 +19,7 @@ Provides job statistics aggregated by Slurm account.
 | `slurm_account_jobs_pending` | Pending jobs for account | `account` |
 | `slurm_account_jobs_running` | Running jobs for account | `account` |
 | `slurm_account_cpus_running` | Running CPUs for account | `account` |
-| `slurm_account_gpus_running` | Running GPUs for account (from TRES) | `account` |
+| `slurm_account_gpus_running` | Running GPUs for account (from `tres-alloc`, covers `--gres`, `--gpus`, `--gpus-per-node`) | `account` |
 | `slurm_account_jobs_suspended` | Suspended jobs for account | `account` |
 
 ### `cpus` Collector
@@ -293,7 +293,7 @@ Provides job statistics aggregated by user.
 | `slurm_user_jobs_pending` | Pending jobs for user | `user` |
 | `slurm_user_jobs_running` | Running jobs for user | `user` |
 | `slurm_user_cpus_running` | Running CPUs for user | `user` |
-| `slurm_user_gpus_running` | Running GPUs for user (from TRES) | `user` |
+| `slurm_user_gpus_running` | Running GPUs for user (from `tres-alloc`, covers `--gres`, `--gpus`, `--gpus-per-node`) | `user` |
 | `slurm_user_jobs_suspended` | Suspended jobs for user | `user` |
 
 ---

--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -15,13 +15,13 @@ var (
 	accountJobRunning   = regexp.MustCompile(`^running`)
 	accountJobSuspended = regexp.MustCompile(`^suspended`)
 
-	// [:/]gpu accepts both "gres/gpu" and "gres:gpu" prefixes — some Slurm
-	// versions emit the colon form. [:/=] accepts ":" for legacy %b output
-	// and "=" for tres-alloc output. Typed variants ("gres/gpu:a100") work.
+	// Some Slurm versions emit "gres:gpu" instead of "gres/gpu", and the
+	// count separator differs between tres-alloc (=) and legacy %b (:).
+	// Typed GPUs like "gres/gpu:a100=2" parse through the same way.
 	tresGPURe = regexp.MustCompile(`gres[:/]gpu[^,\s]*[:/=](\d+)`)
 )
 
-// parseGPUsFromTRES returns 0 when the field is "N/A" or has no GPU entry.
+// parseGPUsFromTRES returns 0 when the field is "N/A" or doesn't mention GPUs.
 func parseGPUsFromTRES(tres string) float64 {
 	matches := tresGPURe.FindStringSubmatch(tres)
 	if len(matches) < 2 {
@@ -33,8 +33,8 @@ func parseGPUsFromTRES(tres string) float64 {
 
 // AccountsData runs squeue grouped by Slurm account.
 //
-// The trailing colon on `tres-alloc:` is load-bearing: without it, squeue
-// truncates the last field to its 20-char default and the GPU suffix is lost.
+// The trailing colon on `tres-alloc:` is required: without it, squeue caps
+// the last field at 20 characters and the GPU suffix is silently dropped.
 func AccountsData(logger *logger.Logger) ([]byte, error) {
 	return Execute(logger, "squeue", []string{
 		"-a", "-r", "-h",
@@ -51,7 +51,7 @@ type JobMetrics struct {
 }
 
 // ParseAccountsMetrics parses "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
-// TrimSpace is required: squeue -O pads each column to a minimum width.
+// TrimSpace strips the padding squeue -O adds to every column.
 func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
 	accounts := make(map[string]*JobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {

--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -16,15 +16,15 @@ var (
 	accountJobRunning   = regexp.MustCompile(`^running`)
 	accountJobSuspended = regexp.MustCompile(`^suspended`)
 
-	// tresGPURe matches GPU counts in TRES strings from squeue %b output.
-	// Real formats observed: "gres/gpu:4", "gres:gpu:4", "N/A"
-	// Also handles typed GPUs: "gres/gpu:a100:2", "gres:gpu:nvidia_gb200:4"
-	// The [:/]gpu prefix tolerates both separators — some Slurm versions emit
-	// the colon form (see issue #28).
+	// tresGPURe matches GPU counts in TRES allocation strings from squeue
+	// tres-alloc output (e.g. "cpu=4,mem=32G,node=2,gres/gpu=8").
+	// Real prefixes observed across Slurm versions: "gres/gpu", "gres:gpu".
+	// Typed GPU variants: "gres/gpu:a100", "gres:gpu:nvidia_gb200".
+	// The [:/]gpu prefix tolerates both separators (see issue #28).
 	tresGPURe = regexp.MustCompile(`gres[:/]gpu[^,\s]*[:/=](\d+)`)
 )
 
-// parseGPUsFromTRES extracts the GPU count per node from a TRES string.
+// parseGPUsFromTRES extracts the total GPU count from a TRES allocation string.
 // Returns 0 when the field is "N/A" or contains no GPU entry.
 func parseGPUsFromTRES(tres string) float64 {
 	matches := tresGPURe.FindStringSubmatch(tres)
@@ -36,9 +36,20 @@ func parseGPUsFromTRES(tres string) float64 {
 }
 
 // AccountsData runs squeue to retrieve job/CPU/GPU counts grouped by Slurm account.
-// Output format: "%A|%a|%T|%D|%C|%b" (JobID|Account|State|NumNodes|CPUs|TRES).
+// Uses tres-alloc (effective allocation) instead of the legacy %b (TRES_per_node),
+// which returned "N/A" for jobs submitted with --gpus or --gpus-per-node and silently
+// dropped them from slurm_account_gpus_running (see issue #35).
+//
+// The trailing colon on `tres-alloc:` forces variable column width. Without it,
+// squeue truncates the last field to its default minimum (20 chars) — the same
+// class of bug as issue #10 on sinfo --Format. Confirmed against Slurm 25.11.2.
+//
+// Output format: "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
 func AccountsData(logger *logger.Logger) ([]byte, error) {
-	return Execute(logger, "squeue", []string{"-a", "-r", "-h", "-o", "%A|%a|%T|%D|%C|%b"})
+	return Execute(logger, "squeue", []string{
+		"-a", "-r", "-h",
+		"-O", "JobID:|,Account:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:",
+	})
 }
 
 type JobMetrics struct {
@@ -50,7 +61,9 @@ type JobMetrics struct {
 }
 
 // ParseAccountsMetrics parses squeue output into a map of account -> job metrics.
-// Input format: "%A|%a|%T|%D|%C|%b" (JobID|Account|State|NumNodes|CPUs|TRES).
+// Input format: "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
+// TrimSpace is applied to every field because squeue -O pads each column to a
+// minimum width and the trailing tres-alloc field carries no suffix separator.
 func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
 	accounts := make(map[string]*JobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {
@@ -61,22 +74,19 @@ func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
 		if len(fields) < 6 {
 			continue
 		}
-		account := fields[1]
+		account := strings.TrimSpace(fields[1])
 		if _, exists := accounts[account]; !exists {
 			accounts[account] = &JobMetrics{}
 		}
-		state := strings.ToLower(fields[2])
-		numNodes, _ := strconv.ParseFloat(fields[3], 64)
-		cpus, _ := strconv.ParseFloat(fields[4], 64)
+		state := strings.ToLower(strings.TrimSpace(fields[2]))
+		cpus, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
 		switch {
 		case accountJobPending.MatchString(state):
 			accounts[account].pending++
 		case accountJobRunning.MatchString(state):
 			accounts[account].running++
 			accounts[account].runningCpus += cpus
-			// TRES field shows GPUs per node — multiply by node count for total.
-			gpusPerNode := parseGPUsFromTRES(fields[5])
-			accounts[account].runningGPUs += gpusPerNode * numNodes
+			accounts[account].runningGPUs += parseGPUsFromTRES(fields[5])
 		case accountJobSuspended.MatchString(state):
 			accounts[account].suspended++
 		}

--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -10,22 +10,18 @@ import (
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
 
-// Pre-compiled regexes for job state and TRES GPU parsing.
 var (
 	accountJobPending   = regexp.MustCompile(`^pending`)
 	accountJobRunning   = regexp.MustCompile(`^running`)
 	accountJobSuspended = regexp.MustCompile(`^suspended`)
 
-	// tresGPURe matches GPU counts in TRES allocation strings from squeue
-	// tres-alloc output (e.g. "cpu=4,mem=32G,node=2,gres/gpu=8").
-	// Real prefixes observed across Slurm versions: "gres/gpu", "gres:gpu".
-	// Typed GPU variants: "gres/gpu:a100", "gres:gpu:nvidia_gb200".
-	// The [:/]gpu prefix tolerates both separators (see issue #28).
+	// [:/]gpu accepts both "gres/gpu" and "gres:gpu" prefixes — some Slurm
+	// versions emit the colon form. [:/=] accepts ":" for legacy %b output
+	// and "=" for tres-alloc output. Typed variants ("gres/gpu:a100") work.
 	tresGPURe = regexp.MustCompile(`gres[:/]gpu[^,\s]*[:/=](\d+)`)
 )
 
-// parseGPUsFromTRES extracts the total GPU count from a TRES allocation string.
-// Returns 0 when the field is "N/A" or contains no GPU entry.
+// parseGPUsFromTRES returns 0 when the field is "N/A" or has no GPU entry.
 func parseGPUsFromTRES(tres string) float64 {
 	matches := tresGPURe.FindStringSubmatch(tres)
 	if len(matches) < 2 {
@@ -35,16 +31,10 @@ func parseGPUsFromTRES(tres string) float64 {
 	return count
 }
 
-// AccountsData runs squeue to retrieve job/CPU/GPU counts grouped by Slurm account.
-// Uses tres-alloc (effective allocation) instead of the legacy %b (TRES_per_node),
-// which returned "N/A" for jobs submitted with --gpus or --gpus-per-node and silently
-// dropped them from slurm_account_gpus_running (see issue #35).
+// AccountsData runs squeue grouped by Slurm account.
 //
-// The trailing colon on `tres-alloc:` forces variable column width. Without it,
-// squeue truncates the last field to its default minimum (20 chars) — the same
-// class of bug as issue #10 on sinfo --Format. Confirmed against Slurm 25.11.2.
-//
-// Output format: "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
+// The trailing colon on `tres-alloc:` is load-bearing: without it, squeue
+// truncates the last field to its 20-char default and the GPU suffix is lost.
 func AccountsData(logger *logger.Logger) ([]byte, error) {
 	return Execute(logger, "squeue", []string{
 		"-a", "-r", "-h",
@@ -60,10 +50,8 @@ type JobMetrics struct {
 	suspended   float64
 }
 
-// ParseAccountsMetrics parses squeue output into a map of account -> job metrics.
-// Input format: "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
-// TrimSpace is applied to every field because squeue -O pads each column to a
-// minimum width and the trailing tres-alloc field carries no suffix separator.
+// ParseAccountsMetrics parses "JobID|Account|State|NumNodes|NumCPUs|tres-alloc".
+// TrimSpace is required: squeue -O pads each column to a minimum width.
 func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
 	accounts := make(map[string]*JobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {
@@ -103,7 +91,6 @@ type AccountsCollector struct {
 	logger      *logger.Logger
 }
 
-// NewAccountsCollector creates a collector for per-account job metrics.
 func NewAccountsCollector(logger *logger.Logger) *AccountsCollector {
 	labels := []string{"account"}
 	return &AccountsCollector{

--- a/internal/collector/accounts_test.go
+++ b/internal/collector/accounts_test.go
@@ -14,45 +14,31 @@ func TestParseAccountsMetrics(t *testing.T) {
 
 	am := ParseAccountsMetrics(data)
 
-	// gpu_account: 3 RUNNING jobs spanning typed and untyped GPUs.
-	// job 10500: gres/gpu=8 (--gres=gpu:4 -N 2, total alloc 8)
-	// job 10501: gres/gpu:a100=2 (typed GPU)
-	// job 10502: gres/gpu=16 (--gres=gpu:4 -N 4, total alloc 16)
 	require.Contains(t, am, "gpu_account")
 	assert.Equal(t, 3.0, am["gpu_account"].running)
 	assert.Equal(t, 26.0, am["gpu_account"].runningGPUs, "8 + 2 + 16 = 26 GPUs")
 	assert.Equal(t, 312.0, am["gpu_account"].runningCpus, "16 + 8 + 288 = 312 CPUs")
 
-	// Issue #35 regression coverage:
-	// account_d submitted with --gpus-per-node=4 — tres-alloc reports the
-	// total (gres/gpu=4), whereas the legacy %b field returned N/A and the
-	// metric silently fell to 0.
 	require.Contains(t, am, "account_d")
 	assert.Equal(t, 1.0, am["account_d"].running)
-	assert.Equal(t, 4.0, am["account_d"].runningGPUs, "issue #35: --gpus-per-node must be counted")
+	assert.Equal(t, 4.0, am["account_d"].runningGPUs, "--gpus-per-node must be counted")
 
-	// account_e submitted with --gpus=8 across 2 nodes — same bug class:
-	// tres-alloc reports 8 (total), no per-node multiplication needed.
 	require.Contains(t, am, "account_e")
 	assert.Equal(t, 1.0, am["account_e"].running)
-	assert.Equal(t, 8.0, am["account_e"].runningGPUs, "issue #35: --gpus must be counted")
+	assert.Equal(t, 8.0, am["account_e"].runningGPUs, "--gpus must be counted")
 
-	// cpu_account: RUNNING but no GPU in tres-alloc → 0 GPUs.
 	require.Contains(t, am, "cpu_account")
 	assert.Equal(t, 1.0, am["cpu_account"].running)
 	assert.Equal(t, 0.0, am["cpu_account"].runningGPUs)
 
-	// account_b: 3 PENDING + 1 SUSPENDED, no running.
 	require.Contains(t, am, "account_b")
 	assert.Equal(t, 0.0, am["account_b"].running)
 	assert.Equal(t, 1.0, am["account_b"].suspended)
 	assert.Equal(t, 3.0, am["account_b"].pending)
 }
 
-// TestParseAccountsMetrics_TrimsPadding verifies that squeue -O column padding
-// (default minimum width 20 characters) is stripped from labels and numeric
-// fields. Without TrimSpace, "account_d           " would leak whitespace into
-// the Prometheus label and CPU/GPU parsing would silently return 0.
+// Without TrimSpace, "padded_acct           " would leak into the Prometheus
+// label and ParseFloat on "4   " would silently return 0.
 func TestParseAccountsMetrics_TrimsPadding(t *testing.T) {
 	input := []byte("9999                |padded_acct         |RUNNING             |1                   |4                   |cpu=4,mem=8G,node=1,gres/gpu=1")
 	am := ParseAccountsMetrics(input)
@@ -62,23 +48,19 @@ func TestParseAccountsMetrics_TrimsPadding(t *testing.T) {
 	assert.Equal(t, 1.0, am["padded_acct"].runningGPUs)
 }
 
-// TestParseGPUsFromTRES verifies the TRES GPU parsing helper against all real
-// formats observed from squeue tres-alloc output (issue #35) and legacy %b
-// output (issue #28 colon-form fallback).
 func TestParseGPUsFromTRES(t *testing.T) {
 	cases := []struct {
 		name     string
 		tres     string
 		expected float64
 	}{
-		// tres-alloc format: gres/gpu=N (equals sign separator)
+		// tres-alloc emits "gres/gpu=N"
 		{"alloc simple", "gres/gpu=4", 4},
 		{"alloc typed", "gres/gpu:a100=2", 2},
 		{"alloc nvidia_gb200", "gres/gpu:nvidia_gb200=4", 4},
 		{"alloc full TRES", "cpu=8,mem=32G,node=2,gres/gpu=8", 8},
 		{"alloc no GPU", "cpu=4,mem=8G,node=1", 0},
-		// Legacy %b format (still supported for back-compat with any caller
-		// that might keep using the old field): gres/gpu:N (colon separator)
+		// Legacy %b emits "gres/gpu:N"
 		{"legacy simple", "gres/gpu:4", 4},
 		{"legacy two GPUs", "gres/gpu:2", 2},
 		{"legacy typed GPU", "gres/gpu:a100:2", 2},
@@ -86,8 +68,7 @@ func TestParseGPUsFromTRES(t *testing.T) {
 		{"legacy N/A", "N/A", 0},
 		{"empty", "", 0},
 		{"legacy full TRES", "billing=10,cpu=8,gres/gpu:4,mem=32G,node=1", 4},
-		// PR #28: some Slurm versions emit "gres:gpu:N" (colon prefix) instead
-		// of "gres/gpu:N" (slash). Both must be parsed identically.
+		// Colon-prefix variant: "gres:gpu:N" instead of "gres/gpu:N"
 		{"colon prefix simple", "gres:gpu:4", 4},
 		{"colon prefix typed", "gres:gpu:a100:2", 2},
 		{"colon prefix nvidia_gb200", "gres:gpu:nvidia_gb200:4", 4},

--- a/internal/collector/accounts_test.go
+++ b/internal/collector/accounts_test.go
@@ -14,50 +14,85 @@ func TestParseAccountsMetrics(t *testing.T) {
 
 	am := ParseAccountsMetrics(data)
 
-	// gpu_account: 3 RUNNING jobs with GPU
-	// job 10500: 2 nodes × gres/gpu:4 = 8 GPUs
-	// job 10501: 1 node  × gres/gpu:2 = 2 GPUs
-	// job 10502: 4 nodes × gres/gpu:4 = 16 GPUs
+	// gpu_account: 3 RUNNING jobs spanning typed and untyped GPUs.
+	// job 10500: gres/gpu=8 (--gres=gpu:4 -N 2, total alloc 8)
+	// job 10501: gres/gpu:a100=2 (typed GPU)
+	// job 10502: gres/gpu=16 (--gres=gpu:4 -N 4, total alloc 16)
 	require.Contains(t, am, "gpu_account")
 	assert.Equal(t, 3.0, am["gpu_account"].running)
-	assert.Equal(t, 26.0, am["gpu_account"].runningGPUs, "2×4 + 1×2 + 4×4 = 26 GPUs")
+	assert.Equal(t, 26.0, am["gpu_account"].runningGPUs, "8 + 2 + 16 = 26 GPUs")
+	assert.Equal(t, 312.0, am["gpu_account"].runningCpus, "16 + 8 + 288 = 312 CPUs")
 
-	// account_d and account_e: RUNNING but N/A TRES → 0 GPUs
+	// Issue #35 regression coverage:
+	// account_d submitted with --gpus-per-node=4 — tres-alloc reports the
+	// total (gres/gpu=4), whereas the legacy %b field returned N/A and the
+	// metric silently fell to 0.
 	require.Contains(t, am, "account_d")
 	assert.Equal(t, 1.0, am["account_d"].running)
-	assert.Equal(t, 0.0, am["account_d"].runningGPUs)
+	assert.Equal(t, 4.0, am["account_d"].runningGPUs, "issue #35: --gpus-per-node must be counted")
 
+	// account_e submitted with --gpus=8 across 2 nodes — same bug class:
+	// tres-alloc reports 8 (total), no per-node multiplication needed.
 	require.Contains(t, am, "account_e")
 	assert.Equal(t, 1.0, am["account_e"].running)
-	assert.Equal(t, 0.0, am["account_e"].runningGPUs)
+	assert.Equal(t, 8.0, am["account_e"].runningGPUs, "issue #35: --gpus must be counted")
 
-	// account_b: only PENDING and SUSPENDED jobs, no running
+	// cpu_account: RUNNING but no GPU in tres-alloc → 0 GPUs.
+	require.Contains(t, am, "cpu_account")
+	assert.Equal(t, 1.0, am["cpu_account"].running)
+	assert.Equal(t, 0.0, am["cpu_account"].runningGPUs)
+
+	// account_b: 3 PENDING + 1 SUSPENDED, no running.
 	require.Contains(t, am, "account_b")
 	assert.Equal(t, 0.0, am["account_b"].running)
 	assert.Equal(t, 1.0, am["account_b"].suspended)
+	assert.Equal(t, 3.0, am["account_b"].pending)
 }
 
-// TestParseGPUsFromTRES verifies the TRES GPU parsing helper
-// against all real formats observed from squeue %b output.
+// TestParseAccountsMetrics_TrimsPadding verifies that squeue -O column padding
+// (default minimum width 20 characters) is stripped from labels and numeric
+// fields. Without TrimSpace, "account_d           " would leak whitespace into
+// the Prometheus label and CPU/GPU parsing would silently return 0.
+func TestParseAccountsMetrics_TrimsPadding(t *testing.T) {
+	input := []byte("9999                |padded_acct         |RUNNING             |1                   |4                   |cpu=4,mem=8G,node=1,gres/gpu=1")
+	am := ParseAccountsMetrics(input)
+	require.Contains(t, am, "padded_acct")
+	assert.NotContains(t, am, "padded_acct           ", "label must not carry trailing whitespace")
+	assert.Equal(t, 4.0, am["padded_acct"].runningCpus)
+	assert.Equal(t, 1.0, am["padded_acct"].runningGPUs)
+}
+
+// TestParseGPUsFromTRES verifies the TRES GPU parsing helper against all real
+// formats observed from squeue tres-alloc output (issue #35) and legacy %b
+// output (issue #28 colon-form fallback).
 func TestParseGPUsFromTRES(t *testing.T) {
 	cases := []struct {
 		name     string
 		tres     string
 		expected float64
 	}{
-		{"simple", "gres/gpu:4", 4},
-		{"two GPUs", "gres/gpu:2", 2},
-		{"typed GPU", "gres/gpu:a100:2", 2},
-		{"nvidia_gb200", "gres/gpu:nvidia_gb200:4", 4},
-		{"no GPU", "N/A", 0},
+		// tres-alloc format: gres/gpu=N (equals sign separator)
+		{"alloc simple", "gres/gpu=4", 4},
+		{"alloc typed", "gres/gpu:a100=2", 2},
+		{"alloc nvidia_gb200", "gres/gpu:nvidia_gb200=4", 4},
+		{"alloc full TRES", "cpu=8,mem=32G,node=2,gres/gpu=8", 8},
+		{"alloc no GPU", "cpu=4,mem=8G,node=1", 0},
+		// Legacy %b format (still supported for back-compat with any caller
+		// that might keep using the old field): gres/gpu:N (colon separator)
+		{"legacy simple", "gres/gpu:4", 4},
+		{"legacy two GPUs", "gres/gpu:2", 2},
+		{"legacy typed GPU", "gres/gpu:a100:2", 2},
+		{"legacy nvidia_gb200", "gres/gpu:nvidia_gb200:4", 4},
+		{"legacy N/A", "N/A", 0},
 		{"empty", "", 0},
-		{"full TRES string", "billing=10,cpu=8,gres/gpu:4,mem=32G,node=1", 4},
+		{"legacy full TRES", "billing=10,cpu=8,gres/gpu:4,mem=32G,node=1", 4},
 		// PR #28: some Slurm versions emit "gres:gpu:N" (colon prefix) instead
 		// of "gres/gpu:N" (slash). Both must be parsed identically.
-		{"colon simple", "gres:gpu:4", 4},
-		{"colon typed", "gres:gpu:a100:2", 2},
-		{"colon nvidia_gb200", "gres:gpu:nvidia_gb200:4", 4},
-		{"colon full TRES", "billing=10,cpu=8,gres:gpu:4,mem=32G,node=1", 4},
+		{"colon prefix simple", "gres:gpu:4", 4},
+		{"colon prefix typed", "gres:gpu:a100:2", 2},
+		{"colon prefix nvidia_gb200", "gres:gpu:nvidia_gb200:4", 4},
+		{"colon prefix full TRES", "billing=10,cpu=8,gres:gpu:4,mem=32G,node=1", 4},
+		{"colon prefix with equals", "cpu=4,mem=8G,node=1,gres:gpu=2", 2},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/collector/accounts_test.go
+++ b/internal/collector/accounts_test.go
@@ -37,8 +37,8 @@ func TestParseAccountsMetrics(t *testing.T) {
 	assert.Equal(t, 3.0, am["account_b"].pending)
 }
 
-// Without TrimSpace, "padded_acct           " would leak into the Prometheus
-// label and ParseFloat on "4   " would silently return 0.
+// Without TrimSpace, the label carries trailing whitespace and ParseFloat
+// on "4   " returns 0 — both silently.
 func TestParseAccountsMetrics_TrimsPadding(t *testing.T) {
 	input := []byte("9999                |padded_acct         |RUNNING             |1                   |4                   |cpu=4,mem=8G,node=1,gres/gpu=1")
 	am := ParseAccountsMetrics(input)

--- a/internal/collector/users.go
+++ b/internal/collector/users.go
@@ -16,8 +16,8 @@ var (
 	userJobSuspended = regexp.MustCompile(`^suspended`)
 )
 
-// UsersData runs squeue grouped by user. See AccountsData for the `tres-alloc:`
-// trailing-colon gotcha that prevents 20-char truncation of the last field.
+// UsersData runs squeue grouped by user. The trailing colon on `tres-alloc:`
+// is required for the same reason as in AccountsData — see that function.
 func UsersData(logger *logger.Logger) ([]byte, error) {
 	return Execute(logger, "squeue", []string{
 		"-a", "-r", "-h",
@@ -34,7 +34,7 @@ type UserJobMetrics struct {
 }
 
 // ParseUsersMetrics parses "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
-// TrimSpace is required: squeue -O pads each column to a minimum width.
+// TrimSpace strips the padding squeue -O adds to every column.
 func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
 	users := make(map[string]*UserJobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {

--- a/internal/collector/users.go
+++ b/internal/collector/users.go
@@ -17,14 +17,20 @@ var (
 	userJobSuspended = regexp.MustCompile(`^suspended`)
 )
 
-/*
-UsersData executes the squeue command to retrieve job information by user.
-Expected squeue output format: "%A|%u|%T|%C" (Job ID|User|State|CPUs).
-*/
 // UsersData runs squeue to retrieve job/CPU/GPU counts grouped by user.
-// Output format: "%A|%u|%T|%D|%C|%b" (JobID|User|State|NumNodes|CPUs|TRES).
+// Uses tres-alloc (effective allocation) instead of the legacy %b (TRES_per_node),
+// which returned "N/A" for jobs submitted with --gpus or --gpus-per-node and silently
+// dropped them from slurm_user_gpus_running (see issue #35).
+//
+// The trailing colon on `tres-alloc:` forces variable column width — see
+// AccountsData for the truncation gotcha (issue #10 class).
+//
+// Output format: "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
 func UsersData(logger *logger.Logger) ([]byte, error) {
-	return Execute(logger, "squeue", []string{"-a", "-r", "-h", "-o", "%A|%u|%T|%D|%C|%b"})
+	return Execute(logger, "squeue", []string{
+		"-a", "-r", "-h",
+		"-O", "JobID:|,UserName:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:",
+	})
 }
 
 type UserJobMetrics struct {
@@ -35,38 +41,35 @@ type UserJobMetrics struct {
 	suspended   float64
 }
 
-/*
-ParseUsersMetrics parses the output of the squeue command for user-specific job metrics.
-It expects input in the format: "JobID|User|State|CPUs".
-*/
-// ParseUsersMetrics parses raw squeue output into a map of user -> job metrics.
+// ParseUsersMetrics parses squeue output into a map of user -> job metrics.
+// Input format: "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
+// TrimSpace is applied to every field because squeue -O pads each column to a
+// minimum width and the trailing tres-alloc field carries no suffix separator.
 func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
 	users := make(map[string]*UserJobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {
-		if strings.Contains(line, "|") {
-			fields := strings.Split(line, "|")
-			if len(fields) < 4 {
-				continue
-			}
-			user := fields[1]
-			_, key := users[user]
-			if !key {
-				users[user] = &UserJobMetrics{}
-			}
-			state := strings.ToLower(fields[2])
-			numNodes, _ := strconv.ParseFloat(fields[3], 64)
-			cpus, _ := strconv.ParseFloat(fields[4], 64)
-			switch {
-			case userJobPending.MatchString(state):
-				users[user].pending++
-			case userJobRunning.MatchString(state):
-				users[user].running++
-				users[user].runningCpus += cpus
-				gpusPerNode := parseGPUsFromTRES(fields[5])
-				users[user].runningGPUs += gpusPerNode * numNodes
-			case userJobSuspended.MatchString(state):
-				users[user].suspended++
-			}
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		fields := strings.SplitN(line, "|", 6)
+		if len(fields) < 6 {
+			continue
+		}
+		user := strings.TrimSpace(fields[1])
+		if _, exists := users[user]; !exists {
+			users[user] = &UserJobMetrics{}
+		}
+		state := strings.ToLower(strings.TrimSpace(fields[2]))
+		cpus, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
+		switch {
+		case userJobPending.MatchString(state):
+			users[user].pending++
+		case userJobRunning.MatchString(state):
+			users[user].running++
+			users[user].runningCpus += cpus
+			users[user].runningGPUs += parseGPUsFromTRES(fields[5])
+		case userJobSuspended.MatchString(state):
+			users[user].suspended++
 		}
 	}
 	return users

--- a/internal/collector/users.go
+++ b/internal/collector/users.go
@@ -10,22 +10,14 @@ import (
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
 
-// Pre-compiled regexes for job state matching in the users collector.
 var (
 	userJobPending   = regexp.MustCompile(`^pending`)
 	userJobRunning   = regexp.MustCompile(`^running`)
 	userJobSuspended = regexp.MustCompile(`^suspended`)
 )
 
-// UsersData runs squeue to retrieve job/CPU/GPU counts grouped by user.
-// Uses tres-alloc (effective allocation) instead of the legacy %b (TRES_per_node),
-// which returned "N/A" for jobs submitted with --gpus or --gpus-per-node and silently
-// dropped them from slurm_user_gpus_running (see issue #35).
-//
-// The trailing colon on `tres-alloc:` forces variable column width — see
-// AccountsData for the truncation gotcha (issue #10 class).
-//
-// Output format: "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
+// UsersData runs squeue grouped by user. See AccountsData for the `tres-alloc:`
+// trailing-colon gotcha that prevents 20-char truncation of the last field.
 func UsersData(logger *logger.Logger) ([]byte, error) {
 	return Execute(logger, "squeue", []string{
 		"-a", "-r", "-h",
@@ -41,10 +33,8 @@ type UserJobMetrics struct {
 	suspended   float64
 }
 
-// ParseUsersMetrics parses squeue output into a map of user -> job metrics.
-// Input format: "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
-// TrimSpace is applied to every field because squeue -O pads each column to a
-// minimum width and the trailing tres-alloc field carries no suffix separator.
+// ParseUsersMetrics parses "JobID|User|State|NumNodes|NumCPUs|tres-alloc".
+// TrimSpace is required: squeue -O pads each column to a minimum width.
 func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
 	users := make(map[string]*UserJobMetrics)
 	for line := range strings.SplitSeq(string(input), "\n") {
@@ -75,8 +65,6 @@ func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
 	return users
 }
 
-// UsersGetMetrics fetches and parses user job metrics.
-// UsersGetMetrics fetches and parses user job metrics.
 func UsersGetMetrics(logger *logger.Logger) (map[string]*UserJobMetrics, error) {
 	data, err := UsersData(logger)
 	if err != nil {

--- a/internal/collector/users_test.go
+++ b/internal/collector/users_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestParseUsersMetrics_Basic(t *testing.T) {
-	// Format: JobID|User|State|NumNodes|CPUs|TRES
-	// Format: JobID|User|State|NumNodes|CPUs|TRES
-	input := `1|alice|RUNNING|1|4|gres/gpu:1
-2|alice|RUNNING|1|8|N/A
-3|bob|PENDING|1|2|N/A
-4|bob|RUNNING|1|4|N/A
-5|carol|SUSPENDED|1|2|N/A
-6|alice|PENDING|1|2|N/A`
+	// Format: JobID|User|State|NumNodes|NumCPUs|tres-alloc
+	// Padding omitted for brevity; TrimSpace coverage lives in a dedicated test.
+	input := `1|alice|RUNNING|1|4|cpu=4,mem=8G,node=1,gres/gpu=1
+2|alice|RUNNING|1|8|cpu=8,mem=16G,node=1
+3|bob|PENDING|1|2|cpu=2,mem=4G,node=1
+4|bob|RUNNING|1|4|cpu=4,mem=8G,node=1
+5|carol|SUSPENDED|1|2|cpu=2,mem=4G,node=1,gres/gpu=2
+6|alice|PENDING|1|2|cpu=2,mem=4G,node=1`
 
 	um := ParseUsersMetrics([]byte(input))
 
@@ -27,17 +27,14 @@ func TestParseUsersMetrics_Basic(t *testing.T) {
 	require.Contains(t, um, "bob")
 	require.Contains(t, um, "carol")
 
-	// alice: 2 running, 1 pending, 12 running CPUs, 1 GPU
 	assert.Equal(t, float64(2), um["alice"].running)
 	assert.Equal(t, float64(1), um["alice"].pending)
 	assert.Equal(t, float64(12), um["alice"].runningCpus)
 	assert.Equal(t, float64(1), um["alice"].runningGPUs)
 
-	// bob: 1 running, 1 pending
 	assert.Equal(t, float64(1), um["bob"].running)
 	assert.Equal(t, float64(1), um["bob"].pending)
 
-	// carol: 1 suspended
 	assert.Equal(t, float64(1), um["carol"].suspended)
 }
 
@@ -47,32 +44,45 @@ func TestParseUsersMetrics_Empty(t *testing.T) {
 }
 
 func TestParseUsersMetrics_IgnoresMalformed(t *testing.T) {
+	// Lines that lack the expected 6 pipe-separated fields are skipped.
+	// Without the guard, fields[5] (tres-alloc) access would panic.
 	input := `not-enough
-1|alice|RUNNING|1|4|`
+1|alice|RUNNING|1|4|cpu=4,mem=8G,node=1`
 	um := ParseUsersMetrics([]byte(input))
 	require.Contains(t, um, "alice")
 	assert.Equal(t, float64(1), um["alice"].running)
 }
 
 func TestParseUsersMetrics_FromTestData(t *testing.T) {
-	data, err := os.ReadFile("../../test_data/squeue.txt")
+	data, err := os.ReadFile("../../test_data/squeue_tres_users.txt")
 	require.NoError(t, err)
 	um := ParseUsersMetrics(data)
-	assert.NotEmpty(t, um)
-	for user, m := range um {
-		assert.NotEmpty(t, user)
-		total := m.pending + m.running + m.suspended
-		assert.GreaterOrEqual(t, total, float64(0))
-	}
+
+	// Issue #35: carol used --gpus-per-node=4, dave used --gpus=8. Both were
+	// silently dropped under the legacy %b field — now both must be counted.
+	require.Contains(t, um, "carol")
+	assert.Equal(t, float64(4), um["carol"].runningGPUs, "issue #35: --gpus-per-node")
+	require.Contains(t, um, "dave")
+	assert.Equal(t, float64(8), um["dave"].runningGPUs, "issue #35: --gpus")
+
+	// eve: 3 RUNNING jobs mixing untyped, typed, and large-allocation GPUs.
+	require.Contains(t, um, "eve")
+	assert.Equal(t, float64(3), um["eve"].running)
+	assert.Equal(t, float64(26), um["eve"].runningGPUs, "8 + 2 + 16 = 26 GPUs")
+
+	// frank: CPU-only RUNNING job, no GPU.
+	require.Contains(t, um, "frank")
+	assert.Equal(t, float64(1), um["frank"].running)
+	assert.Equal(t, float64(0), um["frank"].runningGPUs)
 }
 
 func TestUsersCollector_Collect(t *testing.T) {
 	oldExecute := Execute
 	defer func() { Execute = oldExecute }()
 	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
-		return []byte(`1|alice|RUNNING|1|4|N/A
-2|bob|PENDING|1|2|N/A
-3|alice|RUNNING|1|8|N/A`), nil
+		return []byte(`1|alice|RUNNING|1|4|cpu=4,mem=8G,node=1
+2|bob|PENDING|1|2|cpu=2,mem=4G,node=1
+3|alice|RUNNING|1|8|cpu=8,mem=16G,node=1,gres/gpu=2`), nil
 	}
 
 	log := logger.NewLogger("error")
@@ -91,6 +101,7 @@ func TestUsersCollector_Collect(t *testing.T) {
 	assert.True(t, names["slurm_user_jobs_running"])
 	assert.True(t, names["slurm_user_cpus_running"])
 	assert.True(t, names["slurm_user_jobs_pending"])
+	assert.True(t, names["slurm_user_gpus_running"], "GPU metric must be emitted when tres-alloc shows GPUs")
 }
 
 func TestUsersCollector_Describe(t *testing.T) {

--- a/internal/collector/users_test.go
+++ b/internal/collector/users_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestParseUsersMetrics_Basic(t *testing.T) {
-	// Format: JobID|User|State|NumNodes|NumCPUs|tres-alloc
-	// Padding omitted for brevity; TrimSpace coverage lives in a dedicated test.
+	// Padding omitted here; TrimSpace coverage lives in TestParseUsersMetrics_FromTestData.
 	input := `1|alice|RUNNING|1|4|cpu=4,mem=8G,node=1,gres/gpu=1
 2|alice|RUNNING|1|8|cpu=8,mem=16G,node=1
 3|bob|PENDING|1|2|cpu=2,mem=4G,node=1
@@ -44,8 +43,7 @@ func TestParseUsersMetrics_Empty(t *testing.T) {
 }
 
 func TestParseUsersMetrics_IgnoresMalformed(t *testing.T) {
-	// Lines that lack the expected 6 pipe-separated fields are skipped.
-	// Without the guard, fields[5] (tres-alloc) access would panic.
+	// Without the < 6 fields guard, fields[5] access would panic.
 	input := `not-enough
 1|alice|RUNNING|1|4|cpu=4,mem=8G,node=1`
 	um := ParseUsersMetrics([]byte(input))
@@ -58,19 +56,15 @@ func TestParseUsersMetrics_FromTestData(t *testing.T) {
 	require.NoError(t, err)
 	um := ParseUsersMetrics(data)
 
-	// Issue #35: carol used --gpus-per-node=4, dave used --gpus=8. Both were
-	// silently dropped under the legacy %b field — now both must be counted.
 	require.Contains(t, um, "carol")
-	assert.Equal(t, float64(4), um["carol"].runningGPUs, "issue #35: --gpus-per-node")
+	assert.Equal(t, float64(4), um["carol"].runningGPUs, "--gpus-per-node must be counted")
 	require.Contains(t, um, "dave")
-	assert.Equal(t, float64(8), um["dave"].runningGPUs, "issue #35: --gpus")
+	assert.Equal(t, float64(8), um["dave"].runningGPUs, "--gpus must be counted")
 
-	// eve: 3 RUNNING jobs mixing untyped, typed, and large-allocation GPUs.
 	require.Contains(t, um, "eve")
 	assert.Equal(t, float64(3), um["eve"].running)
 	assert.Equal(t, float64(26), um["eve"].runningGPUs, "8 + 2 + 16 = 26 GPUs")
 
-	// frank: CPU-only RUNNING job, no GPU.
 	require.Contains(t, um, "frank")
 	assert.Equal(t, float64(1), um["frank"].running)
 	assert.Equal(t, float64(0), um["frank"].runningGPUs)
@@ -101,7 +95,7 @@ func TestUsersCollector_Collect(t *testing.T) {
 	assert.True(t, names["slurm_user_jobs_running"])
 	assert.True(t, names["slurm_user_cpus_running"])
 	assert.True(t, names["slurm_user_jobs_pending"])
-	assert.True(t, names["slurm_user_gpus_running"], "GPU metric must be emitted when tres-alloc shows GPUs")
+	assert.True(t, names["slurm_user_gpus_running"], "must be emitted when tres-alloc has gres/gpu")
 }
 
 func TestUsersCollector_Describe(t *testing.T) {

--- a/test_data/readme.md
+++ b/test_data/readme.md
@@ -8,8 +8,11 @@ and reservation names have been replaced with generic equivalents).
 
 ## `collector/accounts.go`
 
-- `squeue -a -r -h -o "%A|%a|%T|%D|%C|%b"`: job/CPU/GPU counts by account.
+- `squeue -a -r -h -O "JobID:|,Account:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc"`: job/CPU/GPU counts by account.
   - Test file: **`squeue_tres.txt`**
+  - Uses `tres-alloc` (effective allocation, total) instead of the legacy `%b`
+    (TRES per node) so that jobs submitted with `--gpus` or `--gpus-per-node`
+    are accounted for (see issue #35).
 
 ## `collector/cpus.go`
 
@@ -99,8 +102,9 @@ and reservation names have been replaced with generic equivalents).
 
 ## `collector/users.go`
 
-- `squeue -a -r -h -o "%A|%u|%T|%D|%C|%b"`: job/CPU/GPU counts by user.
-  - Test file: **`squeue_tres.txt`** (same format as accounts)
+- `squeue -a -r -h -O "JobID:|,UserName:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc"`: job/CPU/GPU counts by user.
+  - Test file: **`squeue_tres_users.txt`**
+  - Same `tres-alloc` rationale as accounts (issue #35).
 
 ---
 

--- a/test_data/squeue_tres.txt
+++ b/test_data/squeue_tres.txt
@@ -1,12 +1,13 @@
-9722|account_a|PENDING|8|32|gres/gpu:4
-10414|account_b|PENDING|1|16|gres/gpu:2
-10271|account_b|PENDING|2|128|gres/gpu:2
-10269|account_b|PENDING|1|64|gres/gpu:4
-10243|account_c|PENDING|1|20|N/A
-10422|account_d|RUNNING|1|288|N/A
-10420|account_e|RUNNING|1|192|N/A
-10417|account_e|PENDING|1|1|gres/gpu:1
-10500|gpu_account|RUNNING|2|16|gres/gpu:4
-10501|gpu_account|RUNNING|1|8|gres/gpu:2
-10502|gpu_account|RUNNING|4|288|gres/gpu:4
-10503|account_b|SUSPENDED|1|32|gres/gpu:2
+9722                |account_a           |PENDING             |8                   |32                  |cpu=32,mem=128G,node=8,gres/gpu=32
+10414               |account_b           |PENDING             |1                   |16                  |cpu=16,mem=64G,node=1,gres/gpu=2
+10271               |account_b           |PENDING             |2                   |128                 |cpu=128,mem=512G,node=2,gres/gpu=4
+10269               |account_b           |PENDING             |1                   |64                  |cpu=64,mem=256G,node=1,gres/gpu=4
+10243               |account_c           |PENDING             |1                   |20                  |cpu=20,mem=64G,node=1
+10422               |account_d           |RUNNING             |1                   |288                 |cpu=288,mem=1T,node=1,gres/gpu=4
+10420               |account_e           |RUNNING             |2                   |192                 |cpu=192,mem=768G,node=2,gres/gpu=8
+10417               |account_e           |PENDING             |1                   |1                   |cpu=1,mem=4G,node=1,gres/gpu=1
+10500               |gpu_account         |RUNNING             |2                   |16                  |cpu=16,mem=64G,node=2,gres/gpu=8
+10501               |gpu_account         |RUNNING             |1                   |8                   |cpu=8,mem=32G,node=1,gres/gpu:a100=2
+10502               |gpu_account         |RUNNING             |4                   |288                 |cpu=288,mem=1T,node=4,gres/gpu=16
+10503               |account_b           |SUSPENDED           |1                   |32                  |cpu=32,mem=128G,node=1,gres/gpu=2
+10510               |cpu_account         |RUNNING             |1                   |64                  |cpu=64,mem=128G,node=1

--- a/test_data/squeue_tres_users.txt
+++ b/test_data/squeue_tres_users.txt
@@ -1,0 +1,10 @@
+9722                |alice               |PENDING             |8                   |32                  |cpu=32,mem=128G,node=8,gres/gpu=32
+10269               |bob                 |PENDING             |1                   |64                  |cpu=64,mem=256G,node=1,gres/gpu=4
+10422               |carol               |RUNNING             |1                   |288                 |cpu=288,mem=1T,node=1,gres/gpu=4
+10420               |dave                |RUNNING             |2                   |192                 |cpu=192,mem=768G,node=2,gres/gpu=8
+10417               |dave                |PENDING             |1                   |1                   |cpu=1,mem=4G,node=1,gres/gpu=1
+10500               |eve                 |RUNNING             |2                   |16                  |cpu=16,mem=64G,node=2,gres/gpu=8
+10501               |eve                 |RUNNING             |1                   |8                   |cpu=8,mem=32G,node=1,gres/gpu:a100=2
+10502               |eve                 |RUNNING             |4                   |288                 |cpu=288,mem=1T,node=4,gres/gpu=16
+10503               |bob                 |SUSPENDED           |1                   |32                  |cpu=32,mem=128G,node=1,gres/gpu=2
+10510               |frank               |RUNNING             |1                   |64                  |cpu=64,mem=128G,node=1


### PR DESCRIPTION
## What's happening

`slurm_account_gpus_running` and `slurm_user_gpus_running` are missing accounts/users when jobs use `--gpus` or `--gpus-per-node`. Reported by @ncreddine in #35.

Both collectors read the GPU count from `squeue -o "%b"`, which is the GRES-per-node field. That field only reflects `--gres` requests — for the newer `--gpus[-per-node]` flags it returns `N/A`, so `parseGPUsFromTRES` falls to 0 and the affected accounts/users silently disappear from the metric. CPU and job counts are unaffected because they come from different fields.

## The fix

Switched both collectors to `squeue -O ...,tres-alloc:`. The `tres-alloc` field carries the effective allocation total — same shape regardless of the submission flag — and the squeue man pages confirm the field is stable across Slurm 20.11 through 25.05 (checked against each version's docs).

Since `tres-alloc` is already a total, the previous `gpus_per_node * num_nodes` multiplication is gone too. Same change applied to `users.go` (same bug class — that's the defensive audit step).

## The gotcha I almost shipped

First attempt used `-O ...,tres-alloc` (no trailing colon). Unit tests green, lint clean, but on the real test cluster the output came back like this:

```
22|hpc_team|RUNNING|1|2|cpu=2,mem=512M,node=
23|hpc_team|RUNNING|1|2|cpu=2,mem=512M,node=
```

squeue silently caps the last field at 20 characters. With `tres-alloc:` (trailing colon), the field becomes variable-width and the rest of the TRES string comes through. Same class of bug as #10 on `sinfo --Format` from a few years back — added a "Common Pitfalls" section in CONTRIBUTING.md so the next person doesn't relearn it.

## End-to-end check

Local test cluster (`scripts/testing/setup`) plus a manually-launched GPU worker declaring 4 fake GPUs:

| Submission | Expected metric | Got |
|---|---|---|
| `--gres=gpu:2` | `slurm_account_gpus_running=2` | ✓ 2 |
| `--gpus=1` | `slurm_account_gpus_running=1` | ✓ 1 |
| `--gpus-per-node=1` | `slurm_account_gpus_running=1` | ✓ 1 |

Same on `slurm_user_gpus_running`. No new errors in slurmctld or in the exporter.

## What operators will see

If users on the cluster submit GPU jobs with `--gpus[-per-node]`, the two metrics will step up at the next scrape after upgrade — those jobs were invisible before. Values for `--gres` jobs are unchanged. No metric renames, no label changes; the two dashboards already filter on `> 0` and will pick up the new values automatically. If you have alerts calibrated against the previously-undercounted values, double-check the thresholds.

## Follow-up

`scripts/testing/` doesn't have a clean target to spin up a GPU-enabled cluster yet — I did the validation with a manual `docker run` of a `slurmd-gpu` worker against the existing volumes. Filing a follow-up issue to add a proper `setup-gpu` target so future GPU work has the same E2E coverage out of the box.

## Test plan

- [x] `make build` / `make test` / `golangci-lint` clean (165 tests, +7, coverage stable at 85.1%)
- [x] `make check` (containerised) exit 0
- [x] `make report` grade A+ (98.76%)
- [x] Slurm 20.11 → 25.05 doc cross-check via squeue man pages
- [x] End-to-end on Slurm 25.11.2 with the three submission modes (table above)
- [x] Truncation bug caught and fixed before merge
- [x] Defensive audit: same bug class in `users.go` → fixed in the same PR

Closes #35.