### PR TITLE
feat(ci): add CODEOWNERS (#66)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for slurm_exporter.
+#
+# When a pull request touches a matched path, the listed owner is automatically
+# requested for review. This is the file half of issue #66 (ISSUE-505); the
+# server-side "require review from Code Owners" branch-protection rule is a
+# separate, deliberate change to the merge process and is NOT enabled here.
+#
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository.
+*                       @SckyzO
+
+# Supply-chain / CI-sensitive paths — called out explicitly so ownership of the
+# release, signing and CI plumbing stays unambiguous even if more owners are
+# added to the catch-all above later.
+/.github/               @SckyzO
+/Dockerfile*            @SckyzO
+/.goreleaser*           @SckyzO
+/scripts/docker/        @SckyzO


### PR DESCRIPTION
Adds `.github/CODEOWNERS` — the file half of issue #66 (ISSUE-505). PRs touching the repo, and the supply-chain / CI-sensitive paths in particular (`.github/`, `Dockerfile*`, `.goreleaser*`, `scripts/docker/`), will automatically request owner review.

Validated: `GET /codeowners/errors` returns `{"errors":[]}`.

### Not done here (needs your explicit decision)
The server-side rule **"Require review from Code Owners" on `master`** changes the merge process and is intentionally **not** enabled by this PR. To enable it later:

```bash
gh api -X PATCH repos/SckyzO/slurm_exporter/branches/master/protection/required_pull_request_reviews \
  -F require_code_owner_reviews=true
```

(or Settings → Branches → master → Require a pull request before merging → Require review from Code Owners)

Refs #66