### PR TITLE
refactor(partitions_test): drop CC from 18 to 6 via fixture picker

### DIFF
--- a/internal/collector/partitions_test.go
+++ b/internal/collector/partitions_test.go
@@ -13,6 +13,33 @@ import (
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
 
+// pickPartitionFixtureFilename maps a (command, args) pair from the partitions
+// collector to the fixture file that should be returned by the mock Execute.
+// Returns "" when the call shape is unexpected — callers turn that into an error.
+func pickPartitionFixtureFilename(command string, args []string) string {
+	switch command {
+	case "sinfo":
+		if len(args) >= 3 && args[1] == "-o" && args[2] == "%R,%C" {
+			return "sinfo_partitions_cpu.txt"
+		}
+		if len(args) >= 2 && strings.Contains(args[1], "--Format=") &&
+			strings.Contains(args[1], "Gres") && strings.Contains(args[1], "GresUsed") {
+			return "sinfo_partitions_gpu.txt"
+		}
+	case "squeue":
+		if len(args) < 6 {
+			return ""
+		}
+		if strings.Contains(args[5], "PENDING") {
+			return "squeue_partitions_pending_job.txt"
+		}
+		if strings.Contains(args[5], "RUNNING") {
+			return "squeue_partitions_running_job.txt"
+		}
+	}
+	return ""
+}
+
 func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 	oldExecute := Execute
 	defer func() { Execute = oldExecute }()
@@ -25,32 +52,10 @@ func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 		}
 		t.Run(slurmVersion, func(t *testing.T) {
 			Execute = func(logger *logger.Logger, command string, args []string) ([]byte, error) {
-				var filename string
-
-				switch command {
-				case "sinfo":
-					if len(args) >= 3 && args[1] == "-o" && args[2] == "%R,%C" {
-						filename = "sinfo_partitions_cpu.txt"
-					} else if len(args) >= 2 && strings.Contains(args[1], "--Format=") {
-						if strings.Contains(args[1], "Gres") && strings.Contains(args[1], "GresUsed") {
-							filename = "sinfo_partitions_gpu.txt"
-						}
-					}
-				case "squeue":
-					if len(args) >= 6 {
-						if strings.Contains(args[5], "PENDING") {
-							filename = "squeue_partitions_pending_job.txt"
-						}
-						if strings.Contains(args[5], "RUNNING") {
-							filename = "squeue_partitions_running_job.txt"
-						}
-					}
-				}
-
+				filename := pickPartitionFixtureFilename(command, args)
 				if filename == "" {
 					return nil, fmt.Errorf("unhandled command: %s %v", command, args)
 				}
-
 				path := filepath.Join(dir, filename)
 				data, err := os.ReadFile(path)
 				if err != nil {
@@ -70,7 +75,6 @@ func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 					pm.jobPending, pm.jobRunning)
 			}
 
-			// Verify known partitions exist and have plausible values
 			require.Contains(t, metrics, "cpu")
 			assert.Greater(t, metrics["cpu"].cpuTotal, 0.0)
 


### PR DESCRIPTION
Second step on #37 — getting gocyclo from 92.59% (master before this series) to 100%.

\`TestParsePartitionsMetricsWithRealOutput\` had a CC of 18, all of it concentrated in the mock \`Execute\` that picked which fixture file to load based on the (\`command\`, \`args\`) shape — a nested switch/if cascade.

Pulled that resolution into a top-level helper:

\`\`\`go
func pickPartitionFixtureFilename(command string, args []string) string
\`\`\`

The mock Execute is now four lines: pick the filename, error on "", read the file, return. The test logic stays identical.

CC before / after:

\`\`\`
TestParsePartitionsMetricsWithRealOutput  18 -> 6
pickPartitionFixtureFilename               -  -> 13   (new)
\`\`\`

\`make report\` moves from \`gocyclo 94.44% / overall 99.07%\` to \`gocyclo 96.29% / overall 99.38%\`. Two files left: \`nodes.go\` (two functions) and \`scheduler.go\`.

## Test plan

- [x] \`make build\`
- [x] \`make test\` (165 pass)
- [x] \`golangci-lint run\`
- [x] \`TestParsePartitionsMetricsWithRealOutput\` and the two GPU-related partition tests all pass

Refs #37.