### PR TITLE
fix(ci): skip refresh tags without a single-stage Dockerfile

### DIFF
--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -105,11 +105,13 @@ jobs:
             git checkout "$tag"
 
             # The single-stage Dockerfile expects ./slurm_exporter in the
-            # build context. Tags before single-stage migration have a
-            # multi-stage Dockerfile that this workflow's build context
-            # can't satisfy — skip them with a warning.
-            if grep -q 'AS builder' Dockerfile; then
-              echo "::warning::$tag uses a multi-stage Dockerfile, skipping"
+            # build context. Older tags either ship no Dockerfile at all
+            # (Docker support landed in v1.8.3) or carry a multi-stage one
+            # this workflow's build context can't satisfy — skip both. The
+            # -f test short-circuits the grep so a missing file doesn't
+            # emit a stderr error or leak through as a false negative.
+            if [ ! -f Dockerfile ] || grep -q 'AS builder' Dockerfile; then
+              echo "::warning::$tag has no usable single-stage Dockerfile, skipping"
               echo "::endgroup::"
               continue
             fi


### PR DESCRIPTION
## Summary

- The weekly Docker refresh failed on its 2026-05-18 cron run while processing `v1.8.2`.
- `v1.8.2` predates Docker support (Dockerfiles landed in v1.8.3 / #49) and ships **no Dockerfile at all**, but the skip guard assumed one always exists.
- One-line guard fix so pre-Docker (and any future multi-stage) tags are skipped cleanly.

## Root cause

The job auto-selects the last two stable semver tags. While v1.9 is unreleased that pair is `v1.8.3, v1.8.2`. The guard meant to skip incompatible tags was:

```bash
if grep -q 'AS builder' Dockerfile; then   # detect multi-stage
```

On `v1.8.2` there is no `Dockerfile`, so `grep` exits 2 and prints `grep: Dockerfile: No such file or directory`. Inside an `if`, a non-zero exit reads as **false**, so the tag was **not** skipped and `docker buildx build --file Dockerfile` failed the run.

`v1.8.3` had already been refreshed successfully (4 signed manifests on both registries) before the loop reached `v1.8.2` — no published artifacts are affected.

## Fix

```bash
if [ ! -f Dockerfile ] || grep -q 'AS builder' Dockerfile; then
  echo "::warning::$tag has no usable single-stage Dockerfile, skipping"
```

The `-f` test runs first and short-circuits the grep, so a missing file no longer leaks a stderr error or slips through as a false negative. Covers all three cases: no Dockerfile, multi-stage Dockerfile, single-stage Dockerfile. This aligns the implementation with the intent already documented at the top of the workflow.

## Test plan

- [x] Logic verified against the failing run (`v1.8.3` builds, `v1.8.2` skipped).
- [ ] Post-merge: dispatch `Weekly Docker refresh` manually to confirm a green run on the current tag window.

## Notes for reviewers

Self-correcting once v1.9.0 ships — the tag window becomes `v1.9.0, v1.8.3`, both buildable. The guard still matters for any future tag that lacks a single-stage Dockerfile.