### PR TITLE
chore(logger): remove five unused compatibility shims

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,13 +1,12 @@
 package logger
 
 import (
-	"context"
 	"log/slog"
 	"os"
-	"time"
 )
 
-// Logger wraps slog.Logger to provide a compatible interface
+// Logger embeds *slog.Logger and is the logging dependency passed to every
+// collector, so collectors never reach for a global logger.
 type Logger struct {
 	*slog.Logger
 }
@@ -78,42 +77,6 @@ func NewJSONLogger(level string) *Logger {
 	return &Logger{Logger: logger}
 }
 
-// Log provides go-kit/log interface compatibility.
-func (l *Logger) Log(keyvals ...interface{}) error {
-	if len(keyvals)%2 != 0 {
-		keyvals = append(keyvals, "MISSING")
-	}
-
-	args := make([]interface{}, 0, len(keyvals))
-	for i := 0; i < len(keyvals); i += 2 {
-		key, ok := keyvals[i].(string)
-		if !ok {
-			continue
-		}
-		args = append(args, key, keyvals[i+1])
-	}
-
-	l.Logger.Info("", args...)
-	return nil
-}
-
-func (l *Logger) With(keyvals ...interface{}) *Logger {
-	if len(keyvals)%2 != 0 {
-		keyvals = append(keyvals, "MISSING")
-	}
-
-	args := make([]interface{}, 0, len(keyvals))
-	for i := 0; i < len(keyvals); i += 2 {
-		key, ok := keyvals[i].(string)
-		if !ok {
-			continue
-		}
-		args = append(args, key, keyvals[i+1])
-	}
-
-	return &Logger{Logger: l.Logger.With(args...)}
-}
-
 func (l *Logger) Debug(msg string, args ...interface{}) {
 	l.Logger.Debug(msg, args...)
 }
@@ -128,17 +91,4 @@ func (l *Logger) Warn(msg string, args ...interface{}) {
 
 func (l *Logger) Error(msg string, args ...interface{}) {
 	l.Logger.Error(msg, args...)
-}
-
-// WithContext is a no-op kept for interface compatibility; slog uses context natively.
-func (l *Logger) WithContext(ctx context.Context) *Logger {
-	return l
-}
-
-func (l *Logger) WithTimeout(timeout time.Duration) *Logger {
-	return l.With("timeout", timeout)
-}
-
-func (l *Logger) WithCommand(command string, args []string) *Logger {
-	return l.With("command", command, "args", args)
 }


### PR DESCRIPTION
Third and last pass of the comment audit, after #135 and #136. This one removes
code rather than comments: two comments asserted these methods were required by
something, and the honest fix is to delete what nothing uses.

## Why

`Log()` was documented as "go-kit/log interface compatibility". Nothing needs
it: `main.go` hands `web.ListenAndServe` the embedded `*slog.Logger`, and
exporter-toolkit v0.17.1 declares
`ListenAndServe(server *http.Server, flags *FlagConfig, logger *slog.Logger)`.

`WithContext()` was documented as "a no-op kept for interface compatibility"
without naming the interface. There is none.

## What goes, with caller counts across `cmd/` and `internal/`

| Method | Callers | Note |
|---|---|---|
| `Log` | 0 | go-kit shim, no longer required by exporter-toolkit |
| `WithContext` | 0 | no-op returning the receiver |
| `WithTimeout` | 0 | greps that looked like hits were `context.WithTimeout` |
| `WithCommand` | 0 | |
| `With` | 0 | only reachable through `WithTimeout` / `WithCommand` |

The package is `internal/`, so no consumer outside this module can exist. There
is no `reflect` use anywhere in the tree and no interface assertion on
`*Logger`. The `context` and `time` imports go with them.

## Worth flagging

`make deadcode` reported "no dead code" the whole time, including on the commit
before this one. The gate catches unreachable functions, not unused exported
methods on a concrete type, so this class has to be found by reading. Not
proposing a tooling change here, just noting the blind spot.

## Not in this PR

The `Debug`/`Info`/`Warn`/`Error` wrappers stay. They are pure delegation to
the embedded `*slog.Logger` and would keep working through promotion if
deleted, but they have 40 call sites and removing them is a style change, not
dead-code removal.

`gpus.go` still has a `numGPUs += 0` no-op inside the `case 1:` branch. The
branch itself is load-bearing (without it a single-field line falls into
`default` and indexes `fields[1]` out of range), only the statement is dead.
It lives in `internal/collector/`, which per `CLAUDE.md` calls for the
`scripts/testing/` integration cluster, so it is left for a separate PR.

## Verification

`make build` exit 0. `make check` exit 0, 0 test failures (vet, golangci-lint,
tests, govulncheck, actionlint, zizmor, deadcode). `go doc ./internal/logger`
now exposes `Logger` plus its three constructors.
