### PR TITLE
fix(partitions): count jobs submitted to several partitions

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -153,6 +153,16 @@ Provides metrics on CPU usage and pending jobs for each partition.
 | `slurm_partition_gpus_idle`      | Idle GPUs for partition | `partition` |
 | `slurm_partition_gpus_allocated` | Allocated GPUs for partition | `partition` |
 
+A job submitted to several partitions (`sbatch -p a100,cpu`) is queued in each
+of them and counts once in each, so `sum(slurm_partition_jobs_pending)` can be
+larger than the number of distinct pending jobs. A running job occupies a
+single partition, so the running count is not affected.
+
+These two metrics are not directly comparable to `slurm_jobs_pending` and
+`slurm_jobs_running`. The `partitions` collector passes `-a -r` to `squeue`, so
+it sees hidden partitions and expands every array element into its own job,
+while the `queue` collector does neither.
+
 ### `queue` Collector
 
 Provides detailed metrics on job states and resource usage.

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -135,16 +135,41 @@ func parsePartitionGPUs(data []byte, partitions map[string]*PartitionMetrics) {
 	}
 }
 
+// squeuePartitions normalises one line of squeue "%P" output into the partition
+// names it refers to.
+//
+// A pending job submitted with "sbatch -p a100,cpu" is reported as "a100,cpu",
+// and the default partition is reported as "cpu*" on the Slurm versions
+// described in queue.go. The map keys were stripped of the marker by
+// parsePartitionCPUs, so the same normalisation has to happen on the squeue
+// side or the lookup misses and the job is counted nowhere — see issue #140.
+func squeuePartitions(line string) []string {
+	names := strings.Split(line, ",")
+	for i, name := range names {
+		names[i] = strings.TrimRight(strings.TrimSpace(name), "*")
+	}
+	return names
+}
+
 // parsePartitionJobs counts pending and running jobs per partition from squeue output.
+//
+// A job pending in several partitions counts once in each, since it is queued
+// in each and contends for all of them. It runs in only one, so the sum of
+// slurm_partition_jobs_pending can exceed the cluster-wide pending count while
+// slurm_partition_jobs_running cannot.
 func parsePartitionJobs(pendingData, runningData []byte, partitions map[string]*PartitionMetrics) {
-	for _, partition := range strings.Split(string(pendingData), "\n") {
-		if _, exists := partitions[partition]; exists {
-			partitions[partition].jobPending++
+	for _, line := range strings.Split(string(pendingData), "\n") {
+		for _, name := range squeuePartitions(line) {
+			if pm, exists := partitions[name]; exists {
+				pm.jobPending++
+			}
 		}
 	}
-	for _, partition := range strings.Split(string(runningData), "\n") {
-		if _, exists := partitions[partition]; exists {
-			partitions[partition].jobRunning++
+	for _, line := range strings.Split(string(runningData), "\n") {
+		for _, name := range squeuePartitions(line) {
+			if pm, exists := partitions[name]; exists {
+				pm.jobRunning++
+			}
 		}
 	}
 }

--- a/internal/collector/partitions_jobs_test.go
+++ b/internal/collector/partitions_jobs_test.go
@@ -1,0 +1,77 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newJobPartitions builds a partitions map holding the given names, the way
+// parsePartitionCPUs and parsePartitionGPUs leave it before
+// parsePartitionJobs runs.
+func newJobPartitions(names ...string) map[string]*PartitionMetrics {
+	partitions := make(map[string]*PartitionMetrics, len(names))
+	for _, name := range names {
+		partitions[name] = &PartitionMetrics{}
+	}
+	return partitions
+}
+
+// TestParsePartitionJobsCountsMultiPartitionJobs is the non-regression test for
+// slurm_partition_jobs_pending and slurm_partition_jobs_running undercounting.
+//
+// parsePartitionJobs looked partitions up with the raw squeue line, while the
+// map keys had been stored normalised: parsePartitionCPUs and parsePartitionGPUs
+// strip the default-partition marker. Two shapes of squeue output therefore
+// matched no key and were counted nowhere.
+//
+// A job submitted with "sbatch -p a100,cpu" is reported by squeue -o "%P" as
+// "a100,cpu". A default partition is reported as "cpu*" on the Slurm versions
+// described in queue.go. Neither string is a key, so the job silently vanished
+// from every partition it belonged to, and nothing logged it.
+func TestParsePartitionJobsCountsMultiPartitionJobs(t *testing.T) {
+	partitions := newJobPartitions("cpu", "a100", "gpu")
+
+	pending := []byte("a100,cpu\ncpu\ngpu\n")
+	running := []byte("a100,gpu\na100\n")
+
+	parsePartitionJobs(pending, running, partitions)
+
+	assert.Equal(t, 2.0, partitions["cpu"].jobPending, "cpu: one job of its own plus the a100,cpu job")
+	assert.Equal(t, 1.0, partitions["a100"].jobPending, "a100: the a100,cpu job")
+	assert.Equal(t, 1.0, partitions["gpu"].jobPending, "gpu: one job of its own")
+
+	assert.Equal(t, 2.0, partitions["a100"].jobRunning, "a100: the a100,gpu job plus one of its own")
+	assert.Equal(t, 1.0, partitions["gpu"].jobRunning, "gpu: the a100,gpu job")
+	assert.Equal(t, 0.0, partitions["cpu"].jobRunning, "cpu: nothing running")
+}
+
+// TestParsePartitionJobsStripsDefaultPartitionMarker pins the version-dependent
+// half of the same defect. queue.go:108 records that squeue -o "%P" emits
+// "compute*" for the default partition on some Slurm versions. On those, the
+// default partition, usually the busiest one on the cluster, reported zero jobs
+// forever.
+func TestParsePartitionJobsStripsDefaultPartitionMarker(t *testing.T) {
+	partitions := newJobPartitions("compute", "gpu")
+
+	parsePartitionJobs([]byte("compute*\ncompute*\n"), []byte("compute*\ngpu*,compute*\n"), partitions)
+
+	assert.Equal(t, 2.0, partitions["compute"].jobPending)
+	assert.Equal(t, 2.0, partitions["compute"].jobRunning)
+	assert.Equal(t, 1.0, partitions["gpu"].jobRunning)
+}
+
+// TestParsePartitionJobsIgnoresUnknownAndEmptyLines guards the other direction,
+// so counting more jobs cannot be achieved by counting names that are not
+// partitions. A trailing newline yields an empty final element, and a partition
+// that holds no nodes appears in squeue output without ever appearing in sinfo.
+func TestParsePartitionJobsIgnoresUnknownAndEmptyLines(t *testing.T) {
+	partitions := newJobPartitions("cpu")
+
+	parsePartitionJobs([]byte("\ncpu\nretired\n\n"), []byte("  \nretired,unknown\n"), partitions)
+
+	require.Len(t, partitions, 1, "squeue output must not create partitions")
+	assert.Equal(t, 1.0, partitions["cpu"].jobPending)
+	assert.Equal(t, 0.0, partitions["cpu"].jobRunning)
+}


### PR DESCRIPTION
Fixes #140.

`parsePartitionJobs` looked partitions up with the raw `squeue` line, while the
map keys had been normalised by `parsePartitionCPUs` and `parsePartitionGPUs`,
which strip the default-partition marker. Any line that was not already a bare
partition name matched no key and was counted nowhere. Nothing logged it, and
no other metric contradicted it.

## What was confirmed on a live cluster

The issue marked the default-partition half version dependent and the
multi-partition half certain. The multi-partition trigger is now observed on
Slurm 25.11, `scripts/testing` cluster, four jobs submitted with `--hold` so
they stay `PENDING`:

```
$ squeue -a -r -h -o "%P" --states=PENDING
cpu
debug,high
debug,high
high
```

Ground truth is therefore `cpu=1`, `debug=2`, `high=3`. Both binaries were run
side by side against that same cluster, `master` on `:9342` and this branch on
`:9341`:

```
master (7efe8e4)                          this branch
slurm_partition_jobs_pending{cpu}   1     slurm_partition_jobs_pending{cpu}   1
slurm_partition_jobs_pending{debug} 0     slurm_partition_jobs_pending{debug} 2
slurm_partition_jobs_pending{gpu}   0     slurm_partition_jobs_pending{gpu}   0
slurm_partition_jobs_pending{high}  1     slurm_partition_jobs_pending{high}  3
```

Four partition memberships were lost on `master`, including two jobs that
appeared in no partition at all.

## The fix

`squeuePartitions` applies the normalisation `queue.go` already applies, and
splits on commas.

A job pending in several partitions now counts once in each. It is queued in
each and contends for all of them, so that is the reading `slurm_partition_jobs_pending`
should carry. The consequence is that its sum can exceed the number of distinct
pending jobs, which `docs/metrics.md` now states, together with why these
counts are not directly comparable to `slurm_jobs_pending`: the `partitions`
collector passes `-a -r` to `squeue` and the `queue` collector does not.

## Tests

Three tests in `internal/collector/partitions_jobs_test.go`, none of which
existed before. `parsePartitionJobs` had no coverage at all.

- `TestParsePartitionJobsCountsMultiPartitionJobs` covers the comma case on
  both the pending and the running side.
- `TestParsePartitionJobsStripsDefaultPartitionMarker` covers the marker case.
- `TestParsePartitionJobsIgnoresUnknownAndEmptyLines` guards the other
  direction, so the counts cannot be raised by counting names that are not
  partitions.

The first two fail on `master` and pass here. The third passes on both.

Coverage `84.6%` to `84.7%`, measured against a pristine `7efe8e4` worktree.

## Definition of Done

| Step | Result |
|---|---|
| 1 `make build` | pass |
| 2 `make test` | 170 pass, coverage 84.6% to 84.7% |
| 3 `golangci-lint run ./...` | 0 issues, plus `go vet`, `deadcode`, `govulncheck`, `actionlint`, `zizmor` via `make check` |
| 4 cluster setup | 10/10 nodes, 10 dashboards, exporter on `:9341` |
| 5 workload | **not satisfiable on this machine**, see below |
| 6 Prometheus | `slurm_partition_jobs_pending` = 1/2/0/3 for cpu/debug/gpu/high, `sum()` = 6 against `slurm_jobs_pending` = 4, the documented double count |
| 7 logs | 0 ERROR, 0 WARN in the exporter, 0 ERROR in slurmctld |
| 8 dashboards | not applicable, none modified |
| 9 cluster stop | clean, no dangling containers |
| 10 `act push` | job `test` succeeded |

Step 5 cannot run on this host. Every job dies after one second with
`RaisedSignal:53(Real-time_signal_19)` under the WSL2 kernel, whatever the
user, partition or command. Held jobs stay `PENDING` normally, which is what
made the end-to-end proof above possible, and pending is where the
multi-partition case lives: Slurm assigns exactly one partition once a job
starts.

## Left for a production cluster

Two things this cluster cannot answer, both already handled by the code but
unverified in the field:

1. Whether `squeue -o "%P"` ever emits the default-partition marker. Slurm
   25.11 emits `cpu` where `sinfo` shows `cpu*`. The comment at `queue.go:108`
   says older versions emit `compute*`, and the fix handles both.
2. The running-job path. No job could be caught in `RUNNING` state here.

## Out of scope

The `queue` collector reads the same `squeue -o "%P"` field and does not split
on commas, so it emits `slurm_queue_pending{partition="debug,high"}`, a label
matching no real partition. Observed on the same cluster run. Different metric,
different fix, tracked separately.
