### PR TITLE
feat(ci): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# OpenSSF Scorecard — supply-chain security posture scoring.
+#
+# Runs the OpenSSF Scorecard checks (branch protection, pinned dependencies,
+# token permissions, dangerous workflows, maintained, SAST, ...) and uploads the
+# result to the repository's Security → Code scanning tab. Also runs weekly and
+# whenever a branch protection rule changes, so the score is tracked over time.
+#
+# Docs: https://github.com/ossf/scorecard-action
+
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 7 * * 1' # Mondays 07:30 UTC (offset from the other crons)
+  push:
+    branches: [master]
+
+# Top-level token is read-only; the analysis job elevates only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write        # publish results to the OpenSSF API (publish_results)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds an OpenSSF Scorecard workflow scoring the repo's supply-chain posture and uploading SARIF to Security → Code scanning. Runs weekly, on push to master, and on branch_protection_rule changes.

- all actions pinned by commit SHA; `ossf/scorecard-action@v2.4.3`
- top-level `contents: read`; job elevates only `security-events: write` + `id-token: write`
- checkout `persist-credentials: false`

Verified locally: actionlint clean, `zizmor --offline` 0 findings, `act -l` parses. (Scorecard itself runs on push-to-master, so it'll first execute once this merges.)

Closes #82