### PR TITLE
chore(ci): bump pinned Go toolchain 1.26.4 → 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
 
       # Populate the build metadata consumed by .goreleaser.dev.yaml

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - run: make test
 
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: false
       - name: Set build environment variables
         run: |

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build Go binary in a Go container
-        # Compile inside golang:1.26.4-alpine to pin the stdlib version
+        # Compile inside golang:1.26.5-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
         # cached older patch version; the container guarantees what Trivy
         # will see.
@@ -48,7 +48,7 @@ jobs:
             -e CGO_ENABLED=0 \
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
-            golang:1.26.4-alpine \
+            golang:1.26.5-alpine \
             go build -ldflags "-s -w" -o ./linux/amd64/slurm_exporter ./cmd/slurm_exporter
       - name: Build standard image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -75,7 +75,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build Go binary in a Go container
-        # Compile inside golang:1.26.4-alpine to pin the stdlib version
+        # Compile inside golang:1.26.5-alpine to pin the stdlib version
         # embedded in the binary. setup-go + host build can drift to a
         # cached older patch version; the container guarantees what Trivy
         # will see.
@@ -86,7 +86,7 @@ jobs:
             -e CGO_ENABLED=0 \
             -e GOOS=linux \
             -e GOTOOLCHAIN=local \
-            golang:1.26.4-alpine \
+            golang:1.26.5-alpine \
             go build -ldflags "-s -w" -o ./linux/amd64/slurm_exporter ./cmd/slurm_exporter
       - name: Build minimal image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -7,7 +7,7 @@
 # Built locally on first use via `make tools-image`; rebuilds are
 # incremental thanks to the layer cache.
 
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
 
 # shellcheck  → used by actionlint to lint `run:` shell blocks
 # zizmor      → static analysis (security) for GitHub Actions workflows


### PR DESCRIPTION
## Why

`master` (and therefore every open PR's CI, including Dependabot #123) is red on two **Go stdlib** vulnerabilities, both fixed in **go1.26.5**:

| Gate | ID | Detail | Fixed in |
|------|----|--------|----------|
| `govulncheck` | GO-2026-5856 | `crypto/tls` ECH privacy leak — **reachable** (trace via `web.ListenAndServe`) | go1.26.5 |
| `trivy` (`scan-standard` + `scan-minimal`) | CVE-2026-39822 | `os.Root` symlink following | 1.26.5 |

The pinned toolchain was `1.26.4` in every workflow. Same maintenance pattern as the earlier `go1.26.4` bump in #70.

## Changes

- `go-version: '1.26.4'` → `'1.26.5'` in `ci.yml` (×2), `release.yml` (×3), `dev-release.yml`, `docker-refresh.yml`, `govulncheck.yml`
- `golang:1.26.4-alpine` → `golang:1.26.5-alpine` in `trivy-scan.yml` (build containers + comments)
- `tools/Dockerfile` base: `golang:1.26.5-alpine@sha256:0178a641…5fb2` (new digest, verified to resolve to `go1.26.5`)
- `go.mod` language floor (`go 1.26.0`) intentionally **unchanged** — only the pinned toolchain moves.

## Verification

`govulncheck ./...` run inside `golang:1.26.5-alpine` exits **0** (0 reachable vulnerabilities). CI on this PR is the authoritative gate.