### PR TITLE
fix(docker): pin base images by digest (Scorecard PinnedDependencies)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 # See docker/README.md for compose examples and troubleshooting.
 
-FROM ubuntu:26.04
+FROM ubuntu:26.04@sha256:e153663f92c94118ff22a5dc397b59b351ffd695480566debb5850e017e5937a
 
 # slurm-client provides sinfo/squeue/sdiag/scontrol/sshare/sacct.
 # Ubuntu 26.04 ships Slurm 25.11.x, compatible with slurmctld 23.x → 26.x in

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -40,7 +40,7 @@
 # Extract libmunge from a Debian 13 stage. The shell `cp` consolidates the
 # arch-specific Debian multi-arch path (x86_64-linux-gnu vs aarch64-linux-gnu)
 # into a fixed /libs/ directory — the next COPY then doesn't need TARGETARCH.
-FROM debian:13-slim AS munge-extractor
+FROM debian:13-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS munge-extractor
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libmunge2 \
@@ -51,7 +51,7 @@ RUN apt-get update && \
 
 # ---
 
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985
 
 # libmunge is needed by the host-mounted Slurm binaries (sinfo, squeue,
 # scontrol, …) which are dynamically linked against it. Shipping it here

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -7,7 +7,7 @@
 # Built locally on first use via `make tools-image`; rebuilds are
 # incremental thanks to the layer cache.
 
-FROM golang:1.26.4-alpine
+FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648
 
 # shellcheck  → used by actionlint to lint `run:` shell blocks
 # zizmor      → static analysis (security) for GitHub Actions workflows


### PR DESCRIPTION
Pin every Docker base image to its multi-arch manifest digest (tag kept for readability + Dependabot tracking): ubuntu:26.04, debian:13-slim, distroless cc-debian12:nonroot, golang:1.26.4-alpine.

Resolves the Scorecard Pinned-Dependencies findings on the Dockerfiles. Dependabot keeps the digests current.

Verified: all three images build and run `--version` with the pinned digests.

Closes #91