### PR TITLE
fix(security): bump Go toolchain to 1.26.4 (GO-2026-5039, GO-2026-5037)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Run GoReleaser for Dev

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: false
 
       - uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
       - run: make test
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
       - name: Set build environment variables
         run: |

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build Go binary in a Go container
-        # Compile inside golang:1.26.3-alpine to pin the stdlib version
+        # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
         # cached older patch version; the container guarantees what Trivy
         # will see.
@@ -45,7 +45,7 @@ jobs:
             -e CGO_ENABLED=0 \
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
-            golang:1.26.3-alpine \
+            golang:1.26.4-alpine \
             go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
         uses: docker/build-push-action@v7
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build Go binary in a Go container
-        # Compile inside golang:1.26.3-alpine to pin the stdlib version
+        # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
         # cached older patch version; the container guarantees what Trivy
         # will see.
@@ -80,7 +80,7 @@ jobs:
             -e CGO_ENABLED=0 \
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
-            golang:1.26.3-alpine \
+            golang:1.26.4-alpine \
             go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
         uses: docker/build-push-action@v7

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sckyzo/slurm_exporter
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -7,7 +7,7 @@
 # Built locally on first use via `make tools-image`; rebuilds are
 # incremental thanks to the layer cache.
 
-FROM golang:1.26-alpine
+FROM golang:1.26.4-alpine
 
 RUN apk add --no-cache git bash curl ca-certificates findutils
 


### PR DESCRIPTION
## What

Bump the pinned Go toolchain `go1.26.3` → `go1.26.4` to fix **two reachable**
Go standard-library vulnerabilities reported by `govulncheck`. No application
code change.

Closes #70.

## Why

`govulncheck ./...` (with go1.26.3) reports two vulnerabilities whose call graph
is reachable from our code:

| ID | Package | Reachability |
|---|---|---|
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | `cmd/slurm_exporter/main.go:262` → `web.ListenAndServe` → `textproto.Reader.ReadMIMEHeader` |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | `main.go:174` → `kingpin.Parse` → `x509.Certificate.Verify`; `internal/collector/execute.go:57` → `fmt.Errorf` → `x509.HostnameError.Error` |

Both are fixed in **go1.26.4**. Dependency scanners (osv-scanner, Trivy on
`go.mod`) do not catch these — they live in the stdlib tied to the toolchain
version, which is exactly what `govulncheck` detects.

## Changes

Aligned every pinned reference to the Go toolchain:

- `go.mod` — `toolchain go1.26.4`
- `.github/workflows/release.yml` — `go-version: '1.26.4'` (lint, test, release)
- `.github/workflows/dev-release.yml` — `go-version: '1.26.4'`
- `.github/workflows/docker-refresh.yml` — `go-version: '1.26.4'`
- `.github/workflows/trivy-scan.yml` — `golang:1.26.4-alpine` (×2)
- `scripts/docker/tools/Dockerfile` — `golang:1.26.4-alpine`

## Non-regression validation (run locally)

| Check | Result |
|---|---|
| `make check` (vet + lint + test) | ✅ exit 0, no failures |
| race detector (`CGO_ENABLED=1 go test -race` under go1.26.4) | ✅ `ok internal/collector`, no data race |
| `make build` | ✅ exit 0 |
| `govulncheck ./...` (go1.26.4) | ✅ **0 vulnerabilities** (was 2 reachable) |
| `make docker-build` + `make docker-build-minimal` | ✅ both build |
| `docker run … --version` (both images) | ✅ run, report `go1.26.4` |

## Notes

- Patch-level toolchain bump — no API or runtime behavior change.
- Separately discovered (out of scope here, will be fixed in the toolchain
  hardening PR): `make race` via the alpine tools image fails because the image
  has no `gcc` and `-race` requires cgo — a pre-existing issue, not introduced
  by this change.
