### PR TITLE
feat(release): SBOM + cosign signing + Trivy scan + Dockerfile single-stage fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the Docker build context small. The single-stage Dockerfiles only
+# need the slurm_exporter binary at the root and the Dockerfile itself —
+# nothing else from the repo is consumed during `docker build`.
+
+# Go source and build artefacts (we ship the pre-compiled binary)
+cmd/
+internal/
+test_data/
+docs/
+monitoring/
+scripts/
+go/
+bin/
+dist/
+*.go
+
+# Module files
+go.mod
+go.sum
+
+# Project metadata that doesn't affect the image
+.git/
+.github/
+.gitignore
+.gitattributes
+.golangci.yml
+.goreleaser.yaml
+.goreleaser.dev.yaml
+CHANGELOG.md
+CLAUDE.md
+CONTRIBUTING.md
+README.md
+LICENSE
+Makefile
+systemd/
+tmp/

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run GoReleaser for Dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
       - run: make test
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
       - name: Set build environment variables
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
       - name: Log in to GHCR
         env:
           GHCR_USER: ${{ github.actor }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -38,7 +38,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: slurm_exporter:scan
           severity: HIGH,CRITICAL
@@ -59,7 +59,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan-minimal
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: slurm_exporter:scan-minimal
           severity: HIGH,CRITICAL

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -33,12 +33,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.3'
-          cache: true
-      - name: Build Go binary
-        run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
+      - name: Build Go binary in a Go container
+        # Compile inside golang:1.26.3-alpine to pin the stdlib version
+        # embedded in the binary. setup-go + host build can drift to a
+        # cached older patch version; the container guarantees what Trivy
+        # will see.
+        run: |
+          docker run --rm \
+            -v "$(pwd):/src" \
+            -w /src \
+            -e CGO_ENABLED=0 \
+            -e GOOS=linux \
+            -e GOTOOLCHAIN=local \
+            golang:1.26.3-alpine \
+            go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
         uses: docker/build-push-action@v6
         with:
@@ -60,12 +68,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.3'
-          cache: true
-      - name: Build Go binary
-        run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
+      - name: Build Go binary in a Go container
+        # Compile inside golang:1.26.3-alpine to pin the stdlib version
+        # embedded in the binary. setup-go + host build can drift to a
+        # cached older patch version; the container guarantees what Trivy
+        # will see.
+        run: |
+          docker run --rm \
+            -v "$(pwd):/src" \
+            -w /src \
+            -e CGO_ENABLED=0 \
+            -e GOOS=linux \
+            -e GOTOOLCHAIN=local \
+            golang:1.26.3-alpine \
+            go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -38,7 +38,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: slurm_exporter:scan
           severity: HIGH,CRITICAL
@@ -59,7 +59,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan-minimal
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: slurm_exporter:scan-minimal
           severity: HIGH,CRITICAL

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,68 @@
+# Trivy vulnerability scan on the two Docker variants.
+#
+# Triggered on PRs that touch the Dockerfile(s) or Go dependencies. Builds
+# both images locally, scans for HIGH and CRITICAL CVEs, and fails the PR if
+# any are found in packages that have a fix available. Unfixable CVEs (no
+# upstream patch yet) are reported in the summary but don't block the merge.
+#
+# Also runs weekly on a cron against the published images so we catch new
+# CVEs reported after release.
+
+name: Trivy scan
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile.minimal'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/trivy-scan.yml'
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  scan-standard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build standard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: slurm_exporter:scan
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: slurm_exporter:scan
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+  scan-minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build minimal image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.minimal
+          push: false
+          load: true
+          tags: slurm_exporter:scan-minimal
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: slurm_exporter:scan-minimal
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -7,6 +7,10 @@
 #
 # Also runs weekly on a cron against the published images so we catch new
 # CVEs reported after release.
+#
+# The Dockerfiles are single-stage and expect ./slurm_exporter to be present
+# in the build context — so this workflow compiles the binary first, mirroring
+# what GoReleaser does for releases and `make docker-build` for local dev.
 
 name: Trivy scan
 
@@ -29,6 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+      - name: Build Go binary
+        run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
         uses: docker/build-push-action@v6
         with:
@@ -50,6 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+      - name: Build Go binary
+        run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
       - name: Build Go binary
         run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
       - name: Build Go binary
         run: CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ go/
 *.tar.gz*
 *.swp
 
+# Pre-compiled binary staged at the repo root by `make docker-build`
+# (single-stage Dockerfiles expect ./slurm_exporter in the context). The
+# Makefile rm's it after each build but git should never see it either way.
+/slurm_exporter
+
 # Dev/test scripts (environment-specific, not committed)
 scripts/dev/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,45 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
+# Supply-chain artefacts. Three things are produced and verifiable on every
+# release:
+#
+#   1. SBOM (CycloneDX) per archive — what's inside each tarball/zip.
+#   2. Cosign signature on the checksum file — proves the release artefacts
+#      weren't tampered with after build.
+#   3. Cosign signatures on every Docker manifest — see docker_signs below.
+#
+# All signatures are keyless via Sigstore: the build identity is the GitHub
+# Actions workflow itself, attested by the runner's OIDC token. Consumers
+# verify with `cosign verify <image>` (see docker/README.md).
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    artifacts: manifests
+    output: true
+    args:
+      - sign
+      - "--yes"
+      - "${artifact}@${digest}"
+
 # Docker images. Two variants (standard + minimal), each built for amd64 and
 # arm64. Per-arch images are pushed first; the docker_manifests section below
 # combines them into multi-arch manifests and adds the floating tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,45 +2,19 @@
 #
 # slurm_exporter — Prometheus exporter for the Slurm workload manager.
 #
-# Two stages:
-#   1. builder    Go 1.26-alpine, produces a static slurm_exporter binary.
-#   2. runtime    Ubuntu 26.04, ships the binary plus the Slurm CLI tools
-#                 (sinfo, squeue, sdiag, scontrol, sshare, sacct) that the
-#                 exporter shells out to.
+# Single-stage runtime image. The slurm_exporter binary is expected to be
+# present in the build context next to this Dockerfile. That's how GoReleaser
+# drives Docker builds: it cross-compiles the binary first, then writes it to
+# a temporary build context alongside the Dockerfile before running
+# `docker build`. The Makefile's docker-build target follows the same
+# convention (see `make docker-build`).
 #
-# The runtime image needs three things from the host to talk to slurmctld:
+# The runtime needs three things from the host to talk to slurmctld:
 #   - /etc/slurm/slurm.conf            (slurmctld endpoint and cluster config)
 #   - /var/run/munge/munge.socket.2    (authentication daemon socket)
 #   - /etc/munge/munge.key             (cluster-wide MUNGE shared key)
 #
-# See docker/README.md for compose examples and the troubleshooting guide.
-
-FROM golang:1.26-alpine AS builder
-
-WORKDIR /src
-
-# Cache module downloads in a separate layer.
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-
-ARG VERSION=dev
-ARG COMMIT=
-ARG BRANCH=
-ARG BUILD_USER=docker
-ARG BUILD_DATE=
-
-RUN CGO_ENABLED=0 GOOS=linux go build \
-    -ldflags "-s -w \
-        -X github.com/prometheus/common/version.Version=${VERSION} \
-        -X github.com/prometheus/common/version.Revision=${COMMIT} \
-        -X github.com/prometheus/common/version.Branch=${BRANCH} \
-        -X github.com/prometheus/common/version.BuildUser=${BUILD_USER} \
-        -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
-    -o /out/slurm_exporter ./cmd/slurm_exporter
-
-# ---
+# See docker/README.md for compose examples and troubleshooting.
 
 FROM ubuntu:26.04
 
@@ -62,14 +36,12 @@ RUN apt-get update && \
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin \
         --uid 9341 --gid munge slurmexporter
 
-COPY --from=builder /out/slurm_exporter /usr/local/bin/slurm_exporter
+COPY slurm_exporter /usr/local/bin/slurm_exporter
 
 USER slurmexporter
 
 EXPOSE 9341
 
-# OCI annotations — re-declared in this stage so the ARG values from the
-# builder stage flow into the runtime image's labels.
 ARG VERSION=dev
 ARG COMMIT=
 ARG BUILD_DATE=

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,11 @@ RUN apt-get update && \
         munge \
         ca-certificates \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble
+# Ubuntu 26.04 ships an unmanaged /usr/bin/pebble (Canonical's init system)
+# that we never use. It still embeds an older Go stdlib that Trivy flags as
+# HIGH CVEs. Removing it shrinks the image by ~10 MB and clears the noise.
 
 # Dedicated unprivileged user, member of the munge group so the container
 # can write into the munge socket inherited from the host.

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -2,9 +2,10 @@
 #
 # slurm_exporter — minimal variant.
 #
-# Does not bundle slurm-client. Ships only:
-#   - the slurm_exporter binary
-#   - libmunge.so.2 (extracted from a Debian 12 builder stage so the host's
+# Ships only:
+#   - the slurm_exporter binary (expected in the build context — provided by
+#     GoReleaser or the Makefile's docker-build target)
+#   - libmunge.so.2 (extracted from a Debian 13 builder stage so the host's
 #     Slurm binaries find their munge dependency at runtime)
 #   - the distroless cc-debian12 runtime (glibc + libstdc++ + ld-linux)
 #
@@ -19,7 +20,8 @@
 # Distroless gives us no shell, no package manager, and a fixed nonroot
 # user — the standard hardened runtime for Prometheus-ecosystem exporters.
 # Forward-compatible with binaries built against RHEL 8 / 9 / Rocky 9 /
-# Debian 12, which covers virtually every Slurm cluster in production.
+# Debian 12 / Debian 13, which covers virtually every Slurm cluster in
+# production.
 #
 # Quick example:
 #
@@ -35,34 +37,8 @@
 #
 # See docker/README.md for the slurm-client-bundled (standard) variant.
 
-FROM golang:1.26-alpine AS builder
-
-WORKDIR /src
-
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-
-ARG VERSION=dev
-ARG COMMIT=
-ARG BRANCH=
-ARG BUILD_USER=docker
-ARG BUILD_DATE=
-
-RUN CGO_ENABLED=0 GOOS=linux go build \
-    -ldflags "-s -w \
-        -X github.com/prometheus/common/version.Version=${VERSION} \
-        -X github.com/prometheus/common/version.Revision=${COMMIT} \
-        -X github.com/prometheus/common/version.Branch=${BRANCH} \
-        -X github.com/prometheus/common/version.BuildUser=${BUILD_USER} \
-        -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
-    -o /out/slurm_exporter ./cmd/slurm_exporter
-
-# ---
-
-# Extract libmunge from a normal Debian stage. We only copy the .so file
-# into the distroless runtime, no apt machinery, no daemon binary.
+# Extract libmunge from a Debian 13 stage. We only copy the .so file into
+# the distroless runtime, no apt machinery, no daemon binary.
 FROM debian:13-slim AS munge-extractor
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -81,7 +57,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot
 COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2 /usr/lib/x86_64-linux-gnu/libmunge.so.2
 COPY --from=munge-extractor /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0 /usr/lib/x86_64-linux-gnu/libmunge.so.2.0.0
 
-COPY --from=builder /out/slurm_exporter /usr/local/bin/slurm_exporter
+COPY slurm_exporter /usr/local/bin/slurm_exporter
 
 EXPOSE 9341
 

--- a/Makefile
+++ b/Makefile
@@ -154,16 +154,39 @@ DOCKER_BUILD_ARGS = \
 	--build-arg BUILD_USER="$$(git config user.email)" \
 	--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# Both image variants are single-stage and expect ./slurm_exporter to be
+# present in the build context. We compile the binary first (mirrors what
+# GoReleaser does for releases), copy it next to the Dockerfile, build, and
+# clean up — never commit ./slurm_exporter to git (it's in .gitignore as
+# the binary at repo root).
+#
+# The same ldflags that go into bin/slurm_exporter for `make build` go
+# into ./slurm_exporter for `make docker-build`, so `docker run … --version`
+# reports the right metadata. The Dockerfile's build-args populate the
+# OCI labels on top — same information, different surface.
+
+# ldflags pulled from the build target so both paths stay in sync.
+DOCKER_GO_LDFLAGS = -s -w \
+	-X github.com/prometheus/common/version.Version=$$(git describe --tags --dirty 2>/dev/null || echo dev) \
+	-X github.com/prometheus/common/version.Revision=$$(git rev-parse HEAD) \
+	-X github.com/prometheus/common/version.Branch=$$(git rev-parse --abbrev-ref HEAD) \
+	-X github.com/prometheus/common/version.BuildUser=$$(git config user.email) \
+	-X github.com/prometheus/common/version.BuildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 .PHONY: docker-build
 docker-build:
 	@echo "Building $(DOCKER_REF)"
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./slurm_exporter ./cmd/slurm_exporter
 	docker build $(DOCKER_BUILD_ARGS) -t $(DOCKER_REF) .
+	@rm -f ./slurm_exporter
 	@echo "✓ $(DOCKER_REF)"
 
 .PHONY: docker-build-minimal
 docker-build-minimal:
 	@echo "Building $(DOCKER_REF_MINIMAL)"
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./slurm_exporter ./cmd/slurm_exporter
 	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.minimal -t $(DOCKER_REF_MINIMAL) .
+	@rm -f ./slurm_exporter
 	@echo "✓ $(DOCKER_REF_MINIMAL)"
 
 .PHONY: docker-build-all

--- a/docker/README.md
+++ b/docker/README.md
@@ -249,6 +249,63 @@ Look for `org.opencontainers.image.created` (build timestamp),
 `org.opencontainers.image.revision` (git commit), and
 `org.opencontainers.image.version` (exporter version).
 
+### Signature verification (cosign)
+
+Every published image manifest is signed using Sigstore keyless signing —
+the build identity is the GitHub Actions workflow that produced it, attested
+by the runner's OIDC token. No key material on either side.
+
+To verify a pulled image:
+
+```bash
+cosign verify ghcr.io/sckyzo/slurm_exporter:v1.8.3 \
+  --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The same command works for the `-minimal` variant and for the Docker Hub
+copies (`docker.io/sckyzo/slurm-exporter:...`). A successful verification
+prints the certificate subject and proves the image was built by the
+expected workflow on the expected repo at the expected commit.
+
+The release checksum file is signed the same way:
+
+```bash
+cosign verify-blob \
+  --certificate slurm_exporter_checksums.txt.pem \
+  --signature slurm_exporter_checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  slurm_exporter_checksums.txt
+```
+
+### Software Bill of Materials (SBOM)
+
+Each release archive ships with a CycloneDX SBOM (`*.sbom.json`) listing
+every Go module compiled into the binary, including transitive dependencies
+and their versions. Suitable for upload into compliance tools
+(Dependency-Track, Anchore, etc.).
+
+```bash
+# Download SBOM alongside the release artefacts
+gh release download v1.8.3 -p '*sbom.json'
+
+# Inspect with jq
+jq '.components[] | {name, version, purl}' \
+  slurm_exporter-1.8.3-linux-amd64.tar.gz.sbom.json
+```
+
+### Vulnerability scanning
+
+Both images are scanned on every PR that touches `Dockerfile*`, `go.mod`,
+or `go.sum` (see `.github/workflows/trivy-scan.yml`). The scan blocks the
+merge on any HIGH/CRITICAL CVE that has a fix available upstream. Unfixable
+CVEs (no upstream patch yet) are reported in the summary but don't block
+the PR — they're not actionable at PR time.
+
+A weekly scheduled scan re-runs the same checks against the published
+images so new CVEs reported after release surface as workflow failures.
+
 ## Security posture
 
 Both variants:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sckyzo/slurm_exporter
 
 go 1.26.0
 
-toolchain go1.26.1
+toolchain go1.26.3
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Supply-chain hardening for the published artefacts. Three independent additions designed to compose into a coherent story.

## 1. SBOM (CycloneDX)

`goreleaser sboms:` produces a `*.sbom.json` next to every archive on the GitHub release. Generated by `syft`, format is CycloneDX — directly consumable by Dependency-Track, Anchore Enterprise, and other SBOM tooling. Workflow installs syft via the `anchore/sbom-action/download-syft@v0` upstream action.

```bash
gh release download v1.8.4 -p '*sbom.json'
jq '.components[] | {name, version, purl}' slurm_exporter-1.8.4-linux-amd64.tar.gz.sbom.json
```

## 2. Cosign keyless signing (Sigstore)

Two surfaces signed on every release:

- **Checksum file**: `goreleaser signs:` produces `.pem` + `.sig` alongside the archive.
- **Docker manifests**: `goreleaser docker_signs:` signs every manifest pushed to GHCR and Docker Hub.

Keyless means the certificate's subject is the GitHub Actions workflow itself, attested by the runner's OIDC token. No keys on the producing side, no keys on the consuming side.

Consumer verification (image):

```bash
cosign verify ghcr.io/sckyzo/slurm_exporter:v1.8.4 \\
  --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \\
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

Consumer verification (checksum):

```bash
cosign verify-blob \\
  --certificate slurm_exporter_checksums.txt.pem \\
  --signature slurm_exporter_checksums.txt.sig \\
  --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \\
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
  slurm_exporter_checksums.txt
```

The release workflow installs cosign via the upstream `sigstore/cosign-installer@v3` action. The `id-token: write` permission was already on the release job (for keyless signing readiness in #43).

## 3. Trivy scan — PR-time and weekly cron

New workflow `.github/workflows/trivy-scan.yml`:

- Triggers on PRs that touch `Dockerfile*`, `go.mod`, or `go.sum`.
- Builds both image variants (standard + minimal) and runs `aquasecurity/trivy-action`.
- `severity: HIGH,CRITICAL` + `ignore-unfixed: true` — fails the PR only on CVEs that have a fix upstream. Unfixable CVEs are reported in the summary but don't block (not actionable at PR time).
- Weekly cron (Monday 06:00 UTC, one hour after Dependabot) re-runs the same checks against the published images so post-release CVEs become visible as workflow failures.

## Documentation

`docker/README.md` gains three new subsections under "Verifying what you're running":
- Signature verification (cosign), with full one-liners for image and for the checksum file.
- Software Bill of Materials, with the `gh release download` + `jq` inspection example.
- Vulnerability scanning, describing the PR-time and weekly Trivy jobs.

## Test plan

- [x] `goreleaser check` passes (validated via the `goreleaser/goreleaser:latest` container)
- [x] `make test` 165 pass, `golangci-lint` 0 issues, `make report` 100%
- [x] All third-party actions are upstream-maintained: `sigstore/cosign-installer`, `anchore/sbom-action`, `aquasecurity/trivy-action` — no custom shell
- [ ] Real-world signing + SBOM emission validated on the first tag push after merge (next release)
- [ ] Trivy job runs on this PR itself since `trivy-scan.yml` is in the diff
