### PR TITLE
chore(ci): bump docker/setup-{qemu,buildx}-action to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
           echo "HEAD commit hash:"
           git rev-parse HEAD
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
       - name: Install syft


### PR DESCRIPTION
Bumps the two docker setup actions from v3 (Node 20) to v4 (Node 24), pre-empting the forced migration on June 2nd, 2026 that GitHub announced.

| Action | v3 → v4 |
|---|---|
| docker/setup-qemu-action | Node 20 → Node 24 |
| docker/setup-buildx-action | Node 20 → Node 24 |

Both v4 releases are stable (cut from upstream master, no breaking changes in the action interface). The release workflow on v1.8.3 emitted the deprecation warning that this PR clears.

## Test plan

- [x] grep confirms both actions updated to @v4 in release.yml
- [ ] First tag push after merge will exercise the new action versions