### PR TITLE
docs(comments): drop restatement noise and change narration

### DIFF
--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -36,7 +36,6 @@ import (
 )
 
 var (
-	// Command-line flags for application configuration
 	commandTimeout = kingpin.Flag("command.timeout", "Timeout for executing Slurm commands.").Default("5s").Duration()
 	logLevel       = kingpin.Flag("log.level", "Only log messages with the given severity or above. One of: [debug, info, warn, error]").Default("info").Enum("debug", "info", "warn", "error")
 	logFormat      = kingpin.Flag("log.format", "Log format. One of: [json, text]").Default("text").Enum("json", "text")
@@ -233,7 +232,6 @@ func main() {
 		)
 	}
 
-	// Register enabled Slurm collectors
 	registerCollectors(reg, log)
 
 	log.Info("Starting Slurm Exporter server...")

--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -152,21 +152,18 @@ func ParseTotalGPUs(data []byte) float64 {
 func ParseGPUsMetrics(logger *logger.Logger) (*GPUsMetrics, error) {
 	var gm GPUsMetrics
 
-	// Get total GPU count
 	totalGPUsData, err := TotalGPUsData(logger)
 	if err != nil {
 		return nil, err
 	}
 	totalGPUs := ParseTotalGPUs(totalGPUsData)
 
-	// Get allocated GPU count
 	allocatedGPUsData, err := AllocatedGPUsData(logger)
 	if err != nil {
 		return nil, err
 	}
 	allocatedGPUs := ParseAllocatedGPUs(allocatedGPUsData)
 
-	// Get idle GPU count
 	idleGPUsData, err := IdleGPUsData(logger)
 	if err != nil {
 		return nil, err
@@ -190,7 +187,6 @@ func ParseGPUsMetrics(logger *logger.Logger) (*GPUsMetrics, error) {
 	gm.other = otherGPUs
 	gm.total = totalGPUs
 
-	// Calculate utilization ratio
 	if totalGPUs > 0 {
 		gm.utilization = allocatedGPUs / totalGPUs
 	}
@@ -206,9 +202,9 @@ func AllocatedGPUsData(logger *logger.Logger) ([]byte, error) {
 
 // IdleGPUsData executes sinfo command to get idle and allocated GPU information.
 //
-// Trailing ":" on each field forces variable column widths; fixed widths
-// (was Gres:50, GresUsed:50) silently truncate rich GRES specs on busy GPU
-// nodes (multi-type GPUs, MIG slices), causing wrong GPU counts.
+// Trailing ":" on each field forces variable column widths. Fixed widths
+// silently truncate rich GRES specs on busy GPU nodes (multi-type GPUs, MIG
+// slices), causing wrong GPU counts.
 // See https://github.com/SckyzO/slurm_exporter/issues/10.
 func IdleGPUsData(logger *logger.Logger) ([]byte, error) {
 	args := []string{"-a", "-h", "--Format=Nodes: ,Gres: ,GresUsed:", "--state=idle,allocated"}

--- a/internal/collector/gpus_test.go
+++ b/internal/collector/gpus_test.go
@@ -16,7 +16,6 @@ func TestGPUsMetrics(t *testing.T) {
 		slurmVersion := strings.TrimPrefix(testDataPath, "../test_data/slurm-")
 		t.Logf("slurm-%s", slurmVersion)
 
-		// Read the input data from a file
 		file, err := os.Open(testDataPath + "/sinfo_gpus_allocated.txt")
 		if err != nil {
 			t.Fatalf("Can not open test data: %v", err)
@@ -25,7 +24,6 @@ func TestGPUsMetrics(t *testing.T) {
 		metrics := ParseAllocatedGPUs(data)
 		t.Logf("Allocated: %+v", metrics)
 
-		// Read the input data from a file
 		file, err = os.Open(testDataPath + "/sinfo_gpus_idle.txt")
 		if err != nil {
 			t.Fatalf("Can not open test data: %v", err)
@@ -34,7 +32,6 @@ func TestGPUsMetrics(t *testing.T) {
 		metrics = ParseIdleGPUs(data)
 		t.Logf("Idle: %+v", metrics)
 
-		// Read the input data from a file
 		file, err = os.Open(testDataPath + "/sinfo_gpus_total.txt")
 		if err != nil {
 			t.Fatalf("Can not open test data: %v", err)

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -50,7 +50,6 @@ func ParseNodeMetrics(input []byte) map[string]*NodeMetrics {
 		// Strip default-partition "*" marker (sinfo %P); matches nodes.go.
 		partition := strings.TrimRight(node[5], "*")
 
-		// Create new node metrics if it doesn't exist
 		if _, exists := nodes[nodeName]; !exists {
 			nodes[nodeName] = &NodeMetrics{0, 0, 0, 0, 0, 0, nodeStatus, []string{}}
 		}
@@ -74,7 +73,6 @@ func ParseNodeMetrics(input []byte) map[string]*NodeMetrics {
 		nodes[nodeName].cpuOther = cpuOther
 		nodes[nodeName].cpuTotal = cpuTotal
 
-		// Add the partition if it's not already in the list
 		nodes[nodeName].partitions = appendUnique(nodes[nodeName].partitions, partition)
 	}
 

--- a/internal/collector/node_test.go
+++ b/internal/collector/node_test.go
@@ -28,7 +28,6 @@ slurm_node_status{name="a048",status="idle", partition="all"} 1
 */
 
 func TestNodeMetrics(t *testing.T) {
-	// Read the input data from a file using os.ReadFile
 	data, err := os.ReadFile("../../test_data/sinfo_mem.txt")
 	if err != nil {
 		t.Fatalf("Can not open test data: %v", err)

--- a/internal/collector/nodes.go
+++ b/internal/collector/nodes.go
@@ -278,7 +278,6 @@ func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for part, nm := range allPartitions {
-		// Create a slice of all the metric maps
 		allMaps := []map[string]float64{
 			nm.alloc, nm.comp, nm.down, nm.drain, nm.err, nm.fail,
 			nm.idle, nm.inval, nm.maint, nm.mix, nm.resv, nm.other, nm.planned,

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -63,13 +63,11 @@ var (
 	partitionGpuRe = regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
 )
 
-// parseGpuCount sums all gpu:*:N matches in a GRES string.
+// parseGpuCount sums every gpu:*:N match in a GRES string.
 //
-// A GRES string can list multiple GPU types on the same node, e.g.
-// "gpu:A100:4,gpu:H100:2" → 6. Previously this function only returned the
-// first match (4), causing slurm_partition_gpus_* to undercount on
-// multi-type GPU nodes. Aligned with gpus.go::parseGPUCount, which has
-// always iterated correctly.
+// A node can expose several GPU types at once ("gpu:A100:4,gpu:H100:2" → 6),
+// so matching only the first entry undercounts slurm_partition_gpus_*.
+// gpus.go::parseGPUCount applies the same rule.
 func parseGpuCount(gpuSpec string, re *regexp.Regexp) float64 {
 	var count = 0.0
 	for _, spec := range strings.Split(gpuSpec, ",") {

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -47,12 +47,12 @@ type SchedulerMetrics struct {
 	totalBackfilledJobsSinceStart float64 // Total backfilled jobs since Slurm start
 	totalBackfilledJobsSinceCycle float64 // Total backfilled jobs since stats cycle start
 	totalBackfilledHeterogeneous  float64 // Total backfilled heterogeneous job components
-	// Job lifecycle counters (since last stats reset)
-	jobsSubmitted         float64            // Jobs submitted since last stats reset
-	jobsStarted           float64            // Jobs started (dispatched) since last stats reset
-	jobsCompleted         float64            // Jobs completed since last stats reset
-	jobsCanceled          float64            // Jobs canceled since last stats reset
-	jobsFailed            float64            // Jobs failed since last stats reset
+	// Job lifecycle counters, all since the last stats reset.
+	jobsSubmitted         float64
+	jobsStarted           float64 // dispatched
+	jobsCompleted         float64
+	jobsCanceled          float64
+	jobsFailed            float64
 	rpcStatsCount         map[string]float64 // RPC call counts by operation
 	rpcStatsAvgTime       map[string]float64 // RPC average times by operation
 	rpcStatsTotalTime     map[string]float64 // RPC total times by operation

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -70,14 +70,13 @@ func TestSchedulerRPCLineRe_HyphenatedUsername(t *testing.T) {
 }
 
 func TestParseSchedulerMetrics_JobCounters(t *testing.T) {
-	// Vérifie que les job counters sdiag sont bien parsés
 	data, err := os.ReadFile("../../test_data/sdiag.txt")
 	require.NoError(t, err)
 
 	sm := ParseSchedulerMetrics(data)
 
-	// Les counters peuvent être 0 dans le test_data (cluster idle)
-	// mais doivent être parsés sans panique
+	// The fixture is an idle cluster, so every counter can legitimately be 0.
+	// What this asserts is that they parse at all, without panicking.
 	assert.GreaterOrEqual(t, sm.jobsSubmitted, float64(0))
 	assert.GreaterOrEqual(t, sm.jobsStarted, float64(0))
 	assert.GreaterOrEqual(t, sm.jobsCompleted, float64(0))


### PR DESCRIPTION
Second pass of the comment audit, after #135. Cosmetic only.

**Comment-only, proven rather than asserted.** Every touched file was reparsed
from its AST with comments discarded and reprinted; the result is
byte-identical to the same treatment of `HEAD`. No behaviour can have changed.

## What changed

**13 restatement comments removed.** `// Get total GPU count` above
`TotalGPUsData()`, `// Read the input data from a file` above `os.Open()` in
four places, `// Create new node metrics if it doesn't exist` above the
existence check, plus similar ones in `main.go`, `node.go` and `nodes.go`.
They repeat the line below them, cost a line of reading, and go stale at the
first rename.

**Two production comments rewritten.** `parseGpuCount` carried "Previously
this function only returned the first match ... Aligned with
gpus.go::parseGPUCount, which has always iterated correctly", and
`IdleGPUsData` carried "(was Gres:50, GresUsed:50)". Both narrate a change
rather than describe the code. Git already holds that history, and a reader who
never saw the old version gains nothing. Each keeps the part that matters: why
multi-type GRES strings must be summed, and why fixed column widths corrupt GPU
counts (#10).

**Five sdiag fields collapsed.** Each repeated "since last stats reset" that
the block comment directly above already states once.

**Three French comments translated** in `scheduler_test.go`, the only
non-English ones left in the tree.

## Deliberately not done

The em dashes and the `──` separators stay. They are consistent house style,
and rewriting 53 comments across 23 files for punctuation would churn `git
blame` over lines that carry real Slurm knowledge, for no functional gain.

Regression-test headers written as "pre-fix X, post-fix Y" also stay. That
framing is wrong in production code but correct in a non-regression test: the
bug is the test's specification, and without it the next person to tidy the
test deletes the guarantee without noticing.

## Verification

- `make build` exit 0, `make check` exit 0, 0 test failures (vet,
  golangci-lint, tests, govulncheck, actionlint, zizmor, deadcode).
- `scripts/testing/` not run: the AST check above establishes there is no
  behaviour to exercise.

## Still open

`internal/logger.WithContext` and `internal/logger.Log` have no callers, and
`web.ListenAndServe` takes a `*slog.Logger` so the go-kit shim is no longer
required by anything. `gpus.go` also has a `numGPUs += 0` no-op. Those are code
removals, not comment edits, so they get their own PR.
