### PR TITLE
docs: enrich PR template and add Make targets section in README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,9 @@
 Thanks for contributing! Please fill in the sections below.
 For larger changes, please open an issue first to discuss the approach —
 it saves rebase work for both sides.
+
+Commit message style: Conventional Commits (feat, fix, chore, docs,
+refactor, test, ci…). See git log on master for examples.
 -->
 
 ## Summary
@@ -10,11 +13,18 @@ it saves rebase work for both sides.
 
 ## Test plan
 
-- [ ] `make check` (vet + lint + tests) passes locally
-- [ ] New behavior is covered by a unit test
-- [ ] `docs/metrics.md` updated if a metric was added/renamed/removed
+<!-- Tick what applies. Skip what doesn't. -->
+
+- [ ] `make check` (containerised vet + lint + tests) passes
+- [ ] `make report` stays at grade A+ (offline goreportcard)
+- [ ] New behavior covered by a unit test
+- [ ] `make race` passes if the change touches concurrent code
+- [ ] `make docker-build && make docker-build-minimal` succeed if the change touches Docker
+- [ ] `docs/metrics.md` updated if a metric was added / renamed / removed
 - [ ] `CHANGELOG.md` updated if the change is user-visible
-- [ ] Manual validation on a real cluster, if relevant (see [`docs/validation-checklist.md`](docs/validation-checklist.md))
+- [ ] Manual validation on a real cluster, if relevant (see [`docs/validation-checklist.md`](../docs/validation-checklist.md))
+
+The Trivy scan workflow runs automatically on this PR if it touches `Dockerfile*`, `go.mod`, or `go.sum`. Wait for it to go green before requesting review.
 
 ## Related issue
 
@@ -23,4 +33,6 @@ it saves rebase work for both sides.
 ## Notes for reviewers
 
 <!-- Anything special: caveats, things you considered and discarded, areas
-     you'd like extra eyes on. Optional. -->
+     you'd like extra eyes on. If your PR touches `squeue -O` / `sinfo
+     --Format`, read the "Common Pitfalls" section of CONTRIBUTING.md
+     first — it'll save you a debug session. Optional. -->

--- a/README.md
+++ b/README.md
@@ -132,6 +132,29 @@ containerized `make check` / `make report` targets).
 | Release process | [`docs/release-process.md`](docs/release-process.md) |
 | Project roadmap | [`docs/roadmap.md`](docs/roadmap.md) |
 
+### Make targets
+
+| Category | Target | What it does |
+|---|---|---|
+| **Build** | `make build` | Compiles `bin/slurm_exporter` with version ldflags |
+| | `make clean` | Removes build artefacts (`bin/`, `dist/`, module cache) |
+| **Test** | `make test` | Runs the full unit-test suite |
+| | `make race` | Tests with the race detector (containerised) |
+| **Quality** | `make check` | `vet` + `lint` + `test`, all containerised |
+| | `make report` | Offline equivalent of goreportcard.com; fails below grade B |
+| | `make report-deps` | Tabular dependency status (current / available / patch-minor-major) |
+| **Docker** | `make docker-build` | Builds the standard image locally as `slurm_exporter:dev` |
+| | `make docker-build-minimal` | Builds the minimal (distroless) variant |
+| | `make docker-build-all` | Both variants in one go |
+| | `make docker-run` | Starts the compose stack (override `IMAGE=` for a local tag) |
+| | `make docker-run-minimal` | Same for the minimal compose |
+| | `make docker-stop` | `docker compose down` on both stacks |
+| | `make docker-clean` | Removes the locally-built images |
+| **Other** | `make run` | Runs the just-built binary |
+| | `make tools-image` | (Re)builds the `slurm_exporter-tools` container used by check/report |
+
+`make check`, `make report`, and `make report-deps` run **inside a container** — contributors only need Docker, no host Go install required.
+
 ---
 
 ## 📊 Dashboards & alerts


### PR DESCRIPTION
Two small but useful doc additions that complement the work done this session.

## 1. PR template (.github/pull_request_template.md)

The previous template mentioned `make check` and the metrics/changelog updates, but not the targets we've actually been relying on across the recent PRs.

Added:

- **`make report`** — release blocker per CLAUDE.md project rules
- **`make race`** — explicit reminder for PRs touching concurrent code
- **`make docker-build && make docker-build-minimal`** — for PRs that touch Docker
- **Trivy scan mention** — automatic on Dockerfile/go.mod changes, telling contributors to wait for it to go green before requesting review
- **Conventional Commits style** in the comment header (was implicit via git history)
- **Pointer to `CONTRIBUTING.md` > Common Pitfalls** in the reviewer notes — the `squeue -O field:` / `sinfo --Format` truncation gotcha cost a real debug session in #35; flagging it up front saves the next contributor the same pain

## 2. Make targets section in README

Sixteen `make` targets grouped in a single table by category (Build / Test / Quality / Docker / Other), placed under **⚙️ Configuration & development**. Includes the note that the quality and report targets all run inside the `slurm_exporter-tools` container — contributors don't need a host Go install for them.

```
Category   | Target                       | What it does
---------- | ---------------------------- | ----------------------------------------------
Build      | make build                   | Compiles bin/slurm_exporter with version ldflags
           | make clean                   | Removes build artefacts
Test       | make test                    | Runs the full unit-test suite
           | make race                    | Tests with the race detector (containerised)
Quality    | make check                   | vet + lint + test, all containerised
           | make report                  | Offline goreportcard equivalent
           | make report-deps             | Tabular dependency status
Docker     | make docker-build            | Builds the standard image locally
           | make docker-build-minimal    | Builds the minimal (distroless) variant
           | make docker-build-all        | Both variants
           | make docker-run              | Starts the compose stack
           | make docker-run-minimal      | Same for minimal
           | make docker-stop             | docker compose down on both stacks
           | make docker-clean            | Removes the locally-built images
Other      | make run                     | Runs the just-built binary
           | make tools-image             | (Re)builds the tools container
```

## Test plan

- [x] Markdown renders cleanly on GitHub (no broken tables, no escaped backticks)
- [x] All anchor links in the README TOC still resolve
- [x] Validated locally that all 16 targets exist in the Makefile

## Out of scope

The Make targets table on the README intentionally duplicates information that's already self-documenting from the Makefile (`make help` could give the same listing). The point is README-side discoverability for a first-time contributor who scans the project before cloning.