### PR TITLE
chore(ci): resolve remaining zizmor findings and gate make check on zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@
 # Related groups bundle updates from the same upstream (golang.org/x,
 # prometheus/*, etc.) so the maintainer reviews one PR instead of five.
 #
+# A 7-day cooldown delays proposing a brand-new release: a freshly published
+# (and possibly compromised) version has time to be yanked before we pull it.
+#
 # See `make report-deps` for an ad-hoc check between dependabot runs.
 
 version: 2
@@ -18,6 +21,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
@@ -43,6 +48,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(ci)"
@@ -58,6 +65,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(docker)"
@@ -73,6 +82,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(docker)"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,12 +19,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
-          cache: true
+          cache: false
 
       - name: Run GoReleaser for Dev
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -63,6 +63,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # local `git checkout <tag>` below works without persisted creds
+          persist-credentials: false
 
       - name: Compute target tags
         id: tags

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
-          cache: true
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
@@ -26,10 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
-          cache: true
+          cache: false
       - run: make test
 
   release:
@@ -45,10 +49,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
-          cache: true
+          cache: false
       - name: Set build environment variables
         run: |
           echo "BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Build Go binary in a Go container
         # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
@@ -68,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Build Go binary in a Go container
         # Compile inside golang:1.26.4-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a

--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,7 @@ actionlint: tools-image
 	@$(IN_TOOLS) -c 'actionlint -color'
 
 # zizmor — static analysis (security) for GitHub Actions (in container).
-# --offline keeps it deterministic (no GitHub API calls). Not yet part of
-# `check`: it reports `unpinned-uses` until the actions are pinned by SHA;
-# it joins `check` in that PR.
+# --offline keeps it deterministic (no GitHub API calls).
 .PHONY: zizmor
 zizmor: tools-image
 	@echo "Running zizmor (containerised)"
@@ -138,7 +136,7 @@ zizmor: tools-image
 
 # Full pre-commit / pre-release verification — mirrors what CI runs.
 .PHONY: check
-check: vet lint test vuln actionlint
+check: vet lint test vuln actionlint zizmor
 
 # Offline equivalent of the goreportcard.com checks (in container).
 # Runs gofmt -s, go vet, gocyclo, ineffassign, misspell, and a LICENSE check,


### PR DESCRIPTION
Follow-up to #77. Brings zizmor to a clean state (0 findings) and wires it into `make check`.

- **cache-poisoning** (4, error) → `cache: false` on setup-go in publishing workflows (release ×3, dev-release). A PR-poisoned Go cache can no longer reach the signing/publishing path.
- **artipacked** (8, warning) → `persist-credentials: false` on every checkout (none push via git).
- **dependabot-cooldown** (4, warning) → 7-day `cooldown` on all four Dependabot ecosystems (a freshly published, possibly compromised release has time to be yanked first).

`check` is now `vet lint test vuln actionlint zizmor`.

Verified: `zizmor --offline` 0 findings; `make check` green; actionlint clean. CI (trivy + govulncheck + CodeQL) re-runs here as proof.

Closes #79