### PR TITLE
chore(ci): toolchain — govulncheck, actionlint, shellcheck, zizmor + fix make race

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -127,9 +127,11 @@ jobs:
         run: |
           set -eu
 
-          echo >> "$GITHUB_STEP_SUMMARY"
-          echo "## Docker Hub cleanup — ${HUB_REPO}" >> "$GITHUB_STEP_SUMMARY"
-          echo >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo
+            echo "## Docker Hub cleanup — ${HUB_REPO}"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
 
           # Docker Hub needs a session token (JWT) for the DELETE endpoint.
           jwt=$(curl -s -H "Content-Type: application/json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
           cache: true
       - name: Set build environment variables
         run: |
-          echo "BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-          echo "GO_VERSION=$(go version)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+          echo "GO_VERSION=$(go version)" >> "$GITHUB_ENV"
       - name: Debug Git State
         run: |
           echo "Current commit:"

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,12 @@ test: tools-image
 
 # Tests with the race detector (in container). Useful to catch concurrency bugs
 # in collectors with background goroutines (e.g. sacct_efficiency).
+# CGO_ENABLED=1 is required: the race detector is implemented in C. The tools
+# image bundles build-base (gcc) for this.
 .PHONY: race
 race: tools-image
 	@echo "Running tests with race detector (containerised)"
-	@$(IN_TOOLS) -c 'go test -race -count=1 ./...'
+	@$(IN_TOOLS) -c 'CGO_ENABLED=1 go test -race -count=1 ./...'
 
 # go vet (in container).
 .PHONY: vet
@@ -109,9 +111,34 @@ lint: tools-image
 	@echo "Running golangci-lint (containerised)"
 	@$(IN_TOOLS) -c 'golangci-lint run ./...'
 
+# govulncheck — Go call-graph vulnerability scanner (in container).
+# Catches reachable stdlib / dependency CVEs that image scanners (Trivy) and
+# module-list scanners (osv-scanner) miss. Needs network to fetch the vuln DB.
+.PHONY: vuln
+vuln: tools-image
+	@echo "Running govulncheck (containerised)"
+	@$(IN_TOOLS) -c 'govulncheck ./...'
+
+# actionlint — GitHub Actions workflow linter (in container). Auto-discovers
+# .github/workflows/ and runs shellcheck on every `run:` block (shellcheck is
+# bundled in the tools image).
+.PHONY: actionlint
+actionlint: tools-image
+	@echo "Running actionlint (containerised)"
+	@$(IN_TOOLS) -c 'actionlint -color'
+
+# zizmor — static analysis (security) for GitHub Actions (in container).
+# --offline keeps it deterministic (no GitHub API calls). Not yet part of
+# `check`: it reports `unpinned-uses` until the actions are pinned by SHA;
+# it joins `check` in that PR.
+.PHONY: zizmor
+zizmor: tools-image
+	@echo "Running zizmor (containerised)"
+	@$(IN_TOOLS) -c 'zizmor --offline .'
+
 # Full pre-commit / pre-release verification — mirrors what CI runs.
 .PHONY: check
-check: vet lint test
+check: vet lint test vuln actionlint
 
 # Offline equivalent of the goreportcard.com checks (in container).
 # Runs gofmt -s, go vet, gocyclo, ineffassign, misspell, and a LICENSE check,

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -9,14 +9,21 @@
 
 FROM golang:1.26.4-alpine
 
-RUN apk add --no-cache git bash curl ca-certificates findutils
+# shellcheck  → used by actionlint to lint `run:` shell blocks
+# zizmor      → static analysis (security) for GitHub Actions workflows
+# build-base  → C toolchain (gcc): `go test -race` requires cgo
+RUN apk add --no-cache git bash curl ca-certificates findutils \
+        shellcheck zizmor build-base
 
 # Static-analysis tools used by `make report` (the same set goreportcard.com
-# runs server-side) and by `make check` (lint + vet + test).
+# runs server-side), by `make check` (lint + vet + test + vuln + actionlint),
+# and by `make vuln` / `make actionlint`.
 RUN go install github.com/fzipp/gocyclo/cmd/gocyclo@latest \
  && go install github.com/client9/misspell/cmd/misspell@latest \
  && go install github.com/gordonklaus/ineffassign@latest \
  && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest \
+ && go install golang.org/x/vuln/cmd/govulncheck@latest \
+ && go install github.com/rhysd/actionlint/cmd/actionlint@latest \
  && go clean -cache -modcache -testcache
 
 # All tools land in /go/bin which is already on $PATH.


### PR DESCRIPTION
## What

Make the full security/CI validation runnable locally with only Docker, and fix
the broken `make race` target.

Closes #72.

## Changes

**tools image** (`scripts/docker/tools/Dockerfile`)
- `apk`: `shellcheck` (actionlint's `run:`-block linter), `zizmor` (GitHub
  Actions SAST), `build-base` (gcc — `go test -race` requires cgo).
- `go install`: `govulncheck`, `actionlint`.

**`Makefile`**
- New targets: `vuln` (govulncheck), `actionlint`, `zizmor` (`--offline`).
- `race`: add `CGO_ENABLED=1` — the race detector is C-based and was failing
  because the alpine image had no compiler (surfaced while validating #70).
- `check`: now `vet lint test vuln actionlint`. `zizmor` will join `check` in
  the SHA-pinning PR, once `unpinned-uses` findings are resolved.

**Shell nits** (so `make actionlint` is clean)
- `release.yml`: quote `>> "$GITHUB_ENV"` (SC2086).
- `docker-cleanup.yml`: group consecutive summary redirects (SC2129).

## Why these three scanners

- `govulncheck` — Go call-graph vuln scanner; catches reachable stdlib /
  dependency CVEs that Trivy (image layers) and osv-scanner (module list) miss.
  This is how #70 was found.
- `actionlint` + `shellcheck` — workflow syntax/expression + `run:` shell linting.
- `zizmor` — Actions SAST (template injection, credential leakage, excessive
  permissions, unpinned actions).

## Non-regression validation (local — no PR-triggered CI matches these paths)

| Check | Result |
|---|---|
| `make check` (vet + lint + test + vuln + actionlint) | ✅ exit 0 |
| `make race` | ✅ exit 0 (was broken) |
| `make vuln` | ✅ 0 vulnerabilities |
| `make actionlint` | ✅ no findings |
| `make zizmor` | runs; reports `unpinned-uses` (expected until the SHA-pin PR) |
