### PR TITLE
chore(ci): add gitleaks (secret scan) and osv-scanner to toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,21 @@ zizmor: tools-image
 	@echo "Running zizmor (containerised)"
 	@$(IN_TOOLS) -c 'zizmor --offline .'
 
+# gitleaks — secret scanner (in container). Scans the working tree. Kept out of
+# `check` (it's a prevention tool, not a build gate); run it before committing.
+.PHONY: secrets
+secrets: tools-image
+	@echo "Running gitleaks secret scan (containerised)"
+	@$(IN_TOOLS) -c 'gitleaks dir . --no-banner --redact'
+
+# osv-scanner — dependency vulnerability scan against the OSV database (in
+# container). Complements govulncheck (call graph) with the OSV feed. Needs
+# network, so it's a separate target rather than part of `check`.
+.PHONY: osv
+osv: tools-image
+	@echo "Running osv-scanner (containerised)"
+	@$(IN_TOOLS) -c 'osv-scanner scan source --lockfile go.mod'
+
 # Full pre-commit / pre-release verification — mirrors what CI runs.
 .PHONY: check
 check: vet lint test vuln actionlint zizmor

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -24,6 +24,8 @@ RUN go install github.com/fzipp/gocyclo/cmd/gocyclo@latest \
  && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest \
  && go install golang.org/x/vuln/cmd/govulncheck@latest \
  && go install github.com/rhysd/actionlint/cmd/actionlint@latest \
+ && go install github.com/zricethezav/gitleaks/v8@latest \
+ && go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest \
  && go clean -cache -modcache -testcache
 
 # All tools land in /go/bin which is already on $PATH.


### PR DESCRIPTION
Add two OSS scanners to the containerised tools image:

- **gitleaks** (`make secrets`) — secret scanner over the working tree.
- **osv-scanner** (`make osv`) — dependency vuln scan against the OSV database, complementing govulncheck (call graph).

Both via `go install` (not in apk). Standalone targets, not part of `make check` (prevention tools; osv needs network). 100% OSS, no SaaS/account.

Verified: `make secrets` (no leaks), `make osv` (0 vulns), `make check` still green (6 steps).

Closes #84