### PR TITLE
chore(release): migrate signing to cosign v3 (cosign-installer v4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Log in to GHCR

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,13 +63,12 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--yes"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
+      - "--yes"
     artifacts: checksum
     output: true
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Every published artifact carries verifiable provenance and is scanned for known 
     --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
-- 🧾 **Signed release checksums** — `slurm_exporter_checksums.txt` ships with `.pem` (certificate) and `.sig` (signature) for offline verification of every release archive.
+- 🧾 **Signed release checksums** — `slurm_exporter_checksums.txt` ships with a `.sigstore.json` Sigstore bundle (certificate + signature) for offline verification of every release archive. Verify with `cosign verify-blob --bundle slurm_exporter_checksums.txt.sigstore.json slurm_exporter_checksums.txt`.
 - 📦 **CycloneDX SBOMs** — one `*.sbom.json` per release archive lists every Go module compiled in (with versions and PURLs). Suitable for Dependency-Track, Anchore Enterprise, and similar.
 - 🛡️ **Vulnerability scanning** — Trivy scans both Docker variants on every PR that touches `Dockerfile*`, `go.mod`, or `go.sum`. PRs are blocked on HIGH/CRITICAL CVEs that have an upstream fix. A weekly cron re-scans the published images so post-release CVEs surface as workflow failures.
 - 👤 **Non-root by default** — the standard image runs as `slurmexporter` (uid 9341, gid `munge`); the minimal image runs as `nonroot` (uid 65532). Example compose drops all capabilities, mounts read-only, `no-new-privileges`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -159,8 +159,17 @@ cosign verify sckyzo/slurm-exporter:latest \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-The release checksums file is signed the same way (`*.pem` + `*.sig`
-alongside `slurm_exporter_checksums.txt` on the GitHub release).
+The release checksums file is signed the same way. A Sigstore bundle
+(`slurm_exporter_checksums.txt.sigstore.json`) ships alongside
+`slurm_exporter_checksums.txt` on the GitHub release:
+
+```bash
+cosign verify-blob \
+  --bundle slurm_exporter_checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/SckyzO/slurm_exporter/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  slurm_exporter_checksums.txt
+```
 
 ### Software Bill of Materials
 


### PR DESCRIPTION
## Summary

Migrate the release pipeline to cosign v3 (installed by `cosign-installer` v4).
cosign v3 makes `--bundle` required for `sign-blob` and removes
`--output-certificate` / `--output-signature`, so the current `signs` block in
`.goreleaser.yaml` would break on the next release.

## Changes

- `.goreleaser.yaml` `signs`: switch the checksum blob signature to the unified
  Sigstore bundle (`${artifact}.sigstore.json`) via `--bundle`, dropping the
  `.pem` / `.sig` outputs.
- `.github/workflows/release.yml`: bump `sigstore/cosign-installer` 3.9.1 → 4.1.2
  (SHA-pinned).
- Docs (`README.md`, `docker/README.md`): update the offline checksum
  verification recipe to `cosign verify-blob --bundle ...sigstore.json`.

`docker_signs` (image manifest signing) and `docker-refresh.yml` use
`cosign sign` / `cosign verify` on OCI manifests, which are unaffected by the
`sign-blob` bundle change. `dev-release.yml` runs goreleaser in `--snapshot`
mode (signing skipped, cosign not installed), so it is unaffected.

## Validation

Keyless signing only runs on a tag push, so this is validated by cutting a
pre-release tag (`v1.8.4-rc1`, auto-detected as prerelease — floating tags are
skipped) and confirming:

1. the release workflow signs the checksum file with cosign v3,
2. `cosign verify-blob --bundle slurm_exporter_checksums.txt.sigstore.json ...`
   succeeds against the published bundle.

Closes #81

## References

- cosign v3 breaking changes: https://github.com/sigstore/cosign/releases/tag/v3.0.0
- GoReleaser migration guide: https://goreleaser.com/blog/cosign-v3/
