### PR TITLE
docs(security): summarize security practices in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,24 @@ maintained for Slurm 25.11+, which natively supports OpenMetrics for Prometheus
 — see [sckyzo/slurm_prometheus_exporter](https://github.com/sckyzo/slurm_prometheus_exporter/)
 for new deployments.
 
+## Security practices
+
+Several checks run automatically so issues are caught before they ship:
+
+- `govulncheck` runs on every pull request and weekly, and reports only the
+  vulnerabilities reachable from the code.
+- CodeQL (extended query suite) and `gosec` check the Go code for vulnerable
+  patterns.
+- Container images are scanned for known CVEs with Trivy and run as a non-root
+  user.
+- Third-party GitHub Actions are pinned to commit SHAs, workflow tokens are kept
+  to least privilege, and `master` merges only once the security checks pass.
+- Dependabot proposes dependency updates weekly, with a short cooldown so a
+  freshly published release is not pulled in the same day.
+
+Released binaries and images are signed; see
+[Verifying published artifacts](#verifying-published-artifacts) below.
+
 ## Verifying published artifacts
 
 Released binaries and container images carry signed provenance (cosign keyless),


### PR DESCRIPTION
Adds a short `Security practices` section to SECURITY.md summarizing what runs to keep the project secure (govulncheck, CodeQL extended + gosec, Trivy + non-root images, SHA-pinned Actions + least-privilege tokens + master gated on CI, Dependabot cooldown). Links to the existing artifact-verification section.

Kept deliberately brief, no implementation detail. Every point reflects what's actually in the repo.