### PR TITLE
docs: bump documented Go toolchain to 1.26.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing!
 
 ### Prerequisites
 
-- Go 1.26+ (toolchain 1.26.3 recommended)
+- Go 1.26+ (toolchain 1.26.4 recommended)
 - Docker + Docker Compose v2
 - [golangci-lint](https://golangci-lint.run/) v2.11.3+
 - A clone of [giovtorres/slurm-docker-cluster](https://github.com/giovtorres/slurm-docker-cluster) for integration tests

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Every published artifact carries verifiable provenance and is scanned for known 
 - 🛡️ **Vulnerability scanning** — Trivy scans both Docker variants on every PR that touches `Dockerfile*`, `go.mod`, or `go.sum`. PRs are blocked on HIGH/CRITICAL CVEs that have an upstream fix. A weekly cron re-scans the published images so post-release CVEs surface as workflow failures.
 - 👤 **Non-root by default** — the standard image runs as `slurmexporter` (uid 9341, gid `munge`); the minimal image runs as `nonroot` (uid 65532). Example compose drops all capabilities, mounts read-only, `no-new-privileges`.
 - 🪞 **Distroless variant** — the `:latest-minimal` tag runs on `gcr.io/distroless/cc-debian12:nonroot`: no shell, no package manager, no userland beyond the dynamic loader and libstdc++. Smallest viable attack surface for a binary that has to `dlopen` libmunge at runtime.
-- 🔁 **Reproducible build chain** — binaries built with pinned Go 1.26.3 in CI; Docker images from pinned `ubuntu:26.04` / `gcr.io/distroless/cc-debian12:nonroot` / `debian:13-slim` (libmunge extractor). All version bumps go through Dependabot PRs.
+- 🔁 **Reproducible build chain** — binaries built with pinned Go 1.26.4 in CI; Docker images from pinned `ubuntu:26.04` / `gcr.io/distroless/cc-debian12:nonroot` / `debian:13-slim` (libmunge extractor). All version bumps go through Dependabot PRs.
 
 Detailed verification recipes (cosign for blobs, SBOM inspection, image labels) in [`docker/README.md`](docker/README.md#supply-chain).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ This project requires access to a node with the Slurm CLI (`sinfo`, `squeue`, `s
 
 ### Prerequisites
 
-- [Go](https://golang.org/dl/) (version 1.26 or higher, toolchain 1.26.3 recommended)
+- [Go](https://golang.org/dl/) (version 1.26 or higher, toolchain 1.26.4 recommended)
 - Slurm CLI tools available in your `$PATH`
 
 ### Building from Source


### PR DESCRIPTION
CI and the tools image pin Go 1.26.4 (`release.yml`/`ci.yml`, `scripts/docker/tools/Dockerfile`). This aligns the three prose references that still said 1.26.3:

- `README.md` (reproducible build chain)
- `CONTRIBUTING.md` (prerequisites)
- `docs/development.md` (prerequisites)

Docs-only, no behavior change.