### PR TITLE
fix(docker): copy binary from $TARGETPLATFORM for dockers_v2 layout

### DIFF
--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -18,8 +18,8 @@
 # Why per-arch (and not one buildx --platform amd64,arm64 over a single
 # binary): the binary is built on the runner. Building it once (natively
 # amd64) and fanning it out across both platforms would copy the SAME amd64
-# binary into the arm64 image — both Dockerfiles `COPY slurm_exporter` from a
-# single build context — yielding an exec-format-error image on arm64. So we
+# binary into the arm64 image — both Dockerfiles `COPY $TARGETPLATFORM/slurm_exporter`
+# from the build context — yielding an exec-format-error image on arm64. So we
 # cross-compile each arch, build that arch's image on its own, and join them.
 # The smoke step (`docker run --platform linux/<arch> … --version`) is the
 # guard that fails the run if an arch ever ships the wrong ELF again.
@@ -164,7 +164,7 @@ jobs:
               # single-platform manifest so imagetools can join them cleanly.
               for arch in amd64 arm64; do
                 CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
-                  go build -ldflags "$ldflags" -o ./slurm_exporter ./cmd/slurm_exporter
+                  go build -ldflags "$ldflags" -o "./linux/${arch}/slurm_exporter" ./cmd/slurm_exporter
 
                 docker buildx build \
                   --platform "linux/${arch}" \
@@ -201,7 +201,7 @@ jobs:
               done
             done
 
-            rm -f ./slurm_exporter
+            rm -rf ./linux
             echo "::endgroup::"
           done
 

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -8,9 +8,10 @@
 # Also runs weekly on a cron against the published images so we catch new
 # CVEs reported after release.
 #
-# The Dockerfiles are single-stage and expect ./slurm_exporter to be present
-# in the build context — so this workflow compiles the binary first, mirroring
-# what GoReleaser does for releases and `make docker-build` for local dev.
+# The Dockerfiles COPY the binary from $TARGETPLATFORM/slurm_exporter (the
+# GoReleaser dockers_v2 layout), so this workflow compiles the binary into
+# ./linux/amd64/ and builds with platforms: linux/amd64, mirroring what
+# GoReleaser does for releases and `make docker-build` for local dev.
 
 name: Trivy scan
 
@@ -48,12 +49,13 @@ jobs:
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
             golang:1.26.4-alpine \
-            go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
+            go build -ldflags "-s -w" -o ./linux/amd64/slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64
           push: false
           load: true
           tags: slurm_exporter:scan
@@ -85,12 +87,13 @@ jobs:
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
             golang:1.26.4-alpine \
-            go build -ldflags "-s -w" -o ./slurm_exporter ./cmd/slurm_exporter
+            go build -ldflags "-s -w" -o ./linux/amd64/slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.minimal
+          platforms: linux/amd64
           push: false
           load: true
           tags: slurm_exporter:scan-minimal

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,12 @@ go/
 *.tar.gz*
 *.swp
 
-# Pre-compiled binary staged at the repo root by `make docker-build`
-# (single-stage Dockerfiles expect ./slurm_exporter in the context). The
-# Makefile rm's it after each build but git should never see it either way.
+# Binary staged by `make docker-build` under ./linux/<arch>/ (the
+# $TARGETPLATFORM layout the Dockerfiles COPY from). The Makefile rm's it
+# after each build but git should never see it either way. /slurm_exporter
+# is the legacy path, kept ignored for safety.
 /slurm_exporter
+/linux/
 
 # Dev/test scripts (environment-specific, not committed)
 scripts/dev/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,10 @@ RUN apt-get update && \
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin \
         --uid 9341 --gid munge slurmexporter
 
-COPY slurm_exporter /usr/local/bin/slurm_exporter
+# GoReleaser dockers_v2 stages per-platform artifacts under $TARGETPLATFORM/
+# (e.g. linux/amd64/slurm_exporter). TARGETPLATFORM is provided by BuildKit.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/slurm_exporter /usr/local/bin/slurm_exporter
 
 USER slurmexporter
 

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -63,7 +63,10 @@ FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be5
 COPY --from=munge-extractor /libs/libmunge.so.2     /usr/lib/libmunge.so.2
 COPY --from=munge-extractor /libs/libmunge.so.2.0.0 /usr/lib/libmunge.so.2.0.0
 
-COPY slurm_exporter /usr/local/bin/slurm_exporter
+# GoReleaser dockers_v2 stages per-platform artifacts under $TARGETPLATFORM/
+# (e.g. linux/amd64/slurm_exporter). TARGETPLATFORM is provided by BuildKit.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/slurm_exporter /usr/local/bin/slurm_exporter
 
 EXPOSE 9341
 

--- a/Makefile
+++ b/Makefile
@@ -201,16 +201,17 @@ DOCKER_BUILD_ARGS = \
 	--build-arg BUILD_USER="$$(git config user.email)" \
 	--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Both image variants are single-stage and expect ./slurm_exporter to be
-# present in the build context. We compile the binary first (mirrors what
-# GoReleaser does for releases), copy it next to the Dockerfile, build, and
-# clean up — never commit ./slurm_exporter to git (it's in .gitignore as
-# the binary at repo root).
+# Both Dockerfiles copy the binary from $TARGETPLATFORM/slurm_exporter, the
+# layout GoReleaser's dockers_v2 stages for releases. We mirror that locally:
+# compile into ./linux/<arch>/slurm_exporter, build with --platform so
+# BuildKit sets TARGETPLATFORM to the same value, then clean up. Never commit
+# ./linux/ to git (the binary is gitignored at repo root).
 #
-# The same ldflags that go into bin/slurm_exporter for `make build` go
-# into ./slurm_exporter for `make docker-build`, so `docker run … --version`
-# reports the right metadata. The Dockerfile's build-args populate the
-# OCI labels on top — same information, different surface.
+# The same ldflags that go into bin/slurm_exporter for `make build` go into
+# the docker binary, so `docker run … --version` reports the right metadata.
+# The Dockerfile's build-args populate the OCI labels on top — same
+# information, different surface.
+DOCKER_PLATFORM := linux/$(shell go env GOARCH)
 
 # ldflags pulled from the build target so both paths stay in sync.
 DOCKER_GO_LDFLAGS = -s -w \
@@ -223,17 +224,17 @@ DOCKER_GO_LDFLAGS = -s -w \
 .PHONY: docker-build
 docker-build:
 	@echo "Building $(DOCKER_REF)"
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./slurm_exporter ./cmd/slurm_exporter
-	docker build $(DOCKER_BUILD_ARGS) -t $(DOCKER_REF) .
-	@rm -f ./slurm_exporter
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./$(DOCKER_PLATFORM)/slurm_exporter ./cmd/slurm_exporter
+	docker build $(DOCKER_BUILD_ARGS) --platform $(DOCKER_PLATFORM) -t $(DOCKER_REF) .
+	@rm -rf ./linux
 	@echo "✓ $(DOCKER_REF)"
 
 .PHONY: docker-build-minimal
 docker-build-minimal:
 	@echo "Building $(DOCKER_REF_MINIMAL)"
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./slurm_exporter ./cmd/slurm_exporter
-	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile.minimal -t $(DOCKER_REF_MINIMAL) .
-	@rm -f ./slurm_exporter
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(DOCKER_GO_LDFLAGS)" -o ./$(DOCKER_PLATFORM)/slurm_exporter ./cmd/slurm_exporter
+	docker build $(DOCKER_BUILD_ARGS) --platform $(DOCKER_PLATFORM) -f Dockerfile.minimal -t $(DOCKER_REF_MINIMAL) .
+	@rm -rf ./linux
 	@echo "✓ $(DOCKER_REF_MINIMAL)"
 
 .PHONY: docker-build-all


### PR DESCRIPTION
## Problem

The Docker images fail to build during a release:

```
COPY slurm_exporter /usr/local/bin/slurm_exporter: "/slurm_exporter": not found
ERROR: failed to build: ... "/slurm_exporter": not found
```

Root cause: #50 migrated the release config from `dockers` to `dockers_v2`
*after* v1.8.3 shipped, so this layout has never been exercised by a real
release. `dockers_v2` stages per-platform artifacts under `$TARGETPLATFORM/`
(e.g. `linux/amd64/slurm_exporter`), but both Dockerfiles still `COPY
slurm_exporter` from the context root. v1.8.3 built fine because it used the
old `dockers` config (binary at context root).

This is independent of the GoReleaser version: the failure reproduces on both
2.15.4 and 2.16.0.

## Fix

- `Dockerfile` / `Dockerfile.minimal`: declare `ARG TARGETPLATFORM` and
  `COPY $TARGETPLATFORM/slurm_exporter ...`, per the GoReleaser dockers_v2
  contract.
- `make docker-build` / `docker-build-minimal`: stage the binary under
  `./linux/<arch>/` and build with `--platform` so BuildKit sets
  `TARGETPLATFORM` to the matching value; clean up `./linux/` afterwards.
- `.gitignore`: ignore `./linux/`.

## Validation

- `make docker-build` and `make docker-build-minimal` build locally; the
  resulting image runs and `--version` reports the correct metadata.
- Full multi-arch validation by re-cutting `v1.8.4-rc1` and confirming the
  release Docker build (linux/amd64 + linux/arm64) succeeds.

## Note

The cosign v3 signing migration (#103) is already validated by the rc1 run: the
checksum bundle `slurm_exporter_checksums.txt.sigstore.json` was produced and
GoReleaser's own `cosign verify-blob --bundle` self-check passed. The release
only failed afterwards, at this Docker build step.
