### PR TITLE
feat(release): publish Docker images to GHCR and Docker Hub on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,20 @@ jobs:
           git tag -l
           echo "HEAD commit hash:"
           git rev-parse HEAD
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PASS: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+      - name: Log in to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKER_USERNAME }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKER_TOKEN }}
+        run: echo "$DOCKERHUB_PASS" | docker login docker.io -u "$DOCKERHUB_USER" --password-stdin
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,195 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
+# Docker images. Two variants (standard + minimal), each built for amd64 and
+# arm64. Per-arch images are pushed first; the docker_manifests section below
+# combines them into multi-arch manifests and adds the floating tags
+# (vX.Y, vX, latest) for stable releases.
+#
+# Build-args mirror what the local make targets pass so the OCI labels carry
+# the same metadata whether you build via GoReleaser or via the Makefile.
+dockers:
+  # Standard variant, amd64
+  - id: standard-amd64
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=slurm_exporter"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=COMMIT={{.FullCommit}}"
+      - "--build-arg=BRANCH={{.Branch}}"
+      - "--build-arg=BUILD_USER=goreleaser"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+
+  # Standard variant, arm64
+  - id: standard-arm64
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-arm64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=slurm_exporter"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=COMMIT={{.FullCommit}}"
+      - "--build-arg=BRANCH={{.Branch}}"
+      - "--build-arg=BUILD_USER=goreleaser"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+
+  # Minimal variant, amd64
+  - id: minimal-amd64
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-amd64"
+    dockerfile: Dockerfile.minimal
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=slurm_exporter (minimal)"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=COMMIT={{.FullCommit}}"
+      - "--build-arg=BRANCH={{.Branch}}"
+      - "--build-arg=BUILD_USER=goreleaser"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+
+  # Minimal variant, arm64
+  - id: minimal-arm64
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-arm64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-arm64"
+    dockerfile: Dockerfile.minimal
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=slurm_exporter (minimal)"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=COMMIT={{.FullCommit}}"
+      - "--build-arg=BRANCH={{.Branch}}"
+      - "--build-arg=BUILD_USER=goreleaser"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+
+# Multi-arch manifests, one set per registry. The :{{ .Version }} and
+# :{{ .Version }}-minimal tags are always pushed. Floating tags (latest,
+# vX.Y, vX) are skipped on pre-releases (v1.9.0-rc1, etc.) so the rolling
+# pointers always reference a stable release.
+docker_manifests:
+  # ─── GHCR — standard ────────────────────────────────────────────────────────
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:latest"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  # ─── GHCR — minimal ─────────────────────────────────────────────────────────
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-arm64"
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Major }}.{{ .Minor }}-minimal"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:{{ .Major }}-minimal"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "ghcr.io/sckyzo/slurm_exporter:latest-minimal"
+    image_templates:
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-amd64"
+      - "ghcr.io/sckyzo/slurm_exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  # ─── Docker Hub — standard ──────────────────────────────────────────────────
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Version }}"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-arm64"
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Major }}"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:latest"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  # ─── Docker Hub — minimal ───────────────────────────────────────────────────
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-arm64"
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Major }}.{{ .Minor }}-minimal"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:{{ .Major }}-minimal"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
+  - name_template: "docker.io/sckyzo/slurm-exporter:latest-minimal"
+    image_templates:
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-amd64"
+      - "docker.io/sckyzo/slurm-exporter:{{ .Version }}-minimal-arm64"
+    skip_push: '{{ ne .Prerelease "" }}'
+
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
GoReleaser now builds and pushes both image variants (standard + minimal) for two architectures (amd64 + arm64) to two registries on every release tag.

## Tag matrix

For a stable release like `v1.9.0`, the workflow produces twenty manifests:

| Tag form | Standard | Minimal | Notes |
|---|---|---|---|
| Pinned version | `:v1.9.0` | `:v1.9.0-minimal` | Always pushed (including on RCs) |
| Floating minor | `:v1.9` | `:v1.9-minimal` | Stable only — `skip_push` on prereleases |
| Floating major | `:v1` | `:v1-minimal` | Stable only |
| Latest | `:latest` | `:latest-minimal` | Stable only |

Doubled for `ghcr.io/sckyzo/slurm_exporter` and `docker.io/sckyzo/slurm-exporter`.

Pre-release tags (e.g. `v1.9.0-rc1`) push the pinned tag only and don't touch the floating pointers, so `:latest` always references the latest stable.

## Per-arch entries

Four `dockers:` entries (standard × {amd64, arm64} + minimal × {amd64, arm64}) build the per-arch images. The eight `docker_manifests:` entries combine them into multi-arch manifests under each tag/registry combination.

OCI labels (`created`, `version`, `revision`, `title`) come from build args mirroring what `make docker-build` injects locally — same metadata whether you build via GoReleaser or via the Makefile.

## CI changes

Added to `.github/workflows/release.yml` before the GoReleaser step:

```yaml
- name: Set up QEMU
  uses: docker/setup-qemu-action@v3
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
- name: Log in to GHCR
  env: { GHCR_USER, GHCR_PASS }
  run: echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
- name: Log in to Docker Hub
  env: { DOCKERHUB_USER, DOCKERHUB_PASS }
  run: echo "$DOCKERHUB_PASS" | docker login docker.io -u "$DOCKERHUB_USER" --password-stdin
```

The `docker login` lines use env vars instead of the `docker/login-action` because the latter trips the workflow-injection linter when it sees `github.actor` — env vars are equivalent and cleaner.

## Required secrets

| Secret | Where to set | How to obtain |
|---|---|---|
| `DOCKER_USERNAME` | Repo settings → Secrets and variables → Actions | Your Docker Hub login (`sckyzo`) |
| `DOCKER_TOKEN` | Same | hub.docker.com → Account Settings → Security → New Access Token (`Read, Write, Delete`) |

`GHCR` works out of the box using the default `GITHUB_TOKEN` — no extra secret needed.

**Without these two secrets the docker.io login step fails and the whole release job fails before publishing anything.** That's intentional: no partial publish.

## Test plan

- [x] `goreleaser check` passes (validated via `docker run goreleaser/goreleaser:latest check`)
- [x] `make test` 165 pass, `golangci-lint` 0 issues, `make report` 100%
- [x] Docker build flow already smoke-tested end-to-end against the local Slurm 25.11.2 cluster in #43, #45, #46
- [ ] arm64 builds will be exercised on the first tag push (QEMU cross-build)

## Out of scope (follow-up PRs)

- SBOM emission via `syft` + image signing via `cosign` (Sigstore keyless) — `id-token: write` permission already in place
- Trivy vulnerability scan in PR pipeline
- Weekly cron rebuild of the two latest stable lines with refreshed base images
- Monthly cron cleanup of dated immutable tags (`:vX.Y.Z-YYYYMMDD`)

The freshness/retention policy is already documented in `docker/README.md` (PR #43); the workflows that implement it follow.
