### PR TITLE
chore(ci): pin govulncheck to v1.6.0

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -32,6 +32,9 @@ jobs:
           go-version: '1.26.5'
           cache: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned to a tagged release for reproducible CI (Scorecard
+        # PinnedDependencies). The vuln database is fetched at runtime, so
+        # pinning the tool binary does not reduce coverage. Bump deliberately.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
       - name: Run govulncheck
         run: govulncheck ./...


### PR DESCRIPTION
Pins `go install golang.org/x/vuln/cmd/govulncheck@latest` → `@v1.6.0` in `govulncheck.yml`.

**Why:** Scorecard `PinnedDependenciesID` (alert #29, *goCommand not pinned*) + reproducible CI. The vuln database is fetched at runtime, so pinning the tool binary does not reduce coverage.

**Scope:** CI workflow only. The `@latest` in the local `scripts/docker/tools` dev image is intentionally left floating (dev-only, not shipped) — its Scorecard alerts were triaged as won't-fix.