### PR TITLE
fix(ci): drop redundant tag fetch from dev-release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -13,12 +13,12 @@ jobs:
       contents: write # needed to write releases
     steps:
       - name: Checkout
+        # fetch-depth: 0 already retrieves all tags (the fetch refspec
+        # includes +refs/tags/*), which GoReleaser needs for the changelog.
+        # release.yml relies on this same checkout with no extra tag fetch.
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Fetch all tags
-        run: git fetch --force --tags
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## What

Removes the `Fetch all tags` step (`git fetch --force --tags`) from the
dev-release workflow.

## Why

The step was redundant and the sole failure point of run
[26331878474](https://github.com/SckyzO/slurm_exporter/actions/runs/26331878474):

- **Redundant** — `actions/checkout@v6` with `fetch-depth: 0` already
  fetches all tags via its fetch refspec (`+refs/tags/*:refs/tags/*`).
  `release.yml` relies on exactly this checkout with no separate tag
  fetch, and tagged releases ship fine.
- **Fragile** — unlike checkout's own fetch, this manual step had no
  retry. A transient GitHub credential blip (`could not read Username for
  'https://github.com'`) hit both checkout and this step at the same
  instant; checkout retried and recovered, the manual step failed the job.

A re-run of the same job then passed unchanged, confirming the blip was
transient. This change removes the no-retry failure point so the next
blip is absorbed by checkout's retry instead of failing the run.

## Impact

None on artifacts — dev-release runs GoReleaser in `--snapshot` mode and
publishes nothing. Pure CI hardening; aligns dev-release with release.yml.