### PR TITLE
feat(ci): sync docker/README.md to Docker Hub description

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -1,0 +1,44 @@
+# Syncs docker/README.md to the Docker Hub repository description.
+#
+# Triggers:
+#   - push to master that touches docker/README.md (or this workflow itself)
+#   - every published release
+#   - manual dispatch from the Actions UI
+#
+# GHCR doesn't need this — it reads org.opencontainers.image.description
+# from the image labels, which GoReleaser sets at build time.
+#
+# Required secrets:
+#   DOCKER_USERNAME    Docker Hub login
+#   DOCKER_TOKEN       Docker Hub access token with at minimum
+#                      "Public Repo Write" scope (the token used for image
+#                      push has narrower scope and won't work here)
+
+name: Sync Docker Hub README
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docker/README.md'
+      - '.github/workflows/dockerhub-readme.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: sckyzo/slurm-exporter
+          short-description: "Prometheus exporter for the Slurm workload manager"
+          readme-filepath: ./docker/README.md


### PR DESCRIPTION
GHCR reads the image description directly from the OCI labels GoReleaser sets at build time. Docker Hub doesn't — the repository description is a separate piece of metadata that has to be pushed via API.

## What this PR adds

`.github/workflows/dockerhub-readme.yml` — uses the upstream `peter-evans/dockerhub-description@v4` action to mirror `docker/README.md` into the Docker Hub repo description.

### Triggers

| Trigger | When |
|---|---|
| `push` to master touching `docker/README.md` | Doc updates flow to Docker Hub automatically |
| `release: published` | Description timestamp refreshed on every release |
| `workflow_dispatch` | Manual fire from the Actions UI (useful for the first run) |

### Secrets

Reuses the existing `DOCKER_USERNAME` + `DOCKER_TOKEN` secrets. **But** the token that GoReleaser uses for image push only needs `Repository Write` scope, whereas editing the repo description needs **`Public Repo Write`** (or `Admin`).

If the first run fails with HTTP 401, the fix is on hub.docker.com:
- Account Settings → Security → New Access Token
- Scope: `Public Repo Write` (covers description editing) or `Admin`
- Update the `DOCKER_TOKEN` repo secret on GitHub with the new value
- Re-run the workflow from the Actions UI

## Test plan

- [x] Workflow YAML validates locally (no syntax issues)
- [ ] First push to master triggers the workflow on the merge commit
- [ ] If 401: regenerate the Docker Hub token with proper scope per the notes above

After merge, the description on https://hub.docker.com/r/sckyzo/slurm-exporter should match `docker/README.md`. The GHCR side (`ghcr.io/sckyzo/slurm_exporter`) doesn't need this — its description was already populated from the OCI label.