### PR TITLE
feat(ci): run lint + test on every PR (Definition of Done gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# CI — lint + test on every pull request and on push to master.
+#
+# This is the gate that the CONTRIBUTING.md "Definition of Done" (steps 1-3)
+# expects on every change. The release workflow only runs on tags, so without
+# this nothing ran the test suite or the linter on PRs. Integration tests
+# (the Slurm test cluster in scripts/testing/) remain a manual step.
+
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.4'
+          cache: false
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: latest
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.4'
+          cache: false
+      - name: Build
+        run: go build -v ./...
+      - name: Test (race + coverage)
+        run: go test -race -count=1 -coverprofile=coverage.out ./...


### PR DESCRIPTION
Adds `ci.yml` running build + golangci-lint + race test on every PR and push to master. Closes the gap where PRs could merge on `govulncheck` alone (lint/test only ran on tags).

After merge, `lint` and `test` will be added to the required status checks. Integration tests (`scripts/testing/`) stay manual per CONTRIBUTING.md.

Actions pinned by SHA; `persist-credentials: false`; `contents: read`. Validated: actionlint clean, zizmor 0 findings, act -l.

Closes #93