### PR TITLE
fix(ci): pin goreleaser to 2.15.4 (dockers_v2 layout change in 2.16)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -42,7 +42,8 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
-          version: '~> v2'
+          # Pinned to match the release workflow and keep dev builds reproducible.
+          version: '2.15.4'
           args: release --config .goreleaser.dev.yaml --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,10 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
-          version: '~> v2'
+          # Pinned: dockers_v2 changed its build-context layout in goreleaser
+          # 2.16 (artifacts moved under $TARGETPLATFORM/), which breaks the
+          # Dockerfile COPY. 2.15.4 is the version that shipped v1.8.3.
+          version: '2.15.4'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The release and dev-release workflows pinned GoReleaser loosely with
`version: '~> v2'`, which floats to the latest v2 release. GoReleaser 2.16.0
graduated `dockers_v2` to GA and changed its build-context layout: per-platform
artifacts now live under `$TARGETPLATFORM/` instead of the context root. Our
Dockerfiles do `COPY slurm_exporter ...`, so the build now fails:

```
COPY slurm_exporter /usr/local/bin/slurm_exporter: "/slurm_exporter": not found
ERROR: failed to build: failed to solve: ... "/slurm_exporter": not found
```

v1.8.3 shipped on GoReleaser 2.15.4 and built fine; the only thing that changed
is the floating version resolving to 2.16.0.

## Fix

Pin GoReleaser to `2.15.4` (the version that shipped v1.8.3) in both
`release.yml` and `dev-release.yml`. A release pipeline must be reproducible
rather than depend on whatever v2.x is latest at tag time.

Migrating to the GoReleaser 2.16 `dockers_v2` GA layout (adapting the
Dockerfiles to `$TARGETPLATFORM/`) is a possible follow-up, tracked separately.

## Validation

- actionlint + zizmor clean
- Full validation by re-cutting the `v1.8.4-rc1` pre-release tag and confirming
  the Docker build, image signing, and the cosign v3 checksum bundle all succeed.
