### PR TITLE
fix(ci): pin third-party GitHub Actions by commit SHA (#66)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -16,18 +16,18 @@ jobs:
         # fetch-depth: 0 already retrieves all tags (the fetch refspec
         # includes +refs/tags/*), which GoReleaser needs for the changelog.
         # release.yml relies on this same checkout with no extra tag fetch.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: Run GoReleaser for Dev
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -60,7 +60,7 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -85,14 +85,14 @@ jobs:
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
           echo "date_suffix=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
           cache: false
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: sigstore/cosign-installer@v3
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Log in to GHCR
         env:

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -33,9 +33,9 @@ jobs:
   update-readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,21 +12,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -42,10 +42,10 @@ jobs:
       id-token: write # needed for keyless signing
       packages: write # needed for ghcr access
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -62,13 +62,13 @@ jobs:
           echo "HEAD commit hash:"
           git rev-parse HEAD
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Log in to GHCR
         env:
           GHCR_USER: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
           DOCKERHUB_PASS: ${{ secrets.DOCKER_TOKEN }}
         run: echo "$DOCKERHUB_PASS" | docker login docker.io -u "$DOCKERHUB_USER" --password-stdin
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -32,7 +32,7 @@ jobs:
   scan-standard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Go binary in a Go container
         # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
@@ -48,7 +48,7 @@ jobs:
             golang:1.26.4-alpine \
             go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
@@ -56,7 +56,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: slurm_exporter:scan
           severity: HIGH,CRITICAL
@@ -67,7 +67,7 @@ jobs:
   scan-minimal:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Go binary in a Go container
         # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
@@ -83,7 +83,7 @@ jobs:
             golang:1.26.4-alpine \
             go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.minimal
@@ -91,7 +91,7 @@ jobs:
           load: true
           tags: slurm_exporter:scan-minimal
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: slurm_exporter:scan-minimal
           severity: HIGH,CRITICAL


### PR DESCRIPTION
Pin every action reference to a full commit SHA (with `# vX` comments for readability + Dependabot tracking), closing the mutable-tag supply-chain exposure in #66 (ISSUE-701, tj-actions/changed-files class).

**SHAs re-resolved fresh** against upstream — the #66 table (2026-05-25) had drifted, e.g. `docker/setup-qemu-action@v4` moved `ce360397` → `06116385`.

28 references across 5 workflows (release, dev-release, docker-refresh, dockerhub-readme, trivy-scan), including first-party `actions/checkout` and `actions/setup-go` pinned for hygiene.

Verified locally: zizmor `unpinned-uses` 28 → 0; actionlint clean; `act -l` parses all workflows; `make check` green. This PR also re-triggers trivy-scan + govulncheck + CodeQL as live proof.

Remaining zizmor findings (artipacked, dependabot-cooldown, cache-poisoning) are tracked for a dedicated follow-up; zizmor joins `make check` once they're resolved.

Refs #66