### PR TITLE
fix(ci): stop invoking host `go` on every make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,18 @@ DOCKER_BUILD_ARGS = \
 # the docker binary, so `docker run … --version` reports the right metadata.
 # The Dockerfile's build-args populate the OCI labels on top — same
 # information, different surface.
-DOCKER_PLATFORM := linux/$(shell go env GOARCH)
+# Host arch in Go nomenclature, which is what BuildKit normalises TARGETPLATFORM
+# to — the binary path and the --platform flag must agree with the Dockerfile's
+# `COPY $TARGETPLATFORM/slurm_exporter`.
+#
+# Lazily expanded (`=`, not `:=`) on purpose: the rest of this Makefile runs
+# containerised and needs Docker only, so nothing should spawn `go` on the host
+# unless a docker-build* target actually runs.
+#
+# Fallback for hosts without a Go toolchain: uname. Its arch names differ from
+# Go's, so map the two we ship for; anything else passes through unchanged and
+# will surface as an explicit docker error rather than a silent empty platform.
+DOCKER_PLATFORM = linux/$(shell go env GOARCH 2>/dev/null || uname -m | sed -e 's/^x86_64$$/amd64/' -e 's/^aarch64$$/arm64/')
 
 # ldflags pulled from the build target so both paths stay in sync.
 DOCKER_GO_LDFLAGS = -s -w \


### PR DESCRIPTION
Follow-up spotted while running `make check` on a Docker-only host.

## Problem

`DOCKER_PLATFORM` used `:=`, so `$(shell go env GOARCH)` was evaluated at
Makefile *parse* time — on every `make` invocation, including the fully
containerised `test` / `lint` / `vet` / `check` targets. Those are documented
right above as needing Docker only:

> The only host requirement is Docker — no Go toolchain needed.

On a host without Go:

1. Every `make <anything>` printed `go: command not found` on stderr.
2. `GOARCH` expanded to nothing, leaving `DOCKER_PLATFORM = linux/`, so
   `docker-build` compiled to `./linux//slurm_exporter` and passed
   `--platform linux/` to `docker build`.

## Fix

Lazy expansion (`=` instead of `:=`) so `go` is only spawned if a
`docker-build*` target actually runs, plus a `uname` fallback for Go-less
hosts.

The fallback deliberately normalises to Go arch names. BuildKit normalises
`TARGETPLATFORM`, so a raw `uname -m` would pass `--platform linux/x86_64`,
BuildKit would set `TARGETPLATFORM=linux/amd64`, and the Dockerfile's
`COPY $TARGETPLATFORM/slurm_exporter` would look for a path the build never
wrote — a silent breakage at the COPY step. Unmapped architectures pass
through unchanged so docker fails loudly instead.

## Verification

- `make check` — 7/7 green (vet, lint, test, vuln, actionlint, zizmor,
  deadcode), **zero** `command not found` on the host (was one per make
  invocation).
- `make -n docker-build` now expands to `--platform linux/amd64` with a
  matching `-o ./linux/amd64/slurm_exporter`, consistent with
  `COPY $TARGETPLATFORM/`.

### Not verified

The end-to-end `make docker-build` was **not** run: that target compiles with
the host `go`, which is precisely what this machine lacks. The platform
consistency above is from a `make -n` dry run. Worth one real `make docker-build`
on a host with Go before merging.