### PR TITLE
chore(test): remove orphaned legacy GPU fixtures (slurm 17.11.2)

### DIFF
--- a/test_data/_slurm-17.11.2/sacct_gpus_allocated.txt
+++ b/test_data/_slurm-17.11.2/sacct_gpus_allocated.txt
@@ -1,5 +1,0 @@
-gpu:4
-gpu:7
-gpu:1
-gpu:1
-gpu:1

--- a/test_data/_slurm-17.11.2/sinfo_gpus_total.txt
+++ b/test_data/_slurm-17.11.2/sinfo_gpus_total.txt
@@ -1,2 +1,0 @@
-xantipa gpu:8
-xantipa2 gpu:8


### PR DESCRIPTION
## What

Removes `test_data/_slurm-17.11.2/` (`sacct_gpus_allocated.txt`,
`sinfo_gpus_total.txt`) — two legacy GPU fixtures that no test loads.

Version-specific GPU tests discover fixtures with
`filepath.Glob("test_data/slurm-*")` (`gpus_test.go`, `partitions_test.go`).
The leading underscore in `_slurm-17.11.2` excludes the directory from that
glob, so these files are never read.

## Validation

- No Go reference to the directory (`grep`)
- `go test ./...` passes unchanged after removal

Closes #101
