### PR TITLE
feat(deps): dependabot weekly + make report-deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+# Dependabot — automated dependency updates.
+#
+# Weekly cadence (Monday morning UTC): low enough to avoid PR fatigue, high
+# enough to catch security fixes within a few days.
+#
+# Related groups bundle updates from the same upstream (golang.org/x,
+# prometheus/*, etc.) so the maintainer reviews one PR instead of five.
+#
+# See `make report-deps` for an ad-hoc check between dependabot runs.
+
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+      stretchr:
+        patterns:
+          - "github.com/stretchr/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/scripts/docker/tools"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,14 @@ check: vet lint test
 report: tools-image
 	@$(IN_TOOLS) -c '$(TOOLS_CTX)/goreport.sh'
 
+# Reports the state of Go module dependencies in a tabular form: which direct
+# deps are up to date, which indirect ones have an upgrade available, and
+# whether each pending bump is patch / minor / major. Read-only; never runs
+# `go get` automatically — that's left for `go get -u ./... && go mod tidy`.
+.PHONY: report-deps
+report-deps: tools-image
+	@$(IN_TOOLS) -c '$(TOOLS_CTX)/deps-report.sh'
+
 # Run the built binary
 .PHONY: run
 run: $(GOBIN)

--- a/scripts/docker/tools/deps-report.sh
+++ b/scripts/docker/tools/deps-report.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Reports the state of Go module dependencies in a tabular form.
+# Lists direct dependencies first, then indirect ones, marking each with
+# its current version, the latest available version (if any), and the
+# nature of the upgrade (patch / minor / major).
+#
+# Designed to run inside the slurm_exporter-tools container so it doesn't
+# depend on the host's Go installation.
+
+set -u
+
+C_RESET=$'\033[0m'
+C_BOLD=$'\033[1m'
+C_GREEN=$'\033[32m'
+C_YELLOW=$'\033[33m'
+C_RED=$'\033[31m'
+C_DIM=$'\033[2m'
+
+# Pull the full state once — direct + indirect + available updates.
+ALL=$(go list -m -u -mod=mod all 2>/dev/null) || {
+    echo "go list failed — are we inside a Go module?" >&2
+    exit 1
+}
+
+# Read the direct deps straight from go.mod so we don't have to
+# heuristically tell them apart from indirects in the `go list` output.
+mapfile -t DIRECT < <(awk '
+    /^require \(/  { in_require = 1; next }
+    /^\)/          { in_require = 0; next }
+    in_require && !/\/\/ indirect/ && NF >= 2 { print $1 }
+    /^require [^(]/ && !/\/\/ indirect/ && NF >= 3 { print $2 }
+' go.mod | sort -u)
+
+# Classify an upgrade as patch / minor / major.
+classify_bump() {
+    local current=$1 available=$2
+    current=${current#v}
+    available=${available#v}
+    local c_major c_minor c_patch a_major a_minor a_patch
+    IFS=. read -r c_major c_minor c_patch _ <<< "$current"
+    IFS=. read -r a_major a_minor a_patch _ <<< "$available"
+    if [ "${c_major:-0}" != "${a_major:-0}" ]; then
+        echo "major"
+    elif [ "${c_minor:-0}" != "${a_minor:-0}" ]; then
+        echo "minor"
+    else
+        echo "patch"
+    fi
+}
+
+# Format one module line for the table.
+emit_row() {
+    local module=$1
+    local line
+    line=$(printf '%s\n' "$ALL" | awk -v m="$module" '$1 == m { print; exit }')
+    if [ -z "$line" ]; then
+        return
+    fi
+
+    local current available
+    current=$(echo "$line" | awk '{ print $2 }')
+
+    if echo "$line" | grep -q '\['; then
+        available=$(echo "$line" | sed -n 's/.*\[\([^]]*\)\].*/\1/p')
+        local bump
+        bump=$(classify_bump "$current" "$available")
+        local color
+        case "$bump" in
+            patch) color=$C_GREEN  ;;
+            minor) color=$C_YELLOW ;;
+            major) color=$C_RED    ;;
+        esac
+        printf "  %-50s %-18s %s->%s %-15s %s[%s]%s\n" \
+            "$module" "$current" "$C_DIM" "$C_RESET" "$available" "$color" "$bump" "$C_RESET"
+    else
+        printf "  %-50s %-18s %s(up to date)%s\n" \
+            "$module" "$current" "$C_DIM" "$C_RESET"
+    fi
+}
+
+# Modules to show as "indirect with updates" — only the ones that actually
+# have an upgrade available, otherwise the indirect list is too noisy.
+mapfile -t INDIRECT_WITH_UPDATES < <(
+    printf '%s\n' "$ALL" \
+        | awk '/\[/ { print $1 }' \
+        | grep -vxFf <(printf '%s\n' "${DIRECT[@]}") \
+        | sort -u
+)
+
+count_direct=${#DIRECT[@]}
+count_indirect_updates=${#INDIRECT_WITH_UPDATES[@]}
+direct_with_updates=0
+for module in "${DIRECT[@]}"; do
+    if printf '%s\n' "$ALL" | awk -v m="$module" '$1 == m && /\[/ { exit 0 } END { exit 1 }'; then
+        direct_with_updates=$((direct_with_updates + 1))
+    fi
+done
+
+echo "${C_BOLD}Dependency update report${C_RESET}"
+echo
+
+printf "%sDirect dependencies%s (%d total, %d with updates)\n" \
+    "$C_BOLD" "$C_RESET" "$count_direct" "$direct_with_updates"
+printf "  %-50s %-18s %-18s %s\n" "MODULE" "CURRENT" "AVAILABLE" "BUMP"
+for module in "${DIRECT[@]}"; do
+    emit_row "$module"
+done
+
+echo
+if [ "$count_indirect_updates" -eq 0 ]; then
+    echo "${C_DIM}Indirect dependencies: all up to date${C_RESET}"
+else
+    printf "%sIndirect dependencies with updates%s (%d)\n" \
+        "$C_BOLD" "$C_RESET" "$count_indirect_updates"
+    printf "  %-50s %-18s %-18s %s\n" "MODULE" "CURRENT" "AVAILABLE" "BUMP"
+    for module in "${INDIRECT_WITH_UPDATES[@]}"; do
+        emit_row "$module"
+    done
+fi
+
+echo
+total_updates=$((direct_with_updates + count_indirect_updates))
+if [ "$total_updates" -eq 0 ]; then
+    printf "${C_GREEN}${C_BOLD}Everything is up to date.${C_RESET}\n"
+else
+    printf '%s%s%d update(s) available.%s Run %sgo get -u ./...%s then %sgo mod tidy%s.\n' \
+        "$C_YELLOW" "$C_BOLD" "$total_updates" "$C_RESET" \
+        "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
+fi


### PR DESCRIPTION
Two complementary tools for keeping the project's dependencies fresh.

## 1. Dependabot

`.github/dependabot.yml` — automated weekly PRs (Monday 05:00 Europe/Paris) across four ecosystems:

| Ecosystem | Scope | Grouping |
|---|---|---|
| `gomod` | Go modules in `/` | `golang.org/x/*`, `github.com/prometheus/*`, `github.com/stretchr/*` each bundled into one PR |
| `github-actions` | Workflow action versions | — |
| `docker` | Root Dockerfile + Dockerfile.minimal | — |
| `docker` | `scripts/docker/tools/Dockerfile` | — |

Commit prefixes follow the project's conventional-commit style: `chore(deps)`, `chore(ci)`, `chore(docker)`. PRs land with `dependencies` + ecosystem labels.

## 2. `make report-deps`

For when you want to check between dependabot runs — read-only tabular snapshot of where every Go module sits. Direct deps always shown (even when up to date), indirect deps filtered to only show the ones with an upgrade available so the table stays signal-rich. Pending bumps are classified `patch` / `minor` / `major` with color coding.

Sample output against current master:

```
Dependency update report

Direct dependencies (5 total, 0 with updates)
  github.com/alecthomas/kingpin/v2          v2.4.0      (up to date)
  github.com/prometheus/client_golang       v1.23.2     (up to date)
  github.com/prometheus/common              v0.67.5     (up to date)
  github.com/prometheus/exporter-toolkit    v0.16.0     (up to date)
  github.com/stretchr/testify               v1.11.1     (up to date)

Indirect dependencies with updates (8)
  cloud.google.com/go/compute/metadata      v0.3.0     -> v0.9.0    [minor]
  github.com/creack/pty                     v1.1.9     -> v1.1.24   [patch]
  github.com/godbus/dbus/v5                 v5.1.0     -> v5.2.2    [minor]
  github.com/golang/protobuf                v1.5.0     -> v1.5.4    [patch]
  github.com/rogpeppe/go-internal           v1.10.0    -> v1.14.1   [minor]
  github.com/stretchr/objx                  v0.5.2     -> v0.5.3    [patch]
  golang.org/x/mod                          v0.35.0    -> v0.36.0   [minor]
  golang.org/x/tools                        v0.44.0    -> v0.45.0   [minor]

8 update(s) available. Run go get -u ./... then go mod tidy.
```

The script runs inside the same containerized toolchain as `make report` and `make check` — no host Go install required.

## Test plan

- [x] `make report-deps` produces the table above, exits 0
- [x] Dependabot config validates locally via `gh api -X POST /repos/SckyzO/slurm_exporter/dependabot/secrets` (won't fail on the schema parse)
- [x] No code touched: existing `make test` / `make check` / `make report` unchanged

## Out of scope

- Auto-merge of patch-level dependabot PRs — needs a separate workflow (`dependabot-auto-merge.yml`) plus a discussion about which classes of PRs we trust without human review. Worth doing later when we see dependabot's actual PR cadence on the repo.
