### PR TITLE
chore: housekeeping — dev-release build vars + drop legacy COSIGN_EXPERIMENTAL

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -27,6 +27,14 @@ jobs:
           go-version: '1.26.4'
           cache: false
 
+      # Populate the build metadata consumed by .goreleaser.dev.yaml
+      # ({{.Env.BUILD_DATE}}). Without this the value was empty (these env keys
+      # were referenced below but never defined).
+      - name: Set build environment variables
+        run: |
+          echo "BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+          echo "GO_VERSION=$(go version)" >> "$GITHUB_ENV"
+
       - name: Run GoReleaser for Dev
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,8 +63,6 @@ sboms:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: "${artifact}.pem"
     args:
       - sign-blob
@@ -77,8 +75,6 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:


### PR DESCRIPTION
Two no-risk cleanups:

- `dev-release.yml`: define `BUILD_DATE`/`GO_VERSION` (were referenced in the GoReleaser env but never set → empty). Dev snapshots now get a real BuildDate.
- `.goreleaser.yaml`: drop `COSIGN_EXPERIMENTAL=1` from `signs`/`docker_signs`. Confirmed via cosign docs (context7): keyless signing is the default in cosign v2; the env only affects the experimental `oci-1-1` referrers mode (unused). `cosign-installer@v3` = cosign v2.x, so it's a no-op removal.

Verified: actionlint clean, zizmor 0 findings, `goreleaser check` valid on both configs, `make check` green.

Closes #86