### PR TITLE
feat(ci): weekly cron rebuild of the last 2 stable image lines

### DIFF
--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -1,0 +1,186 @@
+# Weekly rebuild of the last 2 stable image lines against the up-to-date
+# base images, so security patches in ubuntu / debian / distroless flow into
+# published artefacts without waiting for the next release tag.
+#
+# What it does
+#   - Picks the last 2 semver-stable git tags (vX.Y.Z, no prerelease suffix).
+#   - For each tag: checks out the repo at that tag, compiles the Go binary,
+#     builds and pushes both image variants as multi-arch manifests to
+#     GHCR + Docker Hub, signs every pushed manifest with cosign.
+#   - Tags pushed per release-tag:
+#       :X.Y.Z              (moving alias — re-pushed with a fresh digest)
+#       :X.Y.Z-YYYYMMDD     (new immutable tag for GitOps determinism)
+#       :X.Y.Z-minimal       and  :X.Y.Z-minimal-YYYYMMDD   (idem)
+#
+# Triggers
+#   - Cron: Mondays 04:00 UTC (one hour before the Dependabot run, so the
+#     refresh doesn't race base-image bump PRs).
+#   - workflow_dispatch: optional `tags` input to override the default
+#     "last 2 stable" auto-selection.
+#
+# Tags built before the single-stage Dockerfile migration (v1.8.2 and
+# earlier) are detected and skipped — their build context isn't compatible
+# with the current Dockerfiles.
+
+name: Weekly Docker refresh
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Comma-separated tags to rebuild (default: last 2 stable semver tags)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  GHCR_REPO: ghcr.io/sckyzo/slurm_exporter
+  HUB_REPO: docker.io/sckyzo/slurm-exporter
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute target tags
+        id: tags
+        env:
+          MANUAL_TAGS: ${{ inputs.tags }}
+        run: |
+          set -eu
+          if [ -n "${MANUAL_TAGS:-}" ]; then
+            tags="$MANUAL_TAGS"
+          else
+            tags=$(git tag --sort=-version:refname \
+                   | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                   | head -2 | paste -sd, -)
+          fi
+          if [ -z "$tags" ]; then
+            echo "::error::No semver tags found"
+            exit 1
+          fi
+          echo "Tags to rebuild: $tags"
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+          echo "date_suffix=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.3'
+          cache: false
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PASS: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      - name: Log in to Docker Hub
+        env:
+          HUB_USER: ${{ secrets.DOCKER_USERNAME }}
+          HUB_PASS: ${{ secrets.DOCKER_TOKEN }}
+        run: echo "$HUB_PASS" | docker login docker.io -u "$HUB_USER" --password-stdin
+
+      - name: Refresh each tag
+        env:
+          TAGS: ${{ steps.tags.outputs.tags }}
+          DATE_SUFFIX: ${{ steps.tags.outputs.date_suffix }}
+        run: |
+          set -eu
+          IFS=',' read -ra TAG_LIST <<< "$TAGS"
+          for tag in "${TAG_LIST[@]}"; do
+            echo "::group::Refreshing $tag"
+            git checkout "$tag"
+
+            # The single-stage Dockerfile expects ./slurm_exporter in the
+            # build context. Tags before single-stage migration have a
+            # multi-stage Dockerfile that this workflow's build context
+            # can't satisfy — skip them with a warning.
+            if grep -q 'AS builder' Dockerfile; then
+              echo "::warning::$tag uses a multi-stage Dockerfile, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            version="${tag#v}"
+            commit=$(git rev-parse HEAD)
+            build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            dated="${version}-${DATE_SUFFIX}"
+
+            ldflags="-s -w \
+              -X github.com/prometheus/common/version.Version=${version} \
+              -X github.com/prometheus/common/version.Revision=${commit} \
+              -X github.com/prometheus/common/version.Branch=refresh \
+              -X github.com/prometheus/common/version.BuildUser=refresh-cron \
+              -X github.com/prometheus/common/version.BuildDate=${build_date}"
+
+            CGO_ENABLED=0 GOOS=linux go build -ldflags "$ldflags" \
+              -o ./slurm_exporter ./cmd/slurm_exporter
+
+            for variant in standard minimal; do
+              if [ "$variant" = "standard" ]; then
+                dockerfile=Dockerfile
+                moving_tag=$version
+                dated_tag=$dated
+              else
+                dockerfile=Dockerfile.minimal
+                moving_tag="${version}-minimal"
+                dated_tag="${version}-minimal-${DATE_SUFFIX}"
+              fi
+
+              docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --file "$dockerfile" \
+                --build-arg VERSION="$version" \
+                --build-arg COMMIT="$commit" \
+                --build-arg BUILD_DATE="$build_date" \
+                --label "org.opencontainers.image.created=$build_date" \
+                --label "org.opencontainers.image.revision=$commit" \
+                --label "org.opencontainers.image.version=$version" \
+                --tag "${GHCR_REPO}:${moving_tag}" \
+                --tag "${GHCR_REPO}:${dated_tag}" \
+                --tag "${HUB_REPO}:${moving_tag}" \
+                --tag "${HUB_REPO}:${dated_tag}" \
+                --push .
+
+              for ref in \
+                "${GHCR_REPO}:${moving_tag}" \
+                "${GHCR_REPO}:${dated_tag}" \
+                "${HUB_REPO}:${moving_tag}" \
+                "${HUB_REPO}:${dated_tag}"; do
+                cosign sign --yes "$ref"
+              done
+            done
+
+            rm -f ./slurm_exporter
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        env:
+          TAGS: ${{ steps.tags.outputs.tags }}
+          DATE_SUFFIX: ${{ steps.tags.outputs.date_suffix }}
+        run: |
+          {
+            echo "## Weekly Docker refresh"
+            echo
+            echo "**Tags refreshed:** $TAGS"
+            echo "**Dated suffix:** $DATE_SUFFIX"
+            echo
+            echo "Each tag produces 4 multi-arch manifests + 4 cosign"
+            echo "signatures across GHCR and Docker Hub (standard + minimal,"
+            echo "moving alias + dated immutable)."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Per the freshness policy documented in `docker/README.md` (added in #43), the last two stable image lines should be rebuilt weekly so security patches in the base images (ubuntu, debian, distroless) flow into published artefacts without waiting for the next release tag.

## What the workflow does

For each of the last two semver-stable git tags (`vX.Y.Z`, no prerelease suffix):

1. Checks out the repo at that tag.
2. Skips with a workflow warning if the Dockerfile is multi-stage (pre-single-stage tags like v1.8.2 — their build context isn't compatible with the current refresh path).
3. Compiles the binary with pinned Go 1.26.3 and the standard version ldflags.
4. Builds both image variants (Dockerfile + Dockerfile.minimal) as multi-arch manifests (linux/amd64 + linux/arm64) via `docker buildx --push`.
5. Tags each manifest twice:
   - Moving alias: `:X.Y.Z` and `:X.Y.Z-minimal` — re-pushed with a fresh digest so consumers pulling the pinned semver tag get the patched image.
   - Immutable dated tag: `:X.Y.Z-YYYYMMDD` and `:X.Y.Z-minimal-YYYYMMDD` — for GitOps determinism, so anyone who pinned a specific build can re-pull it bit-for-bit even after the next refresh.
6. Cosign-signs every pushed reference (keyless, OIDC-attested).

## Triggers

- **Cron**: Mondays 04:00 UTC. One hour before the Dependabot run so a base-image bump PR doesn't race a freshly published refresh.
- **workflow_dispatch**: optional `tags` input that overrides the default "last 2 stable" auto-selection — useful for backfills or testing.

## What gets published per run

For each of the 2 tags × 2 variants × 2 registries × 2 tag forms (moving + dated) = **16 tags** rewritten, all cosign-signed.

## Secrets reused

No new secrets needed — the workflow inherits `DOCKER_USERNAME`, `DOCKER_TOKEN`, and `GITHUB_TOKEN` already in place for the release workflow. Cosign keyless signing inherits `id-token: write` from the job permissions.

## Validation plan

The workflow is too expensive to dry-run end-to-end on every PR (~10 min for one full pass). My plan after merge:

- [ ] Trigger via `workflow_dispatch` with `tags=v1.8.3` for a single-tag smoke test
- [ ] Verify the new tags appear on GHCR + Docker Hub
- [ ] Verify `cosign verify` succeeds against the dated tag
- [ ] Let the cron run on the next Monday for the full default behaviour

## Test plan

- [x] YAML syntax valid (manual review + workflow appears in the Actions UI)
- [x] All referenced actions exist at the pinned versions (setup-go@v6, setup-qemu-action@v4, setup-buildx-action@v4, cosign-installer@v3)
- [x] Tag-skipping logic — checks for `AS builder` in the Dockerfile at the checked-out tag, skips with a warning if found