### PR TITLE
docs(comments): correct four comments contradicted by the code

### DIFF
--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -118,10 +118,10 @@ var collectorConstructors = map[string]func(logger *logger.Logger) prometheus.Co
 	"reservations":      func(l *logger.Logger) prometheus.Collector { return collector.NewReservationsCollector(l) },
 	"reservation_nodes": func(l *logger.Logger) prometheus.Collector { return collector.NewReservationNodesCollector(l) },
 	"licenses":          func(l *logger.Logger) prometheus.Collector { return collector.NewLicensesCollector(l) },
-	// sacct_efficiency constructor is overridden in main() with a signal-aware
-	// context so the background refresh goroutine is cancelled cleanly on
-	// SIGTERM/SIGINT (see issue #18). Left nil here — disabled-by-default
-	// means the constructor is never invoked through this map directly.
+	// Nil because the signal context does not exist yet at package-init time.
+	// main() replaces this entry with a signal-aware constructor before
+	// registerCollectors ranges over the map, so the goroutine is cancelled
+	// cleanly on SIGTERM/SIGINT (see issue #18).
 	"sacct_efficiency": nil,
 }
 

--- a/internal/collector/cache_test.go
+++ b/internal/collector/cache_test.go
@@ -93,7 +93,8 @@ func TestTimedCache_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	// All 20 goroutines should have gotten the result but fetch called ≤ twice
-	// (once for the initial fetch, potentially once more if TTL expired mid-test)
+	// The double-checked lock must collapse the 20 concurrent callers into a
+	// single fetch. The bound is loose (3, not 1) because a slow runner can let
+	// the 100ms TTL expire mid-test and trigger a legitimate re-fetch.
 	assert.LessOrEqual(t, calls.Load(), int32(3), "concurrent callers must not all re-fetch")
 }

--- a/internal/collector/execute_test.go
+++ b/internal/collector/execute_test.go
@@ -20,7 +20,8 @@ func TestExecuteWithBinPath(t *testing.T) {
 	err := os.WriteFile(fakeScript, []byte("#!/bin/sh\necho 'fake sinfo output'"), 0o755)
 	require.NoError(t, err)
 
-	// Override Execute with the real implementation (in case a test replaced it)
+	// binPath is package-level state: save and restore it so this test does not
+	// leak its temp directory into the rest of the package.
 	oldBinPath := binPath
 	SetBinPath(dir)
 	defer SetBinPath(oldBinPath)

--- a/internal/collector/sacct_efficiency.go
+++ b/internal/collector/sacct_efficiency.go
@@ -195,9 +195,10 @@ type SacctEfficiencyCollector struct {
 	lastRefreshDesc   *prometheus.Desc
 
 	// done is closed when the background goroutine launched by Start() exits.
-	// Tests can wait on it after cancelling the context to ensure the
-	// goroutine is finished before tearing down package-level state (like the
-	// Execute mock). Unused in production.
+	// main() waits on it during graceful shutdown so the goroutine is finished
+	// before the process exits (issue #18). Tests also use it to synchronise
+	// teardown of package-level state, like the Execute mock, after cancelling
+	// the context.
 	done chan struct{}
 
 	logger *logger.Logger


### PR DESCRIPTION
Comment-only diff. `git diff -U0` contains no added or removed line that is not
a `//` comment, so behaviour is unchanged.

## Why

I audited every comment block in the tree (384 blocks, 734 lines) against the
code it describes. Four comments assert something the code does not do. A
comment that is merely redundant costs a line of reading; a comment that is
wrong makes people take decisions. These four are the second kind.

## What changed

**`internal/collector/sacct_efficiency.go`** — the `done` channel was
documented as `Unused in production`. It is used: `cmd/slurm_exporter/main.go`
captures it (`sacctDone = c.Done()`) and waits on it during graceful shutdown
on SIGTERM/SIGINT. This is the one worth fixing on its own. A contributor
trusting the comment would remove the field as test-only scaffolding and
silently break the shutdown path added for #18.

**`cmd/slurm_exporter/main.go`** — the nil `sacct_efficiency` map entry
credited its own safety to the collector being disabled by default. Two things
protect that nil, and the comment named the weaker one. The structural
guarantee is that `main()` replaces the entry before `registerCollectors`
ranges over the map; the default-disabled flag only holds until someone flips
it. The comment now documents the invariant that survives a flag change.

**`internal/collector/execute_test.go`** — the comment claimed to `Override
Execute with the real implementation (in case a test replaced it)`. The code
saves and restores `binPath` and never touches `Execute`, so the test offers no
such protection while calling `Execute` four lines down. The comment now
describes what the line actually does. Restoring `Execute` stays with the tests
that mock it, which all already do it via `defer`.

**`internal/collector/cache_test.go`** — the comment said fetch is called at
most twice, the assertion allows three. With a 100ms TTL and a 5ms fetch the
real count is one; the slack is there for slow runners. The comment now
explains the loose bound instead of describing a different one.

## Verification

- `make build` — exit 0.
- `make check` — exit 0, 0 test failures (vet, golangci-lint, tests,
  govulncheck, actionlint, zizmor, deadcode).
- The `scripts/testing/` integration cluster was not run. It is normally
  required for `internal/collector/` changes, but the diff adds and removes
  only comment lines, so there is no behaviour for it to exercise.

## Follow-ups, not in this PR

The same audit found roughly 30 lines of comment that restate the line below
them, two production comments written as change narration (`partitions.go`,
`gpus.go`) that git history already covers, three French comments in
`scheduler_test.go`, and two unused compatibility shims in `internal/logger`
(`WithContext`, `Log`) whose comments make them look required. Those are
cosmetic or separate decisions and belong in their own PRs.
