### PR TITLE
fix(collector): report Slurm command failures in collector_success

### DIFF
--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -111,11 +111,13 @@ func (ac *AccountsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ac.suspended
 }
 
-func (ac *AccountsCollector) Collect(ch chan<- prometheus.Metric) {
+func (ac *AccountsCollector) Collect(ch chan<- prometheus.Metric) { _ = ac.tryCollect(ch) }
+
+func (ac *AccountsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	data, err := AccountsData(ac.logger)
 	if err != nil {
 		ac.logger.Error("Failed to get accounts data", "err", err)
-		return
+		return err
 	}
 	am := ParseAccountsMetrics(data)
 	for a := range am {
@@ -135,4 +137,6 @@ func (ac *AccountsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(ac.suspended, prometheus.GaugeValue, am[a].suspended, a)
 		}
 	}
+
+	return nil
 }

--- a/internal/collector/cpus.go
+++ b/internal/collector/cpus.go
@@ -75,14 +75,18 @@ func (cc *CPUsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- cc.other
 	ch <- cc.total
 }
-func (cc *CPUsCollector) Collect(ch chan<- prometheus.Metric) {
+func (cc *CPUsCollector) Collect(ch chan<- prometheus.Metric) { _ = cc.tryCollect(ch) }
+
+func (cc *CPUsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	cm, err := CPUsGetMetrics(cc.logger)
 	if err != nil {
 		cc.logger.Error("Failed to get CPUs metrics", "err", err)
-		return
+		return err
 	}
 	ch <- prometheus.MustNewConstMetric(cc.alloc, prometheus.GaugeValue, cm.alloc)
 	ch <- prometheus.MustNewConstMetric(cc.idle, prometheus.GaugeValue, cm.idle)
 	ch <- prometheus.MustNewConstMetric(cc.other, prometheus.GaugeValue, cm.other)
 	ch <- prometheus.MustNewConstMetric(cc.total, prometheus.GaugeValue, cm.total)
+
+	return nil
 }

--- a/internal/collector/fairshare.go
+++ b/internal/collector/fairshare.go
@@ -142,11 +142,13 @@ func (fsc *FairShareCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (fsc *FairShareCollector) Collect(ch chan<- prometheus.Metric) {
+func (fsc *FairShareCollector) Collect(ch chan<- prometheus.Metric) { _ = fsc.tryCollect(ch) }
+
+func (fsc *FairShareCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	metrics, err := FairShareGetMetrics(fsc.logger)
 	if err != nil {
 		fsc.logger.Error("Failed to get fairshare metrics", "err", err)
-		return
+		return err
 	}
 
 	seenAccounts := make(map[string]bool)
@@ -178,4 +180,6 @@ func (fsc *FairShareCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(fsc.userNormUsage, prometheus.GaugeValue, m.NormUsage, m.Account, m.User)
 		}
 	}
+
+	return nil
 }

--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -250,11 +250,13 @@ func (cc *GPUsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect fetches the GPU metrics from Slurm and sends them to Prometheus
-func (cc *GPUsCollector) Collect(ch chan<- prometheus.Metric) {
+func (cc *GPUsCollector) Collect(ch chan<- prometheus.Metric) { _ = cc.tryCollect(ch) }
+
+func (cc *GPUsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	metrics, err := GPUsGetMetrics(cc.logger)
 	if err != nil {
 		cc.logger.Error("Failed to get GPU metrics", "err", err)
-		return
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(cc.alloc, prometheus.GaugeValue, metrics.alloc)
@@ -262,4 +264,6 @@ func (cc *GPUsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(cc.other, prometheus.GaugeValue, metrics.other)
 	ch <- prometheus.MustNewConstMetric(cc.total, prometheus.GaugeValue, metrics.total)
 	ch <- prometheus.MustNewConstMetric(cc.utilization, prometheus.GaugeValue, metrics.utilization)
+
+	return nil
 }

--- a/internal/collector/licenses.go
+++ b/internal/collector/licenses.go
@@ -87,11 +87,13 @@ func (lc *LicenseCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- lc.reserved
 }
 
-func (lc *LicenseCollector) Collect(ch chan<- prometheus.Metric) {
+func (lc *LicenseCollector) Collect(ch chan<- prometheus.Metric) { _ = lc.tryCollect(ch) }
+
+func (lc *LicenseCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	lm, err := LicenseGetMetrics(lc.logger)
 	if err != nil {
 		lc.logger.Error("Failed to get license metrics", "err", err)
-		return
+		return err
 	}
 	for name := range lm.total {
 		ch <- prometheus.MustNewConstMetric(lc.total, prometheus.GaugeValue, lm.total[name], name)
@@ -99,4 +101,6 @@ func (lc *LicenseCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(lc.free, prometheus.GaugeValue, lm.free[name], name)
 		ch <- prometheus.MustNewConstMetric(lc.reserved, prometheus.GaugeValue, lm.reserved[name], name)
 	}
+
+	return nil
 }

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -129,11 +129,13 @@ func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.nodeStatus
 }
 
-func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
+func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) { _ = nc.tryCollect(ch) }
+
+func (nc *NodeCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	nodes, err := NodeGetMetrics(nc.logger)
 	if err != nil {
 		nc.logger.Error("Failed to get node metrics", "err", err)
-		return
+		return err
 	}
 	if len(nodes) == 0 {
 		nc.logger.Warn("node collector parsed zero nodes — sinfo returned no data or output format unexpected; no slurm_node_* series will be exposed this scrape")
@@ -149,6 +151,8 @@ func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(nc.nodeStatus, prometheus.GaugeValue, 1, node, metrics.nodeStatus, partition)
 		}
 	}
+
+	return nil
 }
 
 // appendUnique adds a string to a slice if it doesn't already exist.

--- a/internal/collector/node_drain.go
+++ b/internal/collector/node_drain.go
@@ -87,11 +87,13 @@ func (c *DrainReasonCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.info
 }
 
-func (c *DrainReasonCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *DrainReasonCollector) Collect(ch chan<- prometheus.Metric) { _ = c.tryCollect(ch) }
+
+func (c *DrainReasonCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	data, err := DrainReasonData(c.logger)
 	if err != nil {
 		c.logger.Error("Failed to get drain reason data", "err", err)
-		return
+		return err
 	}
 	metrics := ParseDrainReasonMetrics(data)
 	for _, m := range metrics {
@@ -102,4 +104,6 @@ func (c *DrainReasonCollector) Collect(ch chan<- prometheus.Metric) {
 			m.Node, m.Reason, m.Since,
 		)
 	}
+
+	return nil
 }

--- a/internal/collector/nodes.go
+++ b/internal/collector/nodes.go
@@ -270,12 +270,14 @@ func SendFeatureSetMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, va
 	}
 }
 
-func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
+func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) { _ = nc.tryCollect(ch) }
+
+func (nc *NodesCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	// Single global sinfo call for all partitions — replaces N per-partition calls.
 	allPartitions, err := NodesGetMetricsGlobal(nc.logger)
 	if err != nil {
 		nc.logger.Error("Failed to get global nodes metrics", "err", err)
-		return
+		return err
 	}
 	for part, nm := range allPartitions {
 		allMaps := []map[string]float64{
@@ -334,7 +336,9 @@ func (nc *NodesCollector) Collect(ch chan<- prometheus.Metric) {
 	total, err := SlurmGetTotal(nc.logger)
 	if err != nil {
 		nc.logger.Error("Failed to get total nodes", "err", err)
-		return
+		return err
 	}
 	ch <- prometheus.MustNewConstMetric(nc.total, prometheus.GaugeValue, total)
+
+	return nil
 }

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -216,11 +216,13 @@ func (pc *PartitionsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- pc.gpuAllocated
 }
 
-func (pc *PartitionsCollector) Collect(ch chan<- prometheus.Metric) {
+func (pc *PartitionsCollector) Collect(ch chan<- prometheus.Metric) { _ = pc.tryCollect(ch) }
+
+func (pc *PartitionsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	pm, err := ParsePartitionsMetrics(pc.logger)
 	if err != nil {
 		pc.logger.Error("Failed to parse partitions metrics", "err", err)
-		return
+		return err
 	}
 	if len(pm) == 0 {
 		pc.logger.Warn("partitions collector parsed zero partitions — sinfo/squeue returned no data or output format unexpected; no slurm_partition_* series will be exposed this scrape")
@@ -235,4 +237,6 @@ func (pc *PartitionsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(pc.gpuIdle, prometheus.GaugeValue, pm[p].gpuIdle, p)
 		ch <- prometheus.MustNewConstMetric(pc.gpuAllocated, prometheus.GaugeValue, pm[p].gpuAllocated, p)
 	}
+
+	return nil
 }

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -303,7 +303,9 @@ func (qc *QueueCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- qc.jobsCoresPending
 }
 
-func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
+func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) { _ = qc.tryCollect(ch) }
+
+func (qc *QueueCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	qm, err := QueueGetMetrics(qc.logger)
 	if err != nil {
 		qc.logger.Error("Failed to get queue metrics", "err", err)
@@ -319,7 +321,7 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 			cPending:  make(NNVal), cRunning: make(NVal),
 		}
 		qc.emitGlobalTotals(ch, empty)
-		return
+		return err
 	}
 	if qc.withUserLabel {
 		for reason, values := range qm.pending {
@@ -375,6 +377,8 @@ func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	// Global totals: always emitted even when 0, regardless of withUserLabel.
 	qc.emitGlobalTotals(ch, qm)
+
+	return nil
 }
 
 // emitGlobalTotals emits the 13 cluster-wide job/core metrics.

--- a/internal/collector/reservation_nodes.go
+++ b/internal/collector/reservation_nodes.go
@@ -146,11 +146,13 @@ func (rnc *ReservationNodesCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- rnc.healthy
 }
 
-func (rnc *ReservationNodesCollector) Collect(ch chan<- prometheus.Metric) {
+func (rnc *ReservationNodesCollector) Collect(ch chan<- prometheus.Metric) { _ = rnc.tryCollect(ch) }
+
+func (rnc *ReservationNodesCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	metrics, err := ReservationNodesGetMetrics(rnc.logger)
 	if err != nil {
 		rnc.logger.Error("Failed to get reservation nodes metrics", "err", err)
-		return
+		return err
 	}
 	for resvName, rm := range metrics {
 		ch <- prometheus.MustNewConstMetric(rnc.alloc, prometheus.GaugeValue, rm.alloc, resvName)
@@ -162,4 +164,6 @@ func (rnc *ReservationNodesCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(rnc.other, prometheus.GaugeValue, rm.other, resvName)
 		ch <- prometheus.MustNewConstMetric(rnc.healthy, prometheus.GaugeValue, rm.healthy, resvName)
 	}
+
+	return nil
 }

--- a/internal/collector/reservations.go
+++ b/internal/collector/reservations.go
@@ -83,17 +83,19 @@ func (c *ReservationsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
-func (c *ReservationsCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *ReservationsCollector) Collect(ch chan<- prometheus.Metric) { _ = c.tryCollect(ch) }
+
+func (c *ReservationsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	data, err := c.reservationsData()
 	if err != nil {
 		c.logger.Error("Failed to fetch reservation data", "err", err)
-		return
+		return err
 	}
 
 	reservations, err := parseReservations(data)
 	if err != nil {
 		c.logger.Error("Failed to parse reservation data", "err", err)
-		return
+		return err
 	}
 
 	for i := range reservations {
@@ -105,6 +107,8 @@ func (c *ReservationsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.nodeCount, prometheus.GaugeValue, res.NodeCount, res.Name)
 		ch <- prometheus.MustNewConstMetric(c.coreCount, prometheus.GaugeValue, res.CoreCount, res.Name)
 	}
+
+	return nil
 }
 
 /*

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -301,11 +301,13 @@ func (sc *SchedulerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- sc.userRPCStatsTotalTime
 }
 
-func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) {
+func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) { _ = sc.tryCollect(ch) }
+
+func (sc *SchedulerCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	sm, err := SchedulerGetMetrics(sc.logger)
 	if err != nil {
 		sc.logger.Error("Failed to get scheduler metrics", "err", err)
-		return
+		return err
 	}
 	ch <- prometheus.MustNewConstMetric(sc.jobsSubmitted, prometheus.GaugeValue, sm.jobsSubmitted)
 	ch <- prometheus.MustNewConstMetric(sc.jobsStarted, prometheus.GaugeValue, sm.jobsStarted)
@@ -342,6 +344,8 @@ func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) {
 	for user, value := range sm.userRPCStatsTotalTime {
 		ch <- prometheus.MustNewConstMetric(sc.userRPCStatsTotalTime, prometheus.GaugeValue, value, user)
 	}
+
+	return nil
 }
 
 // NewSchedulerCollector creates a new scheduler metrics collector

--- a/internal/collector/status.go
+++ b/internal/collector/status.go
@@ -24,6 +24,23 @@ type statusEntry struct {
 	collector prometheus.Collector
 }
 
+// failableCollector is a collector that reports whether its collection
+// succeeded, so StatusTracker can emit slurm_exporter_collector_success
+// truthfully.
+//
+// prometheus.Collector.Collect returns nothing, so a collector whose Slurm
+// command fails can only log and emit no series. That is indistinguishable
+// from a genuinely empty cluster, and it left the success gauge stuck at 1
+// during the exact outage it exists to signal.
+//
+// tryCollect is unexported, so only collectors in this package can implement
+// it. Those that do not are still run through the plain Collect path and
+// reported as successful unless they panic.
+type failableCollector interface {
+	prometheus.Collector
+	tryCollect(ch chan<- prometheus.Metric) error
+}
+
 // NewStatusTracker creates a StatusTracker. Register it once with the Prometheus
 // registry; add inner collectors via Add().
 func NewStatusTracker(log *logger.Logger) *StatusTracker {
@@ -60,6 +77,9 @@ func (st *StatusTracker) Describe(ch chan<- *prometheus.Desc) {
 // Each inner collector writes directly into ch — no intermediate channel or extra
 // goroutine. Panics are caught via defer/recover in the same goroutine, which is
 // standard Go and avoids any buffering overhead regardless of metric volume.
+//
+// A collector reports failure two ways: by panicking, or by implementing
+// failableCollector and returning an error. Both lower its success gauge to 0.
 func (st *StatusTracker) Collect(ch chan<- prometheus.Metric) {
 	for _, e := range st.entries {
 		start := time.Now()
@@ -72,6 +92,12 @@ func (st *StatusTracker) Collect(ch chan<- prometheus.Metric) {
 					succeeded = 0
 				}
 			}()
+			if fc, ok := e.collector.(failableCollector); ok {
+				if err := fc.tryCollect(ch); err != nil {
+					succeeded = 0
+				}
+				return
+			}
 			e.collector.Collect(ch)
 		}()
 

--- a/internal/collector/status_execute_failure_test.go
+++ b/internal/collector/status_execute_failure_test.go
@@ -1,0 +1,117 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// collectorSuccessValues gathers reg and returns
+// slurm_exporter_collector_success keyed by the collector label.
+func collectorSuccessValues(t *testing.T, reg *prometheus.Registry) map[string]float64 {
+	t.Helper()
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	got := make(map[string]float64)
+	for _, mf := range mfs {
+		if mf.GetName() != "slurm_exporter_collector_success" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "collector" {
+					got[lp.GetValue()] = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return got
+}
+
+// TestStatusTracker_SuccessIsZeroWhenSlurmCommandsFail is the non-regression
+// test for the health metric being unable to report the failure mode it exists
+// for.
+//
+// slurm_exporter_collector_success is documented in docs/metrics.md as
+// "1=OK, 0=FAIL per collector". StatusTracker.Collect only lowered it to 0
+// inside its recover() block, but no collector panics when a Slurm command
+// fails: every one logs the error and returns. So with slurmctld down, or with
+// sinfo exceeding --command.timeout, the metric kept reporting 1 while the
+// series it should have produced were absent from /metrics. An alert on
+// slurm_exporter_collector_success == 0 could never fire.
+//
+// Every Slurm command is made to fail here, which is what an unreachable
+// slurmctld looks like from inside Execute.
+func TestStatusTracker_SuccessIsZeroWhenSlurmCommandsFail(t *testing.T) {
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return nil, errors.New("simulated: slurmctld unreachable")
+	}
+
+	// Reset the shared scontrol cache so a previous test's payload cannot
+	// satisfy the collectors that read through it.
+	oldCache := scontrolNodesCache
+	scontrolNodesCache = &timedCache{ttl: oldCache.ttl}
+	defer func() { scontrolNodesCache = oldCache }()
+
+	log := logger.NewLogger("error")
+
+	// The full default collector set from cmd/slurm_exporter/main.go, minus
+	// sacct_efficiency which is opt-in and serves a background cache rather
+	// than running on the scrape path.
+	tracker := NewStatusTracker(log)
+	tracker.Add("accounts", NewAccountsCollector(log))
+	tracker.Add("cpus", NewCPUsCollector(log))
+	tracker.Add("nodes", NewNodesCollector(log, true))
+	tracker.Add("node", NewNodeCollector(log))
+	tracker.Add("drain_reason", NewDrainReasonCollector(log))
+	tracker.Add("partitions", NewPartitionsCollector(log))
+	tracker.Add("queue", NewQueueCollector(log, true))
+	tracker.Add("scheduler", NewSchedulerCollector(log))
+	tracker.Add("fairshare", NewFairShareCollector(log, true))
+	tracker.Add("users", NewUsersCollector(log))
+	tracker.Add("gpus", NewGPUsCollector(log))
+	tracker.Add("reservations", NewReservationsCollector(log))
+	tracker.Add("reservation_nodes", NewReservationNodesCollector(log))
+	tracker.Add("licenses", NewLicensesCollector(log))
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(tracker))
+
+	got := collectorSuccessValues(t, reg)
+
+	for _, name := range []string{
+		"accounts", "cpus", "nodes", "node", "drain_reason", "partitions",
+		"queue", "scheduler", "fairshare", "users", "gpus", "reservations",
+		"reservation_nodes", "licenses",
+	} {
+		value, present := got[name]
+		assert.True(t, present, "collector %q must emit slurm_exporter_collector_success", name)
+		assert.Equal(t, 0.0, value,
+			"collector %q reported success=%v while every Slurm command failed", name, value)
+	}
+}
+
+// TestStatusTracker_SuccessStaysOneWhenCommandsSucceed guards the other
+// direction, so the fix above cannot be satisfied by hardcoding 0.
+func TestStatusTracker_SuccessStaysOneWhenCommandsSucceed(t *testing.T) {
+	log := logger.NewLogger("error")
+
+	tracker := NewStatusTracker(log)
+	tracker.Add("healthy", newMockCollector("slurm_probe_metric", 1))
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(tracker))
+
+	got := collectorSuccessValues(t, reg)
+	assert.Equal(t, 1.0, got["healthy"], "a collector that returns normally must report success=1")
+}

--- a/internal/collector/users.go
+++ b/internal/collector/users.go
@@ -102,11 +102,13 @@ func (uc *UsersCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- uc.suspended
 }
 
-func (uc *UsersCollector) Collect(ch chan<- prometheus.Metric) {
+func (uc *UsersCollector) Collect(ch chan<- prometheus.Metric) { _ = uc.tryCollect(ch) }
+
+func (uc *UsersCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	um, err := UsersGetMetrics(uc.logger)
 	if err != nil {
 		uc.logger.Error("Failed to parse users metrics", "err", err)
-		return
+		return err
 	}
 	for u := range um {
 		if um[u].pending > 0 {
@@ -125,4 +127,6 @@ func (uc *UsersCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(uc.suspended, prometheus.GaugeValue, um[u].suspended, u)
 		}
 	}
+
+	return nil
 }


### PR DESCRIPTION
`slurm_exporter_collector_success` is documented in `docs/metrics.md:344` as
"1=OK, 0=FAIL per collector". It reported **1** during the exact outage it
exists to signal.

## The defect

`StatusTracker.Collect` only lowered the gauge inside its `recover()` block.
No collector panics when a Slurm command fails: every one logs the error and
returns. With slurmctld unreachable, or `sinfo` exceeding `--command.timeout`,
the series disappeared from `/metrics` while the health gauge kept saying 1.
An alert on `slurm_exporter_collector_success == 0` could never fire.

The queue collector compounded it in a way that looks deliberate and is:
it emits global totals at 0 on error so the series stay present for alerting.
That is sound only if the health gauge works. Together they produced
`slurm_jobs_running 0` alongside `collector_success 1`, with no way to tell an
idle cluster from a broken `squeue`.

## The change

Collectors signal failure through a `failableCollector` interface with an
unexported `tryCollect` method returning an error. `Collect` delegates to it and
discards the error, so the `prometheus.Collector` contract is untouched.
`StatusTracker` type-asserts and falls back to the plain `Collect` path for
anything that does not implement it.

That fallback makes this a phase-1 change: the 14 collectors migrated here
report failure, and any collector that is not migrated behaves exactly as
before. Per collector the diff is a signature split, `return` becoming
`return err`, and a closing `return nil`.

**`info` is deliberately not migrated.** Binary presence is its data, not a
precondition: a missing binary is emitted as `version="not_found"`, `value=0`,
so its collection genuinely succeeded. The cluster run below confirms it: it
stayed at 1 and correctly reported the missing binaries while the other 14
went to 0.

## Test first

`TestStatusTracker_SuccessIsZeroWhenSlurmCommandsFail` mocks `Execute` to fail
on every command and asserts the gauge is 0 for all 14 collectors. Before the
fix it failed with 14 assertions of `expected: 0, actual: 1`. After, it passes.
A second test pins the other direction so the fix cannot be satisfied by
hardcoding 0.

## Definition of Done

| Step | Result |
|---|---|
| 1 `make build` | exit 0 |
| 2 `make test` + coverage | exit 0, **80.6% -> 84.6%** |
| 3 `golangci-lint` (via `make check`) | exit 0, 0 failures |
| 4 cluster `setup` | clean, 10 dashboards imported, exporter on `slurmctld:9341` |
| 5 `workload N=20` | **not satisfiable on this host**, see below |
| 6 Prometheus validation | see below |
| 7 log check | slurmctld: 0 ERROR |
| 8 dashboards | not modified, N/A |
| 9 `stop` | clean, no dangling containers |
| 10 `act push` | Job succeeded |

**Step 6, the end-to-end proof.** On the running cluster, all 15 collectors
reported 1 while healthy (`slurm_nodes_total` 10, `slurm_jobs_pending` 3,
matching `sinfo`/`squeue`). The Slurm binaries were then moved aside inside the
container, leaving the exporter process alive, which is what an unreachable
controller looks like from inside `Execute`. 14 of 15 flipped to 0 within two
scrape cycles, `info` correctly stayed at 1, and `slurm_jobs_pending` stayed at
0 with `queue` now reporting `success=0` next to it. Restoring the binaries
brought all 15 back to 1.

**Step 5 could not be met on this host, and it is not related to this change.**
Every job dies after one second with `RaisedSignal:53(Real-time_signal_19)`,
whatever the user, partition or command, including a plain `sbatch --wrap="sleep
600"`. The cluster runs `TaskPlugin=task/affinity` on a WSL2 kernel. Two
unrelated problems in `scripts/testing` surfaced along the way and are worth
their own issue: the workload generator submits jobs to `debug` with time limits
above that partition's 30-minute cap, so they sit in `PartitionTimeLimit`
forever; and `_lib.sh:239` starts the exporter with `docker exec -d` and no
redirection, so its stdout is discarded and step 7's "no unexpected ERROR or
WARN in exporter logs" cannot be checked as written.

## Found while running this, not fixed here

The exporter does not terminate on SIGTERM or SIGINT; it needs SIGKILL.
`web.ListenAndServe` at `main.go:260` blocks forever, nothing calls
`server.Shutdown()`, and nothing watches `ctx.Done()`. The signal context is
only wired into the sacct collector. The graceful-shutdown block at
`main.go:266-277` is therefore unreachable, and `CLAUDE.md:78` describes
behaviour that does not happen. Reproduced on a bare host with no Slurm
involved. `main.go` is untouched by this branch, so `master` behaves the same.
Separate issue and separate PR.
