### PR TITLE
docs: add SECURITY.md security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Site-specific labels (`team`, `runbook_url`, `dashboard_url`) are intentionally 
 
 ## 🔐 Security & supply chain
 
+Found a vulnerability? See [`SECURITY.md`](SECURITY.md) for how to report it privately.
+
 Every published artifact carries verifiable provenance and is scanned for known vulnerabilities before release.
 
 - 🖋️ **Signed container images** — every Docker manifest is signed via [cosign](https://github.com/sigstore/cosign) keyless ([Sigstore](https://www.sigstore.dev/) / Fulcio). The signing identity is the GitHub Actions workflow itself, attested by the runner's OIDC token. Verify with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately through GitHub's
+[private vulnerability reporting](https://github.com/SckyzO/slurm_exporter/security/advisories/new)
+(repository **Security** tab → **Report a vulnerability**). This keeps the
+report confidential until a fix is available.
+
+Do not open a public issue or pull request for a suspected vulnerability.
+
+Include, where possible: the affected version, the command(s) the exporter was
+running, and the steps to reproduce. Reports are acknowledged and triaged on a
+best-effort basis.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+Only the latest release receives security fixes. This project is not actively
+maintained for Slurm 25.11+, which natively supports OpenMetrics for Prometheus
+— see [sckyzo/slurm_prometheus_exporter](https://github.com/sckyzo/slurm_prometheus_exporter/)
+for new deployments.
+
+## Verifying published artifacts
+
+Released binaries and container images carry signed provenance (cosign keyless),
+signed checksums, and CycloneDX SBOMs. Verification recipes are in the
+[Security & supply chain](README.md#-security--supply-chain) section of the
+README and in [`docker/README.md`](docker/README.md#supply-chain).


### PR DESCRIPTION
## What

Adds a `SECURITY.md` and a one-line pointer to it from the README's
**Security & supply chain** section.

## Why

Private vulnerability reporting is already enabled on the repository, but
nothing documented the report channel — a reporter had no obvious entry
point. This file populates the **Security policy** entry in the Security
tab and the "Report a vulnerability" flow.

## Contents

- **Reporting** — directs reporters to GitHub private vulnerability
  reporting, asks them not to open public issues for vulnerabilities.
- **Supported versions** — latest release only, with the existing Slurm
  25.11+ sunset note and a pointer to `slurm_prometheus_exporter`.
- **Verifying artifacts** — links to the existing cosign / SBOM
  verification recipes (README + `docker/README.md`), no duplication.

No code or behavior change.