### PR TITLE
chore(ci): add deadcode to the toolchain (make deadcode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,14 @@ osv: tools-image
 	@echo "Running osv-scanner (containerised)"
 	@$(IN_TOOLS) -c 'osv-scanner scan source --lockfile go.mod'
 
+# deadcode — unreachable Go functions (reachability from main + tests). Fails if
+# any dead code is found. Not yet part of `check`: there is known dead code to
+# remove first; it joins `check` once the codebase is clean.
+.PHONY: deadcode
+deadcode: tools-image
+	@echo "Running deadcode (containerised)"
+	@$(IN_TOOLS) -c 'out=$$(deadcode -test ./...); if [ -n "$$out" ]; then echo "$$out"; echo "dead code found"; exit 1; fi; echo "no dead code"'
+
 # Full pre-commit / pre-release verification — mirrors what CI runs.
 .PHONY: check
 check: vet lint test vuln actionlint zizmor

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -26,6 +26,7 @@ RUN go install github.com/fzipp/gocyclo/cmd/gocyclo@latest \
  && go install github.com/rhysd/actionlint/cmd/actionlint@latest \
  && go install github.com/zricethezav/gitleaks/v8@latest \
  && go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest \
+ && go install golang.org/x/tools/cmd/deadcode@latest \
  && go clean -cache -modcache -testcache
 
 # All tools land in /go/bin which is already on $PATH.


### PR DESCRIPTION
Adds `golang.org/x/tools/cmd/deadcode` to the tools image + a `make deadcode` target (`deadcode -test ./...`, fails on findings).

Not wired into `make check` yet (known dead cluster in nodes.go to remove first; it joins check after that). Validated: `make deadcode` runs and correctly reports the 3 unreachable funcs.

Closes #97