### PR TITLE
docs: sync v1.9 roadmap with open issues/PRs + refresh Go toolchain refs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing!
 
 ### Prerequisites
 
-- Go 1.26+ (toolchain 1.26.4 recommended)
+- Go 1.26+ (toolchain 1.26.5 recommended)
 - Docker + Docker Compose v2
 - [golangci-lint](https://golangci-lint.run/) v2.11.3+
 - A clone of [giovtorres/slurm-docker-cluster](https://github.com/giovtorres/slurm-docker-cluster) for integration tests

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Every published artifact carries verifiable provenance and is scanned for known 
 - 🛡️ **Vulnerability scanning** — Trivy scans both Docker variants on every PR that touches `Dockerfile*`, `go.mod`, or `go.sum`. PRs are blocked on HIGH/CRITICAL CVEs that have an upstream fix. A weekly cron re-scans the published images so post-release CVEs surface as workflow failures.
 - 👤 **Non-root by default** — the standard image runs as `slurmexporter` (uid 9341, gid `munge`); the minimal image runs as `nonroot` (uid 65532). Example compose drops all capabilities, mounts read-only, `no-new-privileges`.
 - 🪞 **Distroless variant** — the `:latest-minimal` tag runs on `gcr.io/distroless/cc-debian12:nonroot`: no shell, no package manager, no userland beyond the dynamic loader and libstdc++. Smallest viable attack surface for a binary that has to `dlopen` libmunge at runtime.
-- 🔁 **Reproducible build chain** — binaries built with pinned Go 1.26.4 in CI; Docker images from pinned `ubuntu:26.04` / `gcr.io/distroless/cc-debian12:nonroot` / `debian:13-slim` (libmunge extractor). All version bumps go through Dependabot PRs.
+- 🔁 **Reproducible build chain** — binaries built with pinned Go 1.26.5 in CI; Docker images from pinned `ubuntu:26.04` / `gcr.io/distroless/cc-debian12:nonroot` / `debian:13-slim` (libmunge extractor). All version bumps go through Dependabot PRs.
 
 Detailed verification recipes (cosign for blobs, SBOM inspection, image labels) in [`docker/README.md`](docker/README.md#supply-chain).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ This project requires access to a node with the Slurm CLI (`sinfo`, `squeue`, `s
 
 ### Prerequisites
 
-- [Go](https://golang.org/dl/) (version 1.26 or higher, toolchain 1.26.4 recommended)
+- [Go](https://golang.org/dl/) (version 1.26 or higher, toolchain 1.26.5 recommended)
 - Slurm CLI tools available in your `$PATH`
 
 ### Building from Source

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,12 @@ in PR/issue comments, and internal observations during recent releases.
 
 ## v1.9
 
+> Tracked in [#61](https://github.com/SckyzO/slurm_exporter/issues/61) — the
+> authoritative scope and per-PR breakdown for this milestone. Each item below
+> maps to one atomic PR against `master`. v1.9 is cut once the public-feature
+> checklist there is complete; internal-hygiene items are welcome but slide to
+> v1.9.1 if they are not ready in time.
+
 ### Commitments made publicly
 
 - **Per-state job counts in `sacct_efficiency`** *(answers [#27](https://github.com/SckyzO/slurm_exporter/issues/27))*
@@ -30,11 +36,18 @@ in PR/issue comments, and internal observations during recent releases.
   `--collector.node.gres-types` filter for cardinality control on
   multi-type / MIG clusters. Includes a new dashboard panel.
 
+- **Dashboard uniformity — `$instance`** *(prerequisite for multi-cluster, tracked in [#61](https://github.com/SckyzO/slurm_exporter/issues/61))*
+  Only `04-slurm-usage.json` currently carries an `$instance` template
+  variable; the other 9 dashboards expose just a `${datasource}` picker and
+  query bare metric names. Add a consistent `$instance` variable to all 10 so
+  they behave uniformly — and to give the `$cluster` work below one place to
+  hook into.
+
 - **Multi-cluster dashboards** *(promised in the [issue #10 close-out](https://github.com/SckyzO/slurm_exporter/issues/10#issuecomment-4422385540))*
-  Add a `$cluster` template variable to the in-repo dashboards. Default
-  `allValue: ".*"` so single-cluster users see no change. Document the
-  Prometheus relabel patterns (single Prometheus, Thanos/Mimir/Cortex,
-  federation).
+  Add a `$cluster` template variable to all 10 in-repo dashboards (none has
+  one today). Default `allValue: ".*"` so single-cluster users see no change.
+  Document the `external_labels: {cluster: ...}` Prometheus pattern and the
+  Thanos / Mimir / Cortex equivalents.
 
 ### Internal hygiene (welcome but not promised)
 
@@ -45,6 +58,15 @@ in PR/issue comments, and internal observations during recent releases.
   consolidate the three `sinfo` calls in `internal/collector/gpus.go`
   into a single atomic snapshot. The v1.8.2 clamp on `slurm_gpus_other`
   becomes redundant once this lands.
+- **`Makefile` container-first cleanup** *([#114](https://github.com/SckyzO/slurm_exporter/issues/114))*
+  The "Docker-only, no host Go toolchain" contract only half-holds — `build`,
+  `setup`, `run`, `clean` still use the host `go`. Also a stale `GO_VERSION`
+  fallback (`1.22.2` at `Makefile:6`, vs `go 1.26.0` in `go.mod`) and a stale
+  slurm-client comment (`23.11` at `Makefile:186`, vs the `25.11` the
+  Dockerfile actually ships). Either containerise `build` or soften the claim,
+  and derive the Go version from a single source. Splittable: the
+  comment/version fixes can land ahead of the larger containerise-`build`
+  change.
 
 ---
 
@@ -55,6 +77,21 @@ in PR/issue comments, and internal observations during recent releases.
   `sacct_efficiency` exposes the per-state counts (see v1.9). Today
   the panel uses queue-collector metrics that stay at zero because
   `squeue` doesn't surface terminal states.
+
+---
+
+## Requested, not yet scheduled
+
+Open feature requests that are not committed to a milestone yet — surfaced here
+so they are visible during v1.9 planning.
+
+- **Job wait-time metrics** *([#118](https://github.com/SckyzO/slurm_exporter/issues/118))*
+  Median / histogram wait times (submit → start) broken down by cluster,
+  partition, account and user, for capacity planning and user-experience
+  trends. Feasible from `squeue -O submittime,starttime` (running) or
+  `sacct -X -o submit,start` (running + completed). Needs a cardinality and
+  collector-cost decision (histogram buckets, whether it rides on the opt-in
+  `sacct_efficiency` path) before it can be scoped into a release.
 
 ---
 


### PR DESCRIPTION
Docs-only. Two atomic commits.

## 1. `docs(roadmap): reconcile v1.9 with open issues and PRs`
Reconciles `docs/roadmap.md` with the current open backlog and the v1.9 tracking issue #61:

- Links **#61** as the authoritative scope / per-PR breakdown for v1.9.
- Adds the missing **`$instance` dashboard uniformity** feature (4th public item in #61). **Corrected against source:** #61 claimed *"9 of 10 dashboards have no template variable at all"* — in fact all 10 carry `${datasource}`, only `04-slurm-usage.json` has `$instance`, and none has `$cluster`. The roadmap now states the verified reality (I also fixed #61's body).
- Adds **#114** (Makefile container-first cleanup) to Internal hygiene.
- Adds a **"Requested, not yet scheduled"** section for **#118** (job wait-time metrics) — explicitly *not* scoped into v1.9.

## 2. `docs: bump documented Go toolchain 1.26.4 → 1.26.5`
Follow-up to #124 (which pinned CI/build to go1.26.5). Three docs still advertised 1.26.4: `CONTRIBUTING.md`, `docs/development.md`, `README.md` (reproducible-build-chain bullet).

## Validation
Docs-only change (no `internal/collector/`, `cmd/`, dashboards, or scripts touched) → per CONTRIBUTING "Definition of Done" the integration cluster is not required. CI lint/test/govulncheck are the gate.