### PR TITLE
docs(contributing): document the P0 to P3 issue triage scale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,33 @@ chore: bump CHANGELOG for v1.8.0
 
 ---
 
+## Issue triage
+
+Every issue gets exactly one priority label. The scale is about how much the
+defect costs a running deployment, not how interesting it is to fix.
+
+| Label | Meaning |
+|-------|---------|
+| `P0` | Data loss, a security hole, or the exporter cannot run. Stop other work. |
+| `P1` | Production is degraded and there is no workaround. Fix before the next release. |
+| `P2` | A real defect, but there is a way around it. Schedule it. |
+| `P3` | Cosmetic, hygiene, or a nice to have. |
+
+Two rules that decide most borderline cases:
+
+**A workaround moves an issue down, it does not close it.** An exporter that
+needs `kill -9` to stop is annoying rather than fatal, so it is `P2`, not `P1`.
+
+**Wrong metrics outrank slow ones.** A metric that silently reports a wrong
+value is worse than one that costs an extra RPC, because nobody notices the
+first until they act on it. Undercounting jobs is `P1`; issuing five `squeue`
+calls where one would do is `P2`.
+
+Priority is independent of `bug` and `enhancement`, so an issue normally
+carries one of each.
+
+---
+
 ## Test Data
 
 All fixtures in `test_data/` must be anonymized:


### PR DESCRIPTION
The `P0` to `P3` labels were created on GitHub while triaging the audit backlog,
but nothing in the repository said what they mean. A scale that only exists in
the label list drifts the moment someone else applies it.

Adds an `Issue triage` section to `CONTRIBUTING.md` with the four levels and the
two rules that settle most borderline cases:

- a workaround lowers a priority rather than closing the issue;
- a metric that silently reports a wrong value outranks one that merely costs an
  extra RPC.

Both come from calls made on the current backlog. The first is why #139, the
exporter ignoring SIGTERM, sits at `P2` rather than `P1`: it is genuinely
annoying, but the exporter keeps serving correct metrics and `kill -9` works.
The second is why #140, undercounted partition job totals, is `P1` while #144,
five `squeue` dumps per scrape, is `P2`.

The section also notes that priority is orthogonal to `bug` and `enhancement`,
since an issue normally carries one of each.

## Verification

Markdown only, no Go touched. `make check` passes (exit 0). The wording matches
the label descriptions currently set on GitHub.
