### PR TITLE
feat(ci): add govulncheck workflow (Go call-graph vuln scan)

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,37 @@
+# govulncheck — Go call-graph vulnerability scanning.
+#
+# Complements Trivy (image-layer CVEs) and osv-scanner (module list): govulncheck
+# analyses the call graph and reports only vulnerabilities whose vulnerable symbol
+# is actually reachable from this code — including the Go standard library tied to
+# the toolchain version (this is how the go1.26.4 bump in #70 was found).
+#
+# Runs on every PR and push to master, plus weekly so newly-disclosed CVEs in
+# already-released code are caught between commits.
+
+name: govulncheck
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: '0 7 * * 1' # Mondays 07:00 UTC (offset from the other crons)
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.4'
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
Run `govulncheck ./...` on every PR, every push to master, and weekly.

govulncheck analyses the call graph and reports only **reachable** vulnerabilities — including the Go stdlib tied to the toolchain version (this is how #70 was found). Complements Trivy (image layers) and osv-scanner (module list), neither of which caught #70.

- third-party actions pinned by commit SHA
- `permissions: contents: read`
- checkout uses `persist-credentials: false`

This PR triggers the new workflow itself (on: pull_request) — the check below is the live proof.

Validated locally: actionlint clean, zizmor --offline clean on the new file, `act -l` parses.

Closes #74