### PR TITLE
fix(ci): scope workflow write permissions to the job (Scorecard TokenPermissions)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   GHCR_PACKAGE: slurm_exporter
@@ -47,6 +46,9 @@ env:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # delete dated GHCR tag versions
     steps:
       - name: Resolve dry-run mode
         id: mode

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -49,8 +49,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 env:
   GHCR_REPO: ghcr.io/sckyzo/slurm_exporter
@@ -59,6 +57,10 @@ env:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push images to GHCR
+      id-token: write # keyless cosign signing
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Resolves the OpenSSF Scorecard **Token-Permissions (High)** findings: `docker-refresh`, `docker-cleanup` and `dev-release` granted `write` at the top level (or had no top-level block). Now top-level is `contents: read` and write scopes live on the job that needs them (least privilege).

Verified: actionlint clean, zizmor 0 findings, `act -l` parses all three.

Closes #89