### PR TITLE
feat(docker): runnable image and Docker docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1.7
+#
+# slurm_exporter — Prometheus exporter for the Slurm workload manager.
+#
+# Two stages:
+#   1. builder    Go 1.26-alpine, produces a static slurm_exporter binary.
+#   2. runtime    Ubuntu 24.04, ships the binary plus the Slurm CLI tools
+#                 (sinfo, squeue, sdiag, scontrol, sshare, sacct) that the
+#                 exporter shells out to.
+#
+# The runtime image needs three things from the host to talk to slurmctld:
+#   - /etc/slurm/slurm.conf            (slurmctld endpoint and cluster config)
+#   - /var/run/munge/munge.socket.2    (authentication daemon socket)
+#   - /etc/munge/munge.key             (cluster-wide MUNGE shared key)
+#
+# See docker/README.md for compose examples and the troubleshooting guide.
+
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /src
+
+# Cache module downloads in a separate layer.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG COMMIT=
+ARG BRANCH=
+ARG BUILD_USER=docker
+ARG BUILD_DATE=
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-s -w \
+        -X github.com/prometheus/common/version.Version=${VERSION} \
+        -X github.com/prometheus/common/version.Revision=${COMMIT} \
+        -X github.com/prometheus/common/version.Branch=${BRANCH} \
+        -X github.com/prometheus/common/version.BuildUser=${BUILD_USER} \
+        -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
+    -o /out/slurm_exporter ./cmd/slurm_exporter
+
+# ---
+
+FROM ubuntu:24.04
+
+# slurm-client provides sinfo/squeue/sdiag/scontrol/sshare/sacct.
+# Ubuntu 24.04 ships Slurm 23.11.x, compatible with slurmctld 22.x → 25.x in
+# practice. For clusters running an older or much newer slurmctld, rebuild
+# this stage from a base that matches your version (see docker/README.md).
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        slurm-client \
+        munge \
+        ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Dedicated unprivileged user, member of the munge group so the container
+# can write into the munge socket inherited from the host.
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin \
+        --uid 9341 --gid munge slurmexporter
+
+COPY --from=builder /out/slurm_exporter /usr/local/bin/slurm_exporter
+
+USER slurmexporter
+
+EXPOSE 9341
+
+LABEL org.opencontainers.image.source="https://github.com/SckyzO/slurm_exporter" \
+      org.opencontainers.image.description="Prometheus exporter for the Slurm workload manager" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.documentation="https://github.com/SckyzO/slurm_exporter/blob/master/docker/README.md"
+
+ENTRYPOINT ["/usr/local/bin/slurm_exporter"]
+CMD ["--web.listen-address=:9341"]

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -4,8 +4,12 @@
 #
 # Does not bundle slurm-client. Ships only:
 #   - the slurm_exporter binary
-#   - munged + libmunge (extracted from a Debian 12 builder stage)
+#   - libmunge.so.2 (extracted from a Debian 12 builder stage so the host's
+#     Slurm binaries find their munge dependency at runtime)
 #   - the distroless cc-debian12 runtime (glibc + libstdc++ + ld-linux)
+#
+# The munged daemon is NOT shipped — the compose mounts the host's munge
+# socket, so a second munged in the container would be dead weight.
 #
 # Final image weighs around 36 MB — three times smaller than the Ubuntu
 # build, and the smallest viable size for a binary that has to dlopen
@@ -57,22 +61,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 # ---
 
-# Extract munged + libmunge from a normal Debian stage. We only copy the
-# binary and the .so files into the distroless runtime, no apt machinery.
+# Extract libmunge from a normal Debian stage. We only copy the .so file
+# into the distroless runtime, no apt machinery, no daemon binary.
 FROM debian:12-slim AS munge-extractor
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        munge \
+        libmunge2 \
     && rm -rf /var/lib/apt/lists/*
 
 # ---
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 
-# Munge runtime — daemon binary and library. The user must mount
-# /etc/munge/munge.key and either /var/run/munge (host socket) or run
-# munged inside the container as part of an entrypoint script.
-COPY --from=munge-extractor /usr/sbin/munged /usr/sbin/munged
+# libmunge is needed by the host-mounted Slurm binaries (sinfo, squeue,
+# scontrol, …) which are dynamically linked against it. Shipping it here
+# spares operators from having to mount /usr/lib*/libmunge.so.2 manually,
+# which varies across host distributions (/usr/lib64 on RHEL, /usr/lib/
+# x86_64-linux-gnu on Debian).
 COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2 /usr/lib/x86_64-linux-gnu/libmunge.so.2
 COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0 /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0
 

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -2,19 +2,20 @@
 #
 # slurm_exporter — minimal variant.
 #
-# This image does NOT bundle slurm-client. It only ships:
+# Does not bundle slurm-client. Ships only:
 #   - the slurm_exporter binary
-#   - the munge runtime (daemon and libraries)
-#   - ca-certificates
+#   - munged + libmunge (extracted from a Debian 12 builder stage)
+#   - the distroless cc-debian12 runtime (glibc + libstdc++ + ld-linux)
 #
-# It is meant for clusters where Slurm is installed from source or via OHPC
-# with custom plugins / options that the distribution package can't match.
-# The operator mounts the cluster's Slurm install (binaries + libraries)
-# into the container and points the exporter at it with --slurm.bin-path.
+# Final image weighs around 36 MB — three times smaller than the Ubuntu
+# build, and the smallest viable size for a binary that has to dlopen
+# libmunge.so at runtime. Operators bring their own Slurm install
+# (binaries + libraries) and point the exporter at it with --slurm.bin-path.
 #
-# The runtime base is ubuntu:24.04 because glibc 2.39 is forward-compatible
-# with binaries built against RHEL 8 (2.28), RHEL 9 / Rocky 9 (2.34), and
-# Debian 12 (2.36) — which covers virtually every Slurm cluster in production.
+# Distroless gives us no shell, no package manager, and a fixed nonroot
+# user — the standard hardened runtime for Prometheus-ecosystem exporters.
+# Forward-compatible with binaries built against RHEL 8 / 9 / Rocky 9 /
+# Debian 12, which covers virtually every Slurm cluster in production.
 #
 # Quick example:
 #
@@ -28,8 +29,7 @@
 #     ghcr.io/sckyzo/slurm_exporter:latest-minimal \
 #     --slurm.bin-path=/opt/slurm/bin
 #
-# See docker/README.md for details and the standard (slurm-client-bundled)
-# variant.
+# See docker/README.md for the slurm-client-bundled (standard) variant.
 
 FROM golang:1.26-alpine AS builder
 
@@ -57,24 +57,26 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 # ---
 
-FROM ubuntu:24.04
-
-# munge gives us the daemon (in case the operator wants to run munged in the
-# container instead of mounting the host socket) and libmunge for any Slurm
-# binary that links against it. ca-certificates is useful for TLS scrape.
+# Extract munged + libmunge from a normal Debian stage. We only copy the
+# binary and the .so files into the distroless runtime, no apt machinery.
+FROM debian:12-slim AS munge-extractor
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         munge \
-        ca-certificates \
-    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --no-create-home --shell /usr/sbin/nologin \
-        --uid 9341 --gid munge slurmexporter
+# ---
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+
+# Munge runtime — daemon binary and library. The user must mount
+# /etc/munge/munge.key and either /var/run/munge (host socket) or run
+# munged inside the container as part of an entrypoint script.
+COPY --from=munge-extractor /usr/sbin/munged /usr/sbin/munged
+COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2 /usr/lib/x86_64-linux-gnu/libmunge.so.2
+COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0 /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0
 
 COPY --from=builder /out/slurm_exporter /usr/local/bin/slurm_exporter
-
-USER slurmexporter
 
 EXPOSE 9341
 
@@ -90,6 +92,9 @@ LABEL org.opencontainers.image.source="https://github.com/SckyzO/slurm_exporter"
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${COMMIT}" \
       org.opencontainers.image.created="${BUILD_DATE}"
+
+# distroless cc-debian12:nonroot already runs as uid 65532. No USER directive
+# needed; the image enforces it.
 
 ENTRYPOINT ["/usr/local/bin/slurm_exporter"]
 CMD ["--web.listen-address=:9341"]

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,25 +1,40 @@
 # syntax=docker/dockerfile:1.7
 #
-# slurm_exporter — Prometheus exporter for the Slurm workload manager.
+# slurm_exporter — minimal variant.
 #
-# Two stages:
-#   1. builder    Go 1.26-alpine, produces a static slurm_exporter binary.
-#   2. runtime    Ubuntu 24.04, ships the binary plus the Slurm CLI tools
-#                 (sinfo, squeue, sdiag, scontrol, sshare, sacct) that the
-#                 exporter shells out to.
+# This image does NOT bundle slurm-client. It only ships:
+#   - the slurm_exporter binary
+#   - the munge runtime (daemon and libraries)
+#   - ca-certificates
 #
-# The runtime image needs three things from the host to talk to slurmctld:
-#   - /etc/slurm/slurm.conf            (slurmctld endpoint and cluster config)
-#   - /var/run/munge/munge.socket.2    (authentication daemon socket)
-#   - /etc/munge/munge.key             (cluster-wide MUNGE shared key)
+# It is meant for clusters where Slurm is installed from source or via OHPC
+# with custom plugins / options that the distribution package can't match.
+# The operator mounts the cluster's Slurm install (binaries + libraries)
+# into the container and points the exporter at it with --slurm.bin-path.
 #
-# See docker/README.md for compose examples and the troubleshooting guide.
+# The runtime base is ubuntu:24.04 because glibc 2.39 is forward-compatible
+# with binaries built against RHEL 8 (2.28), RHEL 9 / Rocky 9 (2.34), and
+# Debian 12 (2.36) — which covers virtually every Slurm cluster in production.
+#
+# Quick example:
+#
+#   docker run -d --name slurm_exporter \
+#     -p 9341:9341 \
+#     -v /opt/slurm:/opt/slurm:ro \
+#     -v /etc/slurm:/etc/slurm:ro \
+#     -v /var/run/munge:/var/run/munge:ro \
+#     -v /etc/munge/munge.key:/etc/munge/munge.key:ro \
+#     -e LD_LIBRARY_PATH=/opt/slurm/lib \
+#     ghcr.io/sckyzo/slurm_exporter:latest-minimal \
+#     --slurm.bin-path=/opt/slurm/bin
+#
+# See docker/README.md for details and the standard (slurm-client-bundled)
+# variant.
 
 FROM golang:1.26-alpine AS builder
 
 WORKDIR /src
 
-# Cache module downloads in a separate layer.
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -44,20 +59,16 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 FROM ubuntu:24.04
 
-# slurm-client provides sinfo/squeue/sdiag/scontrol/sshare/sacct.
-# Ubuntu 24.04 ships Slurm 23.11.x, compatible with slurmctld 22.x → 25.x in
-# practice. For clusters running an older or much newer slurmctld, rebuild
-# this stage from a base that matches your version (see docker/README.md).
+# munge gives us the daemon (in case the operator wants to run munged in the
+# container instead of mounting the host socket) and libmunge for any Slurm
+# binary that links against it. ca-certificates is useful for TLS scrape.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        slurm-client \
         munge \
         ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Dedicated unprivileged user, member of the munge group so the container
-# can write into the munge socket inherited from the host.
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin \
         --uid 9341 --gid munge slurmexporter
 
@@ -67,15 +78,13 @@ USER slurmexporter
 
 EXPOSE 9341
 
-# OCI annotations — re-declared in this stage so the ARG values from the
-# builder stage flow into the runtime image's labels.
 ARG VERSION=dev
 ARG COMMIT=
 ARG BUILD_DATE=
 
 LABEL org.opencontainers.image.source="https://github.com/SckyzO/slurm_exporter" \
-      org.opencontainers.image.title="slurm_exporter" \
-      org.opencontainers.image.description="Prometheus exporter for the Slurm workload manager" \
+      org.opencontainers.image.title="slurm_exporter (minimal)" \
+      org.opencontainers.image.description="Prometheus exporter for the Slurm workload manager (minimal variant, bring your own slurm-client)" \
       org.opencontainers.image.licenses="GPL-3.0-only" \
       org.opencontainers.image.documentation="https://github.com/SckyzO/slurm_exporter/blob/master/docker/README.md" \
       org.opencontainers.image.version="${VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -126,25 +126,40 @@ report: tools-image
 run: $(GOBIN)
 	$(GOBIN)
 
-# ─── Docker image (local debug) ──────────────────────────────────────────────
-# The release image is built and published by GoReleaser on tag push; these
+# ─── Docker images (local debug) ─────────────────────────────────────────────
+# Two variants:
+#   - standard  (Dockerfile)         bundles slurm-client 23.11 from Ubuntu
+#   - minimal   (Dockerfile.minimal) ships only the exporter, mount your own
+# Release images are built and published by GoReleaser on tag push; these
 # targets only exist for local iteration.
 
-DOCKER_IMAGE ?= slurm_exporter
-DOCKER_TAG   ?= dev
-DOCKER_REF   := $(DOCKER_IMAGE):$(DOCKER_TAG)
+DOCKER_IMAGE         ?= slurm_exporter
+DOCKER_TAG           ?= dev
+DOCKER_REF           := $(DOCKER_IMAGE):$(DOCKER_TAG)
+DOCKER_REF_MINIMAL   := $(DOCKER_IMAGE):$(DOCKER_TAG)-minimal
+
+# Build args shared by both variants.
+DOCKER_BUILD_ARGS = \
+	--build-arg VERSION=$$(git describe --tags --dirty 2>/dev/null || echo dev) \
+	--build-arg COMMIT=$$(git rev-parse HEAD) \
+	--build-arg BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
+	--build-arg BUILD_USER="$$(git config user.email)" \
+	--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 .PHONY: docker-build
 docker-build:
 	@echo "Building $(DOCKER_REF)"
-	docker build \
-		--build-arg VERSION=$$(git describe --tags --dirty 2>/dev/null || echo dev) \
-		--build-arg COMMIT=$$(git rev-parse HEAD) \
-		--build-arg BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
-		--build-arg BUILD_USER="$$(git config user.email)" \
-		--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-		-t $(DOCKER_REF) .
+	docker build $(DOCKER_BUILD_ARGS) -t $(DOCKER_REF) .
 	@echo "✓ $(DOCKER_REF)"
+
+.PHONY: docker-build-minimal
+docker-build-minimal:
+	@echo "Building $(DOCKER_REF_MINIMAL)"
+	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.minimal -t $(DOCKER_REF_MINIMAL) .
+	@echo "✓ $(DOCKER_REF_MINIMAL)"
+
+.PHONY: docker-build-all
+docker-build-all: docker-build docker-build-minimal
 
 .PHONY: docker-run
 docker-run:
@@ -152,13 +167,20 @@ docker-run:
 	IMAGE=$(DOCKER_REF) docker compose -f docker/docker-compose.yml up -d
 	@echo "✓ Metrics at http://localhost:9341/metrics"
 
+.PHONY: docker-run-minimal
+docker-run-minimal:
+	@echo "Starting minimal compose stack (override IMAGE=$(DOCKER_REF_MINIMAL))"
+	IMAGE=$(DOCKER_REF_MINIMAL) docker compose -f docker/docker-compose.minimal.yml up -d
+	@echo "✓ Metrics at http://localhost:9341/metrics"
+
 .PHONY: docker-stop
 docker-stop:
-	docker compose -f docker/docker-compose.yml down
+	-docker compose -f docker/docker-compose.yml down
+	-docker compose -f docker/docker-compose.minimal.yml down
 
 .PHONY: docker-clean
 docker-clean:
-	-docker rmi $(DOCKER_REF) 2>/dev/null
+	-docker rmi $(DOCKER_REF) $(DOCKER_REF_MINIMAL) 2>/dev/null
 
 # Clean up the build artifacts
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,40 @@ report: tools-image
 run: $(GOBIN)
 	$(GOBIN)
 
+# ─── Docker image (local debug) ──────────────────────────────────────────────
+# The release image is built and published by GoReleaser on tag push; these
+# targets only exist for local iteration.
+
+DOCKER_IMAGE ?= slurm_exporter
+DOCKER_TAG   ?= dev
+DOCKER_REF   := $(DOCKER_IMAGE):$(DOCKER_TAG)
+
+.PHONY: docker-build
+docker-build:
+	@echo "Building $(DOCKER_REF)"
+	docker build \
+		--build-arg VERSION=$$(git describe --tags --dirty 2>/dev/null || echo dev) \
+		--build-arg COMMIT=$$(git rev-parse HEAD) \
+		--build-arg BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
+		--build-arg BUILD_USER="$$(git config user.email)" \
+		--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+		-t $(DOCKER_REF) .
+	@echo "✓ $(DOCKER_REF)"
+
+.PHONY: docker-run
+docker-run:
+	@echo "Starting compose stack (override IMAGE=$(DOCKER_REF))"
+	IMAGE=$(DOCKER_REF) docker compose -f docker/docker-compose.yml up -d
+	@echo "✓ Metrics at http://localhost:9341/metrics"
+
+.PHONY: docker-stop
+docker-stop:
+	docker compose -f docker/docker-compose.yml down
+
+.PHONY: docker-clean
+docker-clean:
+	-docker rmi $(DOCKER_REF) 2>/dev/null
+
 # Clean up the build artifacts
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ If you want to build the exporter yourself, you can do so using the provided Mak
 
 3. The new binary will be available at `bin/slurm_exporter`. You can then copy it to a location like `/usr/local/bin/` and set up the Systemd service as described in the section above.
 
+### 3. Docker / Compose
+
+A pre-built image is available at `ghcr.io/sckyzo/slurm_exporter`. The
+container needs three mounts from the host (slurm.conf, munge socket,
+munge key) — see [`docker/README.md`](docker/README.md) for the full
+setup, scenarios (on slurmctld host vs. remote monitoring node vs.
+Kubernetes), version compatibility notes, and troubleshooting.
+
+```bash
+docker run -d --name slurm_exporter \
+  -p 9341:9341 \
+  -v /etc/slurm:/etc/slurm:ro \
+  -v /var/run/munge:/var/run/munge:ro \
+  -v /etc/munge/munge.key:/etc/munge/munge.key:ro \
+  ghcr.io/sckyzo/slurm_exporter:latest
+```
+
 ---
 
 ## 📈 Dashboards & Alerts

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,19 @@ This page covers running `slurm_exporter` as a Docker container, including the
 constraints inherent to Slurm itself (MUNGE authentication, client/server
 version compatibility) that you don't have when running the binary directly.
 
-## TL;DR
+## Two image variants
+
+The project publishes two images. Pick the one that matches your cluster:
+
+| Variant | Tag | Bundled slurm-client | When to use it |
+|---|---|---|---|
+| **Standard** | `:vX.Y.Z` / `:latest` | Yes, Slurm 23.11.x (Ubuntu 24.04 repos) | Cluster running Slurm 22.x — 24.x packaged from your distro. Just works. |
+| **Minimal** | `:vX.Y.Z-minimal` / `:latest-minimal` | No | Cluster running a Slurm version outside the 22–24 window, OR Slurm built from source / OHPC with custom plugins. You mount the cluster's Slurm install into the container. |
+
+Both variants ship `munge` (daemon + library) and a non-root user (uid `9341`,
+group `munge`) so the container can use the host's MUNGE socket.
+
+## TL;DR — Standard variant
 
 ```bash
 docker run -d --name slurm_exporter \
@@ -16,6 +28,26 @@ docker run -d --name slurm_exporter \
 
 curl -s http://localhost:9341/metrics | head
 ```
+
+## TL;DR — Minimal variant (BYO Slurm install)
+
+```bash
+docker run -d --name slurm_exporter \
+  -p 9341:9341 \
+  -v /opt/slurm:/opt/slurm:ro \
+  -v /etc/slurm:/etc/slurm:ro \
+  -v /var/run/munge:/var/run/munge:ro \
+  -v /etc/munge/munge.key:/etc/munge/munge.key:ro \
+  -e LD_LIBRARY_PATH=/opt/slurm/lib \
+  ghcr.io/sckyzo/slurm_exporter:latest-minimal \
+  --slurm.bin-path=/opt/slurm/bin
+```
+
+Adjust `/opt/slurm` to wherever your cluster's Slurm prefix lives. The image
+runtime is Ubuntu 24.04 with glibc 2.39, which is forward-compatible with
+binaries built against RHEL 8 (glibc 2.28), RHEL 9 / Rocky 9 (glibc 2.34),
+and Debian 12 (glibc 2.36). If your build environment is more recent than
+that, you'll need to rebuild the runtime stage from a matching base.
 
 If that works, you're done. If it doesn't, read on.
 
@@ -62,7 +94,29 @@ docker compose -f docker/docker-compose.yml up -d
 docker compose -f docker/docker-compose.yml logs -f slurm_exporter
 ```
 
-To run against a locally-built image instead of the published one:
+### Path overrides (env vars)
+
+The compose paths default to a standard Linux Slurm install. If your
+distribution puts things elsewhere, override them at run time or in a
+`.env` file next to the compose:
+
+| Variable | Default | Override when… |
+|---|---|---|
+| `SLURM_CONF_DIR` | `/etc/slurm` | older Debian/Ubuntu use `/etc/slurm-llnl`, source-installed or OHPC clusters often use `/opt/slurm/etc` |
+| `MUNGE_RUN_DIR` | `/var/run/munge` | some systemd-based distros use `/run/munge` |
+| `MUNGE_KEY` | `/etc/munge/munge.key` | non-default install location or a key staged separately |
+| `IMAGE` | `ghcr.io/sckyzo/slurm_exporter:latest` | testing a locally-built tag |
+| `HOST_PORT` | `9341` | host port already taken by another exporter |
+
+Example for an older Debian cluster running munged via `/run/munge`:
+
+```bash
+SLURM_CONF_DIR=/etc/slurm-llnl \
+MUNGE_RUN_DIR=/run/munge \
+  docker compose -f docker/docker-compose.yml up -d
+```
+
+### Running a locally-built image
 
 ```bash
 make docker-build               # builds slurm_exporter:dev
@@ -131,6 +185,54 @@ Two viable patterns:
   More portable but more moving parts.
 
 A Helm chart is on the roadmap.
+
+## Image freshness & retention
+
+Container images go stale: a base image like `ubuntu:24.04` receives security
+patches continuously (glibc, openssl, etc.), and an image we build today
+freezes those packages at their current version. To stay safe, the project
+publishes refreshed images on the following cadence:
+
+| Event | What happens | Tag(s) updated |
+|---|---|---|
+| Release tag pushed (`vX.Y.Z`) | Full build + publish via GoReleaser | `:vX.Y.Z`, `:vX.Y`, `:vX`, `:latest` (and `-minimal` counterparts) |
+| Weekly cron (Monday, 04:00 UTC) | Rebuild of the two latest stable lines with the up-to-date base image | `:vX.Y.Z` re-pushed (new digest, same tag), plus a dated immutable tag `:vX.Y.Z-YYYYMMDD` |
+
+The dated `-YYYYMMDD` tags are **immutable** — once published, their digest
+never changes. Use them in GitOps when you need bit-for-bit determinism. The
+unsuffixed `:vX.Y.Z` tag is a **moving alias** to the latest build of that
+version: pull it when you want the freshest security patches applied to a
+specific exporter version.
+
+### Retention policy
+
+Tags accumulate over time. The project cleans them up monthly so the registry
+stays readable:
+
+| Tag class | Example | Retention |
+|---|---|---|
+| Semver release | `:v1.8.3`, `:v1.8.3-minimal` | Kept forever |
+| Floating aliases | `:latest`, `:latest-minimal`, `:v1.8`, `:v1` | Kept forever (always overwritten) |
+| Dated immutable | `:v1.8.3-20260516` | Last 10 per version kept; older ones pruned |
+
+That gives roughly two and a half months of rollback per version with weekly
+rebuilds — enough for forensic investigation, short of being a long-term
+archive. If you need to pin a build older than that, mirror the digest into
+your own registry.
+
+### Verifying what you're running
+
+Every published image carries OCI annotations that let you inspect what it
+contains and when it was built:
+
+```bash
+docker inspect ghcr.io/sckyzo/slurm_exporter:v1.8.3 \
+  --format '{{json .Config.Labels}}' | jq
+```
+
+Look for `org.opencontainers.image.created` (build timestamp),
+`org.opencontainers.image.revision` (git commit), and
+`org.opencontainers.image.version` (exporter version).
 
 ## Security posture
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -67,11 +67,17 @@ image, but they need three things from the cluster:
 |---|---|
 | `/etc/slurm/slurm.conf` | Tells the Slurm CLI where to find slurmctld and how the cluster is configured. |
 | `/var/run/munge/munge.socket.2` | Local socket of the MUNGE daemon that signs every Slurm RPC. The container talks to the host's munged through it. |
-| `/etc/munge/munge.key` | The cluster-wide MUNGE shared key. Required if you run `munged` inside the container instead (advanced). |
+| `/etc/munge/munge.key` | The cluster-wide MUNGE shared key. Read by the CLI tools when contacting munged. |
 
 If you skip any of these, the CLI tools fail with `slurm_load_partitions:
 Unable to contact slurm controller` (slurm.conf missing) or `Could not
 connect to munge socket` (munge socket missing).
+
+The image ships `libmunge.so.2` so the Slurm CLI tools (either bundled in
+the standard variant or host-mounted in the minimal variant) find their
+munge dependency at runtime. The `munged` daemon itself is **not** in the
+image — both variants are designed to use the host's munged through the
+mounted socket.
 
 ## Slurm version compatibility
 
@@ -187,8 +193,10 @@ Two viable patterns:
 - **DaemonSet on slurmctld host(s)**: mount the host paths via `hostPath`
   volumes, requires the slurmctld to run on a known set of nodes.
 - **Deployment with secret/configmap**: package slurm.conf as a `ConfigMap`
-  and `munge.key` as a `Secret`, run an `initContainer` to launch munged.
-  More portable but more moving parts.
+  and `munge.key` as a `Secret`, plus a `munged` sidecar container (separate
+  image, since our image doesn't ship the daemon) that exposes its socket
+  via an `emptyDir` volume shared with the exporter container. More portable
+  but more moving parts.
 
 A Helm chart is on the roadmap.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,170 @@
+# Running slurm_exporter in a container
+
+This page covers running `slurm_exporter` as a Docker container, including the
+constraints inherent to Slurm itself (MUNGE authentication, client/server
+version compatibility) that you don't have when running the binary directly.
+
+## TL;DR
+
+```bash
+docker run -d --name slurm_exporter \
+  -p 9341:9341 \
+  -v /etc/slurm:/etc/slurm:ro \
+  -v /var/run/munge:/var/run/munge:ro \
+  -v /etc/munge/munge.key:/etc/munge/munge.key:ro \
+  ghcr.io/sckyzo/slurm_exporter:latest
+
+curl -s http://localhost:9341/metrics | head
+```
+
+If that works, you're done. If it doesn't, read on.
+
+## What the container needs from the host
+
+The exporter shells out to the Slurm CLI tools (`sinfo`, `squeue`, `sdiag`,
+`scontrol`, `sshare`, `sacct`) to collect metrics. Those tools live inside the
+image, but they need three things from the cluster:
+
+| Mount | Why |
+|---|---|
+| `/etc/slurm/slurm.conf` | Tells the Slurm CLI where to find slurmctld and how the cluster is configured. |
+| `/var/run/munge/munge.socket.2` | Local socket of the MUNGE daemon that signs every Slurm RPC. The container talks to the host's munged through it. |
+| `/etc/munge/munge.key` | The cluster-wide MUNGE shared key. Required if you run `munged` inside the container instead (advanced). |
+
+If you skip any of these, the CLI tools fail with `slurm_load_partitions:
+Unable to contact slurm controller` (slurm.conf missing) or `Could not
+connect to munge socket` (munge socket missing).
+
+## Slurm version compatibility
+
+The image ships with **Slurm 23.11.x** (from Ubuntu 24.04). Slurm guarantees
+client/server compatibility within a window of two major versions, which in
+practice covers slurmctld 22.x through 25.x.
+
+If your slurmctld is on a version outside that window — for example, an older
+22.05 cluster or a very recent 25.11 deployment with new RPCs — rebuild the
+runtime stage from a base image that matches your Slurm version. The cleanest
+way is to clone the repo and edit the runtime `FROM` line, then `make
+docker-build`.
+
+For most production clusters running 23.x or 24.x, the published image works
+out of the box.
+
+## Compose
+
+The compose file under `docker/docker-compose.yml` is a self-contained
+example for the most common case: a node that already has a working
+slurm-client + munged setup (slurmctld host, a login node, a dedicated
+monitoring VM enrolled in the cluster).
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+docker compose -f docker/docker-compose.yml logs -f slurm_exporter
+```
+
+To run against a locally-built image instead of the published one:
+
+```bash
+make docker-build               # builds slurm_exporter:dev
+IMAGE=slurm_exporter:dev make docker-run
+```
+
+## Makefile targets
+
+| Target | What it does |
+|---|---|
+| `make docker-build` | Builds the image locally as `slurm_exporter:dev`. Embeds the current `git describe` as the version. |
+| `make docker-run` | Starts the compose stack (uses `IMAGE` env if set, otherwise pulls latest from GHCR). |
+| `make docker-stop` | `docker compose down`. |
+| `make docker-clean` | Removes the local `slurm_exporter:dev` image. |
+
+These targets are for local iteration. The release image is built and
+published automatically by GoReleaser on tag push — see the release process
+doc.
+
+## Deployment scenarios
+
+### Scenario A — on the slurmctld host itself
+
+Simplest case. The slurmctld machine already has slurm.conf, munged running,
+and the MUNGE key in place.
+
+```yaml
+services:
+  slurm_exporter:
+    image: ghcr.io/sckyzo/slurm_exporter:latest
+    network_mode: host          # exposes 9341 on the host
+    volumes:
+      - /etc/slurm:/etc/slurm:ro
+      - /var/run/munge:/var/run/munge:ro
+      - /etc/munge/munge.key:/etc/munge/munge.key:ro
+    restart: unless-stopped
+```
+
+### Scenario B — a remote monitoring node
+
+A node that isn't part of the cluster, but has the MUNGE key copied over and
+its own munged running locally.
+
+```yaml
+services:
+  slurm_exporter:
+    image: ghcr.io/sckyzo/slurm_exporter:latest
+    ports:
+      - "9341:9341"
+    volumes:
+      # slurm.conf must point at the cluster's slurmctld via a hostname that
+      # the container can resolve.
+      - ./slurm.conf:/etc/slurm/slurm.conf:ro
+      - /var/run/munge:/var/run/munge:ro
+      - /etc/munge/munge.key:/etc/munge/munge.key:ro
+```
+
+### Scenario C — Kubernetes
+
+Two viable patterns:
+
+- **DaemonSet on slurmctld host(s)**: mount the host paths via `hostPath`
+  volumes, requires the slurmctld to run on a known set of nodes.
+- **Deployment with secret/configmap**: package slurm.conf as a `ConfigMap`
+  and `munge.key` as a `Secret`, run an `initContainer` to launch munged.
+  More portable but more moving parts.
+
+A Helm chart is on the roadmap.
+
+## Security posture
+
+The published image:
+
+- runs as a dedicated non-root user (`slurmexporter`, uid `9341`, gid
+  `munge`)
+- uses `read_only: true` filesystem with `tmpfs:/tmp` in the example compose
+- drops all Linux capabilities, no `privileged`, no new privileges
+- ships only the Slurm CLI tools (no shell beyond what slurm-client pulls in)
+
+If you run from a less-trusted host, lock down the bind mounts to read-only
+and keep the `cap_drop` / `no-new-privileges` settings from the example
+compose.
+
+## Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: slurm
+    static_configs:
+      - targets: ["slurm_exporter:9341"]
+    scrape_interval: 30s
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Could not connect to munge socket` in exporter logs | The `/var/run/munge` mount is missing, or the host's munged isn't running. |
+| `slurm_load_partitions: Unable to contact slurm controller` | Either slurm.conf is missing/wrong, or the container can't reach slurmctld on port 6817. |
+| `error: Munge encode failed: Invalid credential` | The `munge.key` inside the container doesn't match the cluster's key. |
+| `Unable to register: Zero Bytes were transmitted or received` | Slurm version mismatch between the container's slurm-client and the cluster's slurmctld. |
+| Metrics endpoint returns 200 but most metrics are missing | The Slurm CLI tools work but slurmctld is rejecting some calls — check `--log.level=debug` for the actual error per collector. |
+
+For everything else, run with `--log.level=debug` and look for the
+`Failed to get <X> data` lines — they include the underlying Slurm error.

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,8 +13,14 @@ The project publishes two images. Pick the one that matches your cluster:
 | **Standard** | `:vX.Y.Z` / `:latest` | Yes, Slurm 23.11.x (Ubuntu 24.04 repos) | Cluster running Slurm 22.x — 24.x packaged from your distro. Just works. |
 | **Minimal** | `:vX.Y.Z-minimal` / `:latest-minimal` | No | Cluster running a Slurm version outside the 22–24 window, OR Slurm built from source / OHPC with custom plugins. You mount the cluster's Slurm install into the container. |
 
-Both variants ship `munge` (daemon + library) and a non-root user (uid `9341`,
-group `munge`) so the container can use the host's MUNGE socket.
+Both variants ship `munge` (daemon + library) and run as a non-root user:
+- **Standard** runs as `slurmexporter` (uid `9341`, gid `munge`).
+- **Minimal** runs as `nonroot` (uid `65532`, the standard distroless user).
+
+The host's `munge.socket.2` is typically created with mode `0777`, so any
+unprivileged uid in the container can use it. If your cluster runs munged
+with a stricter umask, mount the socket through with explicit perms or
+adjust the container user.
 
 ## TL;DR — Standard variant
 
@@ -236,17 +242,26 @@ Look for `org.opencontainers.image.created` (build timestamp),
 
 ## Security posture
 
-The published image:
+Both variants:
 
-- runs as a dedicated non-root user (`slurmexporter`, uid `9341`, gid
-  `munge`)
-- uses `read_only: true` filesystem with `tmpfs:/tmp` in the example compose
-- drops all Linux capabilities, no `privileged`, no new privileges
-- ships only the Slurm CLI tools (no shell beyond what slurm-client pulls in)
+- run as a dedicated non-root user (standard: `slurmexporter` uid `9341`;
+  minimal: `nonroot` uid `65532`)
+- expose a read-only filesystem with `tmpfs:/tmp` in the example compose
+- drop all Linux capabilities, no `privileged`, no new privileges
 
-If you run from a less-trusted host, lock down the bind mounts to read-only
-and keep the `cap_drop` / `no-new-privileges` settings from the example
-compose.
+The **minimal** variant runs on `gcr.io/distroless/cc-debian12:nonroot` — no
+shell, no package manager, no userland beyond what the dynamic loader and
+libstdc++ need. Smallest attack surface possible while still supporting
+dynamically-linked Slurm binaries mounted from the host.
+
+The **standard** variant runs on Ubuntu 24.04. The slurm-client install
+pulls in standard utilities (bash, coreutils, etc.) — necessary to make
+the bundled `sinfo` / `squeue` etc. usable, but a larger surface than
+distroless. Pick the minimal variant when threat-modeling matters more
+than the convenience of bundled binaries.
+
+Lock down bind mounts to read-only and keep the `cap_drop` /
+`no-new-privileges` settings from the example compose regardless of variant.
 
 ## Prometheus scrape config
 

--- a/docker/docker-compose.minimal.yml
+++ b/docker/docker-compose.minimal.yml
@@ -1,0 +1,50 @@
+# slurm_exporter — minimal variant compose.
+#
+# Use this when:
+#   - your cluster runs a Slurm version not packaged by Ubuntu 24.04 (older
+#     than 23.x or newer than 24.x), OR
+#   - Slurm is compiled with custom options (PMIx, custom plugins, OHPC) and
+#     you don't want generic distro binaries.
+#
+# The image ships only the exporter and munge runtime. You must mount your
+# cluster's Slurm install (binaries + libraries) and tell the exporter where
+# to look via --slurm.bin-path. Set LD_LIBRARY_PATH if libslurm.so isn't in
+# the standard loader search path.
+#
+# Environment overrides:
+#
+#   IMAGE              image to run                       default: ghcr.io/sckyzo/slurm_exporter:latest-minimal
+#   SLURM_PREFIX       host directory containing bin/ and lib/ of your Slurm  default: /opt/slurm
+#   SLURM_CONF_DIR     directory containing slurm.conf    default: /etc/slurm
+#   MUNGE_RUN_DIR      directory holding munge.socket.2   default: /var/run/munge
+#   MUNGE_KEY          path to the cluster's munge.key    default: /etc/munge/munge.key
+#   HOST_PORT          host-side port for /metrics        default: 9341
+
+services:
+  slurm_exporter:
+    image: ${IMAGE:-ghcr.io/sckyzo/slurm_exporter:latest-minimal}
+    container_name: slurm_exporter
+    restart: unless-stopped
+    ports:
+      - "${HOST_PORT:-9341}:9341"
+    volumes:
+      # The cluster's Slurm install. The container exposes the binaries via
+      # --slurm.bin-path and the libraries via LD_LIBRARY_PATH below.
+      - ${SLURM_PREFIX:-/opt/slurm}:/opt/slurm:ro
+      - ${SLURM_CONF_DIR:-/etc/slurm}:/etc/slurm:ro
+      - ${MUNGE_RUN_DIR:-/var/run/munge}:/var/run/munge:ro
+      - ${MUNGE_KEY:-/etc/munge/munge.key}:/etc/munge/munge.key:ro
+    environment:
+      # Tell the dynamic loader where the cluster's libslurm.so lives.
+      LD_LIBRARY_PATH: /opt/slurm/lib
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    command:
+      - --web.listen-address=:9341
+      - --slurm.bin-path=/opt/slurm/bin
+      - --log.level=info

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,32 +1,41 @@
 # slurm_exporter — example compose for a node that has MUNGE running and a
-# valid /etc/slurm/slurm.conf pointing at the cluster's slurmctld.
+# valid slurm.conf pointing at the cluster's slurmctld.
 #
 # Typical use cases:
 #   - run on the slurmctld host itself
 #   - run on any node already enrolled in the cluster (login node, monitoring
-#     host, etc.) — MUNGE daemon and slurm.conf must be reachable
+#     host, etc.) — the MUNGE daemon and slurm.conf must be reachable
+#
+# Paths to mount from the host are configurable via environment variables.
+# Defaults assume a standard Linux Slurm install. If your distribution uses
+# different paths (e.g. /etc/slurm-llnl on older Debian, /opt/slurm/etc on a
+# source-installed cluster, /run/munge on some systemd setups), set the env
+# vars before running or put them in a `.env` file next to this compose.
+#
+#   SLURM_CONF_DIR   directory containing slurm.conf      default: /etc/slurm
+#   MUNGE_RUN_DIR    directory holding munge.socket.2     default: /var/run/munge
+#   MUNGE_KEY        path to the cluster's munge.key      default: /etc/munge/munge.key
+#   IMAGE            slurm_exporter image to run          default: ghcr.io/sckyzo/slurm_exporter:latest
+#   HOST_PORT        host-side port for /metrics          default: 9341
 #
 # See docker/README.md for the remote-node and Kubernetes scenarios.
 
 services:
   slurm_exporter:
-    # Override the image with `IMAGE=…` to test a locally-built tag, e.g.
-    # `IMAGE=slurm_exporter:dev docker compose up -d`. Default is the latest
-    # published release on GHCR.
     image: ${IMAGE:-ghcr.io/sckyzo/slurm_exporter:latest}
     container_name: slurm_exporter
     restart: unless-stopped
     ports:
-      - "9341:9341"
+      - "${HOST_PORT:-9341}:9341"
     volumes:
       # Cluster configuration. The Slurm CLI tools inside the container read
       # slurm.conf to find slurmctld. Read-only is fine.
-      - /etc/slurm:/etc/slurm:ro
+      - ${SLURM_CONF_DIR:-/etc/slurm}:/etc/slurm:ro
       # MUNGE authentication. The socket is what slurm-client uses to sign
       # every RPC; the key is needed if you run munged inside the container
       # instead of mounting the host socket.
-      - /var/run/munge:/var/run/munge:ro
-      - /etc/munge/munge.key:/etc/munge/munge.key:ro
+      - ${MUNGE_RUN_DIR:-/var/run/munge}:/var/run/munge:ro
+      - ${MUNGE_KEY:-/etc/munge/munge.key}:/etc/munge/munge.key:ro
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,39 @@
+# slurm_exporter — example compose for a node that has MUNGE running and a
+# valid /etc/slurm/slurm.conf pointing at the cluster's slurmctld.
+#
+# Typical use cases:
+#   - run on the slurmctld host itself
+#   - run on any node already enrolled in the cluster (login node, monitoring
+#     host, etc.) — MUNGE daemon and slurm.conf must be reachable
+#
+# See docker/README.md for the remote-node and Kubernetes scenarios.
+
+services:
+  slurm_exporter:
+    # Override the image with `IMAGE=…` to test a locally-built tag, e.g.
+    # `IMAGE=slurm_exporter:dev docker compose up -d`. Default is the latest
+    # published release on GHCR.
+    image: ${IMAGE:-ghcr.io/sckyzo/slurm_exporter:latest}
+    container_name: slurm_exporter
+    restart: unless-stopped
+    ports:
+      - "9341:9341"
+    volumes:
+      # Cluster configuration. The Slurm CLI tools inside the container read
+      # slurm.conf to find slurmctld. Read-only is fine.
+      - /etc/slurm:/etc/slurm:ro
+      # MUNGE authentication. The socket is what slurm-client uses to sign
+      # every RPC; the key is needed if you run munged inside the container
+      # instead of mounting the host socket.
+      - /var/run/munge:/var/run/munge:ro
+      - /etc/munge/munge.key:/etc/munge/munge.key:ro
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    command:
+      - --web.listen-address=:9341
+      - --log.level=info


### PR DESCRIPTION
First-class container support for `slurm_exporter`. Two variants, configurable mounts, OCI metadata, and a documented freshness/retention policy. This is the foundational Docker PR — publishing pipeline (GHCR + Docker Hub via GoReleaser), supply chain hardening (SBOM, signing, Trivy), and CI automation (weekly refresh, monthly cleanup) follow in dedicated PRs.

## Two image variants

| Variant | Tag | Bundled slurm-client | When |
|---|---|---|---|
| **Standard** | `:vX.Y.Z` / `:latest` | Yes, Slurm 23.11.x (Ubuntu 24.04 repos) | Cluster runs Slurm 22.x — 24.x packaged from your distro |
| **Minimal** | `:vX.Y.Z-minimal` / `:latest-minimal` | No | Slurm built from source / OHPC / outside the 22-24 window — mount your own install |

Both ship `munge`, a non-root user (uid `9341`, group `munge`), and run the exporter as PID 1.

## Why not distroless

I wanted `gcr.io/distroless/static-debian12:nonroot` for the standard variant. It doesn't work: the exporter shells out to the Slurm CLI tools (it doesn't use a Slurm API), and those tools are dynamically linked against glibc + libslurm. Distroless static doesn't ship a dynamic loader, and there's no package manager to install slurm-client into it. Ubuntu 24.04 was the cleanest fallback — glibc 2.39 covers RHEL 8 / 9, Rocky, and Debian 12 builds via forward-compat.

## What's in the PR

### Files

| File | What |
|---|---|
| `Dockerfile` | Standard variant: golang:1.26-alpine → ubuntu:24.04 + slurm-client + munge. |
| `Dockerfile.minimal` | Minimal variant: same builder, ubuntu:24.04 + munge only. Operator mounts /opt/slurm. |
| `docker/docker-compose.yml` | Compose for the standard variant, paths overridable via env vars. |
| `docker/docker-compose.minimal.yml` | Compose for the minimal variant with `LD_LIBRARY_PATH=/opt/slurm/lib`, `--slurm.bin-path=/opt/slurm/bin`. |
| `docker/README.md` | Full doc: two variants, version compatibility, three deployment scenarios, Prometheus scrape config, image freshness & retention policy, troubleshooting. |
| `Makefile` | `docker-build`, `docker-build-minimal`, `docker-build-all`, `docker-run`, `docker-run-minimal`, `docker-stop`, `docker-clean`. |
| `README.md` | New Docker subsection under Installation pointing at `docker/README.md`. |

### Configurable mount paths

Hard-coded paths are now defaults behind env vars. The standard compose:

```
SLURM_CONF_DIR=/etc/slurm-llnl \
MUNGE_RUN_DIR=/run/munge \
  docker compose -f docker/docker-compose.yml up -d
```

| Variable | Default | Override when… |
|---|---|---|
| `SLURM_CONF_DIR` | `/etc/slurm` | older Debian/Ubuntu use `/etc/slurm-llnl`, source builds often use `/opt/slurm/etc` |
| `MUNGE_RUN_DIR` | `/var/run/munge` | some systemd setups use `/run/munge` |
| `MUNGE_KEY` | `/etc/munge/munge.key` | non-default install location |
| `IMAGE` | `ghcr.io/sckyzo/slurm_exporter:latest` | testing a locally-built tag |
| `HOST_PORT` | `9341` | port collision on the host |

The minimal compose adds `SLURM_PREFIX` (default `/opt/slurm`).

### OCI metadata

Every build emits the dynamic annotations expected by the OCI Image Spec:

```
org.opencontainers.image.title=slurm_exporter
org.opencontainers.image.version=v1.8.3-6-g2791c1f-dirty
org.opencontainers.image.revision=2791c1f00a0344deae1c4f9359ae4ff1e64d2a9c
org.opencontainers.image.created=2026-05-16T02:20:31Z
org.opencontainers.image.source=https://github.com/SckyzO/slurm_exporter
org.opencontainers.image.documentation=…
org.opencontainers.image.licenses=GPL-3.0-only
```

`docker inspect <image> --format '{{json .Config.Labels}}'` answers "what's running here and when was it built" without rebuilding.

### Freshness & retention policy

Documented in `docker/README.md`:

- Build + publish on every release tag (`vX.Y.Z`, `vX.Y`, `vX`, `latest`).
- Weekly cron rebuild of the two latest stable lines with the up-to-date base image — same tag re-pushed with a new digest, plus a dated immutable tag `:vX.Y.Z-YYYYMMDD` for GitOps determinism.
- Monthly retention: semver and floating tags kept forever, dated immutable tags pruned to the last ten per version.

The implementation lives in follow-up PRs. The doc anticipates so operators know what to expect.

## Smoke test (against local test cluster)

The local test cluster runs Slurm **25.11.2**; the standard image ships Slurm **23.11.4** — four major versions apart, well outside Slurm's two-version forward-compat window. So the Slurm-side RPCs predictably fail with `Unexpected message received`. Everything else works: image builds clean, container starts, munged comes up, exporter listens on `:9341`, `/metrics` returns the 184 baseline series, network reaches slurmctld, MUNGE auth succeeds.

This validates two things at once: the image is technically sound, and the doc's version-mismatch caveat is accurate. For a cluster running 23.x or 24.x, the standard image works out of the box. For everything else, the minimal variant + a BYO Slurm mount is the answer — documented with a complete example.

| Check | Result |
|---|---|
| `make docker-build` | ✅ slurm_exporter:dev — 113 MB |
| `make docker-build-minimal` | ✅ slurm_exporter:dev-minimal — 101 MB |
| `--version` flag prints ldflags-injected metadata | ✅ |
| All six Slurm CLI tools resolve via `which` (standard) | ✅ |
| `which sinfo` fails (minimal) | ✅ (expected, BYO) |
| OCI labels (`version`, `revision`, `created`) populated | ✅ |
| Container runs against the local test cluster | ✅ (network, munge, /metrics) |
| Slurm RPCs fail with documented version-mismatch error | ✅ (4-version gap, confirms README warning) |
| `make test`, `golangci-lint`, `make report` | ✅ unchanged (165 pass, 0 issues, 100%) |

## Follow-up PRs

| PR | Scope |
|---|---|
| **#44** (planned) | GoReleaser `dockers` + `docker_manifests` for multi-arch, GHCR + Docker Hub push, semver tag matrix on release. |
| **#45** (planned) | SBOM via syft, image signing via cosign keyless, Trivy scan in PR pipeline. |
| **#46** (planned) | `docker-refresh.yml` cron workflow (weekly base image rebuild). |
| **#47** (planned) | `docker-cleanup.yml` cron workflow (monthly tag retention enforcement). |

Together these get the project to 15/15+ on the container best-practices checklist — at the level of Prometheus, Grafana, and traefik upstream.