### PR TITLE
fix(drain_reason): move the drain timestamp out of the label set

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -320,7 +320,24 @@ Zero cardinality overhead on healthy clusters.
 
 | Metric | Description | Labels |
 |---|---|---|
-| `slurm_node_drain_reason_info` | Always 1 — use labels for the reason and timestamp | `node`, `reason`, `since` |
+| `slurm_node_drain_reason_info` | Always 1; the reason label carries the text | `node`, `reason` |
+| `slurm_node_drain_since_timestamp_seconds` | Unix time at which the reason was set | `node` |
+
+The drain time is a value rather than a label, so a re-drain updates the node's
+existing series instead of creating a new one. How long a node has been drained,
+and why:
+
+```promql
+(time() - slurm_node_drain_since_timestamp_seconds)
+  * on(node) group_left(reason) slurm_node_drain_reason_info
+```
+
+`slurm_node_drain_since_timestamp_seconds` is absent for a node whose reason
+carries no timestamp, rather than zero, so the subtraction above never reports a
+drain that started in 1970. The exporter reads the timestamp in the default
+`sinfo` format (`2026-04-01T10:00:00`); setting `SLURM_TIME_FORMAT` to anything
+other than `standard` in the exporter's environment makes the field unreadable,
+which is logged at `WARN` once per affected node per scrape.
 
 ---
 

--- a/internal/collector/node_drain.go
+++ b/internal/collector/node_drain.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -10,10 +11,40 @@ import (
 
 // DrainReasonMetrics holds the drain/down reason for a single node.
 type DrainReasonMetrics struct {
-	Node      string
-	Partition string
-	Reason    string
-	Since     string // ISO8601 timestamp when the reason was set
+	Node   string
+	Reason string
+	Since  string // raw sinfo "%H" field, kept for diagnostics
+	// SinceUnix is Since converted to a Unix timestamp, or 0 when sinfo
+	// reported no usable time. Zero means "do not export", never 1970.
+	SinceUnix float64
+}
+
+// parseDrainTime converts one sinfo "%H" field into a Unix timestamp, using the
+// same slurmTimeLayout every other Slurm timestamp in this package is read with.
+//
+// sinfo renders the field in the local zone of the host running the command,
+// which is the exporter host, so that is the zone it is read back in. Slurm
+// documents the "standard" SLURM_TIME_FORMAT as
+// year-month-dateThour:minute:second; a site that exports another value, or the
+// "relative" preset, produces strings this layout rejects. Those return 0, which
+// the collector treats as "no timestamp" rather than as 1970.
+func parseDrainTime(since string) float64 {
+	t, err := time.ParseInLocation(slurmTimeLayout, since, time.Local)
+	if err != nil {
+		return 0
+	}
+	return float64(t.Unix())
+}
+
+// drainTimeIsUnset reports whether sinfo said there is no timestamp, as opposed
+// to printing one this parser could not read. The first case is normal and
+// silent, the second is a misconfiguration worth logging.
+func drainTimeIsUnset(since string) bool {
+	switch strings.ToLower(since) {
+	case "", "unknown", "none", "n/a":
+		return true
+	}
+	return false
 }
 
 // ParseDrainReasonMetrics parses "sinfo -h -N -o '%N|%E|%H|%T'" output.
@@ -49,9 +80,10 @@ func ParseDrainReasonMetrics(input []byte) []DrainReasonMetrics {
 		}
 		seen[node] = true
 		results = append(results, DrainReasonMetrics{
-			Node:   node,
-			Reason: reason,
-			Since:  since,
+			Node:      node,
+			Reason:    reason,
+			Since:     since,
+			SinceUnix: parseDrainTime(since),
 		})
 	}
 	return results
@@ -66,17 +98,31 @@ func DrainReasonData(log *logger.Logger) ([]byte, error) {
 // DrainReasonCollector collects slurm_node_drain_reason_info for degraded nodes.
 type DrainReasonCollector struct {
 	info   *prometheus.Desc
+	since  *prometheus.Desc
 	logger *logger.Logger
 }
 
 // NewDrainReasonCollector creates a DrainReasonCollector.
+//
+// The drain timestamp is a value, not a label. Carried as a label it made every
+// re-drain of a node create a fresh series and orphan the previous one, so the
+// series count grew with operator activity over the lifetime of the TSDB instead
+// of with the number of drained nodes — see issue #141.
 func NewDrainReasonCollector(log *logger.Logger) *DrainReasonCollector {
 	return &DrainReasonCollector{
 		info: prometheus.NewDesc(
 			"slurm_node_drain_reason_info",
 			"Information about why a node is in drain or down state. "+
-				"Value is always 1 — use labels for the reason and timestamp.",
-			[]string{"node", "reason", "since"},
+				"Always 1; the reason label carries the text and "+
+				"slurm_node_drain_since_timestamp_seconds carries the time it was set.",
+			[]string{"node", "reason"},
+			nil,
+		),
+		since: prometheus.NewDesc(
+			"slurm_node_drain_since_timestamp_seconds",
+			"Unix timestamp at which the drain or down reason was set on the node. "+
+				"Absent when Slurm reports no timestamp.",
+			[]string{"node"},
 			nil,
 		),
 		logger: log,
@@ -85,6 +131,7 @@ func NewDrainReasonCollector(log *logger.Logger) *DrainReasonCollector {
 
 func (c *DrainReasonCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.info
+	ch <- c.since
 }
 
 func (c *DrainReasonCollector) Collect(ch chan<- prometheus.Metric) { _ = c.tryCollect(ch) }
@@ -97,12 +144,17 @@ func (c *DrainReasonCollector) tryCollect(ch chan<- prometheus.Metric) error {
 	}
 	metrics := ParseDrainReasonMetrics(data)
 	for _, m := range metrics {
-		ch <- prometheus.MustNewConstMetric(
-			c.info,
-			prometheus.GaugeValue,
-			1,
-			m.Node, m.Reason, m.Since,
-		)
+		ch <- prometheus.MustNewConstMetric(c.info, prometheus.GaugeValue, 1, m.Node, m.Reason)
+
+		if m.SinceUnix > 0 {
+			ch <- prometheus.MustNewConstMetric(c.since, prometheus.GaugeValue, m.SinceUnix, m.Node)
+			continue
+		}
+		if !drainTimeIsUnset(m.Since) {
+			c.logger.Warn("Unreadable drain timestamp from sinfo; no slurm_node_drain_since_timestamp_seconds for this node",
+				"node", m.Node, "since", m.Since, "expected_layout", slurmTimeLayout,
+				"hint", "SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment")
+		}
 	}
 
 	return nil

--- a/internal/collector/node_drain_since_test.go
+++ b/internal/collector/node_drain_since_test.go
@@ -1,0 +1,111 @@
+package collector
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// stubDrainSinfo makes Execute return the given "%N|%E|%H|%T" lines for the rest
+// of the test.
+func stubDrainSinfo(t *testing.T, output string) {
+	t.Helper()
+	old := Execute
+	t.Cleanup(func() { Execute = old })
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return []byte(output), nil
+	}
+}
+
+// unixLocal converts a sinfo "%H" timestamp the way sinfo produced it, in the
+// local zone of the host running the command, which is the exporter host.
+func unixLocal(t *testing.T, value string) float64 {
+	t.Helper()
+	ts, err := time.ParseInLocation("2006-01-02T15:04:05", value, time.Local)
+	require.NoError(t, err)
+	return float64(ts.Unix())
+}
+
+// drainSeries renders one metric family as sorted `name{label="value",...} value`
+// lines, so a test can assert on the exact series identity instead of on a count.
+func drainSeries(t *testing.T, c prometheus.Collector, name string) []string {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	var series []string
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			pairs := make([]string, 0, len(m.GetLabel()))
+			for _, l := range m.GetLabel() {
+				pairs = append(pairs, fmt.Sprintf("%s=%q", l.GetName(), l.GetValue()))
+			}
+			series = append(series, fmt.Sprintf("%s{%s} %g", name, strings.Join(pairs, ","), m.GetGauge().GetValue()))
+		}
+	}
+	sort.Strings(series)
+	return series
+}
+
+// TestDrainReasonSeriesIdentityIsStableAcrossRedrains is the non-regression test
+// for unbounded series growth on slurm_node_drain_reason_info.
+//
+// The drain timestamp from sinfo "%H" was published as a label. Draining the
+// same node again yields a different timestamp, so Prometheus saw a brand new
+// series and orphaned the previous one. The series count then tracked how often
+// operators drained nodes over the lifetime of the TSDB rather than how many
+// nodes are drained, and a site that drains routinely for maintenance paid for
+// it continuously. See issue #141.
+func TestDrainReasonSeriesIdentityIsStableAcrossRedrains(t *testing.T) {
+	want := []string{`slurm_node_drain_reason_info{node="c1",reason="disk failure"} 1`}
+	log := logger.NewLogger("error")
+
+	stubDrainSinfo(t, "c1|disk failure|2026-04-01T10:00:00|drained\n")
+	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"))
+
+	// The same node, drained again for the same reason three months later.
+	stubDrainSinfo(t, "c1|disk failure|2026-07-01T08:30:00|drained\n")
+	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"),
+		"a re-drain must land on the existing series instead of creating a second one")
+}
+
+// TestDrainReasonExportsSinceAsATimestamp pins the replacement for the label.
+// The drain time belongs in the value, where it can be plotted and subtracted
+// from time() to get a drain duration.
+func TestDrainReasonExportsSinceAsATimestamp(t *testing.T) {
+	stubDrainSinfo(t, "c1|disk failure|2026-04-01T10:00:00|drained\nc2|hw-fail|2026-04-01T09:00:00|down\n")
+
+	want := []string{
+		fmt.Sprintf(`slurm_node_drain_since_timestamp_seconds{node="c1"} %g`, unixLocal(t, "2026-04-01T10:00:00")),
+		fmt.Sprintf(`slurm_node_drain_since_timestamp_seconds{node="c2"} %g`, unixLocal(t, "2026-04-01T09:00:00")),
+	}
+	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(logger.NewLogger("error")), "slurm_node_drain_since_timestamp_seconds"))
+}
+
+// TestDrainReasonOmitsTimestampWhenSinfoReportsNone guards the other direction.
+// sinfo prints "Unknown" when the reason carries no time, and SLURM_TIME_FORMAT
+// can make it print something this parser does not read. Either way the node is
+// still drained and its reason still matters, but the timestamp must be absent
+// rather than zero: zero reads as 1970 and makes every time() subtraction wrong
+// by decades.
+func TestDrainReasonOmitsTimestampWhenSinfoReportsNone(t *testing.T) {
+	stubDrainSinfo(t, "c1|disk failure|Unknown|drained\n")
+	log := logger.NewLogger("error")
+
+	assert.Len(t, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"), 1,
+		"the node is drained, so its reason is still published")
+	assert.Empty(t, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_since_timestamp_seconds"))
+}

--- a/internal/collector/node_drain_test.go
+++ b/internal/collector/node_drain_test.go
@@ -74,9 +74,14 @@ c2|hw-fail|2026-04-01T09:00:00|down
 
 	mfs, err := reg.Gather()
 	require.NoError(t, err)
-	require.Len(t, mfs, 1)
-	assert.Equal(t, "slurm_node_drain_reason_info", mfs[0].GetName())
-	assert.Len(t, mfs[0].Metric, 2)
+	require.Len(t, mfs, 2, "the reason and its timestamp are two families since issue #141")
+
+	names := make([]string, 0, len(mfs))
+	for _, mf := range mfs {
+		names = append(names, mf.GetName())
+		assert.Len(t, mf.Metric, 2, mf.GetName())
+	}
+	assert.ElementsMatch(t, []string{"slurm_node_drain_reason_info", "slurm_node_drain_since_timestamp_seconds"}, names)
 }
 
 func TestDrainReasonCollector_EmptyCluster(t *testing.T) {


### PR DESCRIPTION
Closes #141.

`slurm_node_drain_reason_info` carried the `sinfo "%H"` drain time as a label.
Draining the same node again gives a different timestamp, so Prometheus saw a
brand new series and orphaned the previous one. The series count grew with how
often operators drain nodes over the lifetime of the TSDB rather than with the
number of nodes that are drained.

No dashboard panel and no alerting rule reads this metric, which is what made it
dangerous rather than harmless: the cost landed on the Prometheus server, where
nothing pointed at the cause.

## What changed

The drain time moves from the label set into a value on its own gauge:

```
# before
slurm_node_drain_reason_info{node="c1",reason="disk failure",since="2026-07-22T12:57:18"} 1

# after
slurm_node_drain_reason_info{node="c1",reason="disk failure"} 1
slurm_node_drain_since_timestamp_seconds{node="c1"} 1.784725038e+09
```

How long a node has been drained, and why:

```promql
(time() - slurm_node_drain_since_timestamp_seconds)
  * on(node) group_left(reason) slurm_node_drain_reason_info
```

The metric name, its value of `1`, and its `node` and `reason` labels are
unchanged, so only queries that actually read `since` are affected.

A timestamp `sinfo` does not provide is left **absent** rather than published as
zero, so the subtraction above can never report a drain that started in 1970.

The unused `Partition` field is removed from `DrainReasonMetrics`: it was never
populated and never read. `make check`'s `deadcode` pass confirms.

## Test evidence

Three tests were written first and run against unmodified code. Two fail, the
third guards the opposite direction and passes on `master`:

```
--- FAIL: TestDrainReasonSeriesIdentityIsStableAcrossRedrains
    expected: slurm_node_drain_reason_info{node="c1",reason="disk failure"} 1
    actual  : slurm_node_drain_reason_info{node="c1",reason="disk failure",since="2026-04-01T10:00:00"} 1
    ... and on the second scrape of the same node, same reason:
    actual  : slurm_node_drain_reason_info{node="c1",reason="disk failure",since="2026-07-01T08:30:00"} 1
    a re-drain must land on the existing series instead of creating a second one

--- FAIL: TestDrainReasonExportsSinceAsATimestamp
    expected: slurm_node_drain_since_timestamp_seconds{node="c1"} 1.7750304e+09
    actual  : []string(nil)

--- PASS: TestDrainReasonOmitsTimestampWhenSinfoReportsNone
```

All three pass after the fix, and the whole suite stays green.

## Field verification

Run on the `scripts/testing` cluster, **Slurm 25.11.2**, with `master` on `:9342`
and this branch on `:9341` against the same cluster and the same nodes.

`sinfo` timestamp format confirmed live, which is what the parser reads:

```
$ sinfo -h -N -o "%N|%E|%H|%T"
c1|disk failure, replacing NVMe|2026-07-22T12:57:18|drained
c2|firmware upgrade|2026-07-22T12:57:18|down
```

Drain `c1`, resume it, drain it again for the same reason:

```
scrape 1   master   ..._info{node="c1",reason="disk failure…",since="2026-07-22T12:57:18"} 1
           branch   ..._info{node="c1",reason="disk failure…"} 1
                    ..._since_timestamp_seconds{node="c1"} 1.784725038e+09

scrape 2   master   ..._info{node="c1",reason="disk failure…",since="2026-07-22T13:01:24"} 1
           branch   ..._info{node="c1",reason="disk failure…"} 1
                    ..._since_timestamp_seconds{node="c1"} 1.784725284e+09
```

`master` produced two series for one node and one drain reason. The branch kept
one series and moved the value. Confirmed in the TSDB after both drains:

```
$ /api/v1/series?match[]=slurm_node_drain_reason_info{node="c1"}
1 series:
   {__name__: slurm_node_drain_reason_info, node: c1, reason: disk failure, replacing NVMe}
```

`SLURM_TIME_FORMAT=relative` is a real hazard, confirmed on the cluster: `%H`
becomes `13:01:24`. The exporter then publishes the reason, omits the timestamp,
and logs

```
level=WARN msg="Unreadable drain timestamp from sinfo; no slurm_node_drain_since_timestamp_seconds for this node"
  node=c1 since=13:01:24 expected_layout=2006-01-02T15:04:05
  hint="SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment"
```

## Dashboard and alert impact

No panel and no rule reads either metric (`grep -rn "slurm_node_drain" monitoring/`
returns nothing), so there is nothing to update.

That claim is backed by more than a grep. Diffing the complete `/metrics`
exposition between `master` and this branch on the same cluster, with values
stripped so only series identity is compared:

```
master 446 series, branch 448 series

254,255c254,257
< slurm_node_drain_reason_info{node="c1",reason="disk failure, replacing NVMe",since="2026-07-22T13:01:24"}
< slurm_node_drain_reason_info{node="c2",reason="firmware upgrade",since="2026-07-22T12:57:18"}
---
> slurm_node_drain_reason_info{node="c1",reason="disk failure, replacing NVMe"}
> slurm_node_drain_reason_info{node="c2",reason="firmware upgrade"}
> slurm_node_drain_since_timestamp_seconds{node="c1"}
> slurm_node_drain_since_timestamp_seconds{node="c2"}
```

Every other series is byte-identical, so no panel can see a difference. The 30
dashboard screenshots were captured anyway and all panels render; "Down & Drain
Nodes" correctly lists `c1` drained and `c2` down, from the node state metrics.

## Definition of Done

| Step | Result |
|---|---|
| 1. `make build` | pass |
| 2. `make test`, coverage | pass; 84.7% on the branch vs 84.7% on a pristine `1e9232a` worktree |
| 3. lint | `golangci-lint` 0 issues, `deadcode` clean, `govulncheck` 0 reachable |
| 4. cluster setup | 10 nodes, 10 dashboards imported, exporter on `:9341` |
| 5. workload | **not satisfiable on this host.** Jobs die within a second (`RaisedSignal:53`) under WSL2. Not needed here: the defect is exercised by draining nodes, which works. |
| 6. Prometheus validation | both metrics queryable; the documented join returns a drain duration per node |
| 7. log check | exporter 0 ERROR / 0 WARN over 5 scrapes. `slurmctld.log` shows 11 errors, all pre-existing or self-inflicted: 7 `MailProg is invalid`, the rest `slurmd` startup races, plus 4 `update_node: node cpu-node-01 does not exist` from a mistyped node name in my own first `scontrol` call. |
| 8. dashboards | not modified; verified anyway, see above |
| 9. cluster stop | clean, no dangling containers |
| 10. `act push` | `Job succeeded` |

## Breaking change

`slurm_node_drain_reason_info` no longer carries a `since` label. Anything that
selects on it or displays it must read `slurm_node_drain_since_timestamp_seconds`
instead, joined on `node`. Needs a release note.

## Follow-up

`Execute` inherits the exporter's environment, so `SLURM_TIME_FORMAT` reaches
every Slurm command, not just this one. Pinning it to `standard` for all commands
is a separate change and will get its own issue.
