### PR TITLE
fix(reservations): omit timestamps scontrol printed in an unreadable format

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -215,6 +215,13 @@ Provides metrics about active Slurm reservations.
 | `slurm_reservation_node_count` | The number of nodes allocated to the reservation | `reservation_name` |
 | `slurm_reservation_core_count` | The number of cores allocated to the reservation | `reservation_name` |
 
+Either timestamp is absent, rather than zero, when `scontrol` prints a value the
+exporter cannot read. The expected format is the `scontrol` default
+(`2026-07-22T14:24:22`); setting `SLURM_TIME_FORMAT` to anything other than
+`standard` in the exporter's environment makes the field unreadable, which is
+logged at `WARN` with the raw value. The other metrics of the reservation are
+still published.
+
 ### `reservation_nodes` Collector
 
 Provides per-reservation node state metrics, parsed from `scontrol show nodes -o`.

--- a/internal/collector/helpers_test.go
+++ b/internal/collector/helpers_test.go
@@ -1,0 +1,75 @@
+package collector
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// stubExecute makes every Slurm command return the given output for the rest of
+// the test, and puts the real Execute back afterwards.
+func stubExecute(t *testing.T, output string) {
+	t.Helper()
+	old := Execute
+	t.Cleanup(func() { Execute = old })
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return []byte(output), nil
+	}
+}
+
+// bufferLogger returns a WARN-level logger writing into the returned buffer, so
+// a test can assert that a collector reported a problem instead of staying
+// silent about it.
+func bufferLogger() (*logger.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	return &logger.Logger{Logger: slog.New(handler)}, &buf
+}
+
+// unixLocal converts a Slurm timestamp the way the command produced it, in the
+// local zone of the host that ran it, which is the exporter host. The layout is
+// spelled out rather than read from slurmTimeLayout so that changing the
+// production constant surfaces as a test failure.
+func unixLocal(t *testing.T, value string) float64 {
+	t.Helper()
+	ts, err := time.ParseInLocation("2006-01-02T15:04:05", value, time.Local)
+	require.NoError(t, err)
+	return float64(ts.Unix())
+}
+
+// gatheredSeries renders one gauge family as sorted `name{label="value",...} value`
+// lines, so a test can assert on exact series identity instead of on a count. A
+// family the collector did not publish yields an empty slice, which is how a test
+// states that a metric is absent rather than zero.
+func gatheredSeries(t *testing.T, c prometheus.Collector, name string) []string {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	var series []string
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			pairs := make([]string, 0, len(m.GetLabel()))
+			for _, l := range m.GetLabel() {
+				pairs = append(pairs, fmt.Sprintf("%s=%q", l.GetName(), l.GetValue()))
+			}
+			series = append(series, fmt.Sprintf("%s{%s} %g", name, strings.Join(pairs, ","), m.GetGauge().GetValue()))
+		}
+	}
+	sort.Strings(series)
+	return series
+}

--- a/internal/collector/node_drain_since_test.go
+++ b/internal/collector/node_drain_since_test.go
@@ -2,63 +2,12 @@ package collector
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
-
-// stubDrainSinfo makes Execute return the given "%N|%E|%H|%T" lines for the rest
-// of the test.
-func stubDrainSinfo(t *testing.T, output string) {
-	t.Helper()
-	old := Execute
-	t.Cleanup(func() { Execute = old })
-	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
-		return []byte(output), nil
-	}
-}
-
-// unixLocal converts a sinfo "%H" timestamp the way sinfo produced it, in the
-// local zone of the host running the command, which is the exporter host.
-func unixLocal(t *testing.T, value string) float64 {
-	t.Helper()
-	ts, err := time.ParseInLocation("2006-01-02T15:04:05", value, time.Local)
-	require.NoError(t, err)
-	return float64(ts.Unix())
-}
-
-// drainSeries renders one metric family as sorted `name{label="value",...} value`
-// lines, so a test can assert on the exact series identity instead of on a count.
-func drainSeries(t *testing.T, c prometheus.Collector, name string) []string {
-	t.Helper()
-	reg := prometheus.NewRegistry()
-	require.NoError(t, reg.Register(c))
-	mfs, err := reg.Gather()
-	require.NoError(t, err)
-
-	var series []string
-	for _, mf := range mfs {
-		if mf.GetName() != name {
-			continue
-		}
-		for _, m := range mf.GetMetric() {
-			pairs := make([]string, 0, len(m.GetLabel()))
-			for _, l := range m.GetLabel() {
-				pairs = append(pairs, fmt.Sprintf("%s=%q", l.GetName(), l.GetValue()))
-			}
-			series = append(series, fmt.Sprintf("%s{%s} %g", name, strings.Join(pairs, ","), m.GetGauge().GetValue()))
-		}
-	}
-	sort.Strings(series)
-	return series
-}
 
 // TestDrainReasonSeriesIdentityIsStableAcrossRedrains is the non-regression test
 // for unbounded series growth on slurm_node_drain_reason_info.
@@ -73,12 +22,12 @@ func TestDrainReasonSeriesIdentityIsStableAcrossRedrains(t *testing.T) {
 	want := []string{`slurm_node_drain_reason_info{node="c1",reason="disk failure"} 1`}
 	log := logger.NewLogger("error")
 
-	stubDrainSinfo(t, "c1|disk failure|2026-04-01T10:00:00|drained\n")
-	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"))
+	stubExecute(t, "c1|disk failure|2026-04-01T10:00:00|drained\n")
+	assert.Equal(t, want, gatheredSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"))
 
 	// The same node, drained again for the same reason three months later.
-	stubDrainSinfo(t, "c1|disk failure|2026-07-01T08:30:00|drained\n")
-	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"),
+	stubExecute(t, "c1|disk failure|2026-07-01T08:30:00|drained\n")
+	assert.Equal(t, want, gatheredSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"),
 		"a re-drain must land on the existing series instead of creating a second one")
 }
 
@@ -86,13 +35,13 @@ func TestDrainReasonSeriesIdentityIsStableAcrossRedrains(t *testing.T) {
 // The drain time belongs in the value, where it can be plotted and subtracted
 // from time() to get a drain duration.
 func TestDrainReasonExportsSinceAsATimestamp(t *testing.T) {
-	stubDrainSinfo(t, "c1|disk failure|2026-04-01T10:00:00|drained\nc2|hw-fail|2026-04-01T09:00:00|down\n")
+	stubExecute(t, "c1|disk failure|2026-04-01T10:00:00|drained\nc2|hw-fail|2026-04-01T09:00:00|down\n")
 
 	want := []string{
 		fmt.Sprintf(`slurm_node_drain_since_timestamp_seconds{node="c1"} %g`, unixLocal(t, "2026-04-01T10:00:00")),
 		fmt.Sprintf(`slurm_node_drain_since_timestamp_seconds{node="c2"} %g`, unixLocal(t, "2026-04-01T09:00:00")),
 	}
-	assert.Equal(t, want, drainSeries(t, NewDrainReasonCollector(logger.NewLogger("error")), "slurm_node_drain_since_timestamp_seconds"))
+	assert.Equal(t, want, gatheredSeries(t, NewDrainReasonCollector(logger.NewLogger("error")), "slurm_node_drain_since_timestamp_seconds"))
 }
 
 // TestDrainReasonOmitsTimestampWhenSinfoReportsNone guards the other direction.
@@ -102,10 +51,10 @@ func TestDrainReasonExportsSinceAsATimestamp(t *testing.T) {
 // rather than zero: zero reads as 1970 and makes every time() subtraction wrong
 // by decades.
 func TestDrainReasonOmitsTimestampWhenSinfoReportsNone(t *testing.T) {
-	stubDrainSinfo(t, "c1|disk failure|Unknown|drained\n")
+	stubExecute(t, "c1|disk failure|Unknown|drained\n")
 	log := logger.NewLogger("error")
 
-	assert.Len(t, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"), 1,
+	assert.Len(t, gatheredSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_reason_info"), 1,
 		"the node is drained, so its reason is still published")
-	assert.Empty(t, drainSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_since_timestamp_seconds"))
+	assert.Empty(t, gatheredSeries(t, NewDrainReasonCollector(log), "slurm_node_drain_since_timestamp_seconds"))
 }

--- a/internal/collector/reservations.go
+++ b/internal/collector/reservations.go
@@ -28,6 +28,12 @@ type ReservationInfo struct {
 	CoreCount float64
 	StartTime time.Time
 	EndTime   time.Time
+	// StartTimeRaw and EndTimeRaw hold the fields exactly as scontrol printed
+	// them, so an unreadable value can be named in a log line. A zero time
+	// with a non-empty raw field is a parse failure; both empty means scontrol
+	// never printed the field.
+	StartTimeRaw string
+	EndTimeRaw   string
 }
 
 // ReservationsCollector collects metrics about Slurm reservations.
@@ -102,13 +108,35 @@ func (c *ReservationsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 		res := &reservations[i]
 		labels := []string{res.Name, res.State, res.Users, res.Nodes, res.Partition, res.Flags}
 		ch <- prometheus.MustNewConstMetric(c.info, prometheus.GaugeValue, 1, labels...)
-		ch <- prometheus.MustNewConstMetric(c.startTime, prometheus.GaugeValue, float64(res.StartTime.Unix()), res.Name)
-		ch <- prometheus.MustNewConstMetric(c.endTime, prometheus.GaugeValue, float64(res.EndTime.Unix()), res.Name)
+		c.emitTime(ch, c.startTime, res.Name, "StartTime", res.StartTime, res.StartTimeRaw)
+		c.emitTime(ch, c.endTime, res.Name, "EndTime", res.EndTime, res.EndTimeRaw)
 		ch <- prometheus.MustNewConstMetric(c.nodeCount, prometheus.GaugeValue, res.NodeCount, res.Name)
 		ch <- prometheus.MustNewConstMetric(c.coreCount, prometheus.GaugeValue, res.CoreCount, res.Name)
 	}
 
 	return nil
+}
+
+// emitTime publishes one reservation timestamp, or nothing when scontrol printed
+// a value slurmTimeLayout rejects.
+//
+// The zero time.Time was published as -62135596800, which places the reservation
+// in year 1 and reads as data: dashboards subtract it, thresholds compare it, and
+// nothing marks it invalid. An absent series is the only answer a consumer can
+// tell apart from a measurement. The WARN carries the raw value because that is
+// what points at the cause, almost always SLURM_TIME_FORMAT in the exporter's
+// environment. See issue #158.
+func (c *ReservationsCollector) emitTime(ch chan<- prometheus.Metric, desc *prometheus.Desc, name, field string, t time.Time, raw string) {
+	if !t.IsZero() {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(t.Unix()), name)
+		return
+	}
+	if raw == "" {
+		return // scontrol did not print the field at all
+	}
+	c.logger.Warn("Unreadable reservation timestamp from scontrol; the metric is omitted for this reservation",
+		"reservation", name, "field", field, "value", raw, "expected_layout", slurmTimeLayout,
+		"hint", "SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment")
 }
 
 /*
@@ -144,10 +172,23 @@ func setReservationField(res *ReservationInfo, key, value string) {
 	case "CoreCnt":
 		res.CoreCount, _ = strconv.ParseFloat(value, 64)
 	case "StartTime":
-		res.StartTime, _ = time.ParseInLocation(slurmTimeLayout, value, time.Local)
+		res.StartTimeRaw = value
+		res.StartTime = parseSlurmTime(value)
 	case "EndTime":
-		res.EndTime, _ = time.ParseInLocation(slurmTimeLayout, value, time.Local)
+		res.EndTimeRaw = value
+		res.EndTime = parseSlurmTime(value)
 	}
+}
+
+// parseSlurmTime reads one scontrol timestamp field. A value slurmTimeLayout
+// rejects yields the zero time.Time, which the collector reads as "do not
+// publish" rather than as a date in year 1. See issue #158.
+func parseSlurmTime(value string) time.Time {
+	t, err := time.ParseInLocation(slurmTimeLayout, value, time.Local)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // parseReservations parses the output of `scontrol show reservation`. Records

--- a/internal/collector/reservations_timestamp_test.go
+++ b/internal/collector/reservations_timestamp_test.go
@@ -1,0 +1,100 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// relativeTimeReservation is real `scontrol show reservation` output, captured on
+// the scripts/testing cluster running Slurm 25.11.2 with SLURM_TIME_FORMAT set to
+// "relative". Execute never sets cmd.Env, so whatever value the exporter's own
+// environment holds reaches every Slurm command.
+func relativeTimeReservation(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("../../test_data/sreservations_relative_time.txt")
+	require.NoError(t, err)
+	return string(data)
+}
+
+// TestReservationOmitsUnreadableTimestamps is the non-regression test for issue
+// #158.
+//
+// The parse error was discarded, leaving the zero time.Time, and the collector
+// published it anyway. time.Time{}.Unix() is -62135596800, which places the
+// reservation in year 1 and is indistinguishable from a measurement: no
+// threshold rejects it, no subtraction fails on it, and nothing logged it. An
+// absent series is the only honest answer when the timestamp could not be read.
+func TestReservationOmitsUnreadableTimestamps(t *testing.T) {
+	stubExecute(t, relativeTimeReservation(t))
+	log, logs := bufferLogger()
+	c := NewReservationsCollector(log)
+
+	assert.Empty(t, gatheredSeries(t, c, "slurm_reservation_start_time_seconds"),
+		"an unreadable StartTime must be absent, not year 1")
+	assert.Empty(t, gatheredSeries(t, c, "slurm_reservation_end_time_seconds"),
+		"an unreadable EndTime must be absent, not year 1")
+
+	assert.Equal(t,
+		[]string{`slurm_reservation_node_count{reservation_name="maint-158"} 4`},
+		gatheredSeries(t, c, "slurm_reservation_node_count"),
+		"the reservation itself is still reported; only its timestamps are missing")
+
+	assert.Contains(t, logs.String(), "maint-158")
+	assert.Contains(t, logs.String(), "14:24:22",
+		"the raw value belongs in the log, it is what tells an operator what to fix")
+}
+
+// TestReservationOmitsOnlyTheUnreadableTimestamp pins that the two timestamps are
+// judged one at a time. Dropping both because one failed would lose data the
+// collector actually has.
+func TestReservationOmitsOnlyTheUnreadableTimestamp(t *testing.T) {
+	stubExecute(t, "ReservationName=maint-158 StartTime=2026-07-22T14:24:22 EndTime=16:24:22 Duration=02:00:00\n"+
+		"   Nodes=c[1-4] NodeCnt=4 CoreCnt=64 PartitionName=(null) Flags=MAINT\n"+
+		"   Users=root State=ACTIVE\n")
+	c := NewReservationsCollector(logger.NewLogger("error"))
+
+	assert.Equal(t,
+		[]string{fmt.Sprintf(`slurm_reservation_start_time_seconds{reservation_name="maint-158"} %g`, unixLocal(t, "2026-07-22T14:24:22"))},
+		gatheredSeries(t, c, "slurm_reservation_start_time_seconds"))
+	assert.Empty(t, gatheredSeries(t, c, "slurm_reservation_end_time_seconds"))
+}
+
+// TestReservationStaysSilentWhenScontrolPrintsNoTimestamp separates the two ways
+// a timestamp can be missing. A field scontrol never printed is not something an
+// operator can fix by changing SLURM_TIME_FORMAT, so it must not raise that
+// warning. Only a field that was printed and could not be read does.
+func TestReservationStaysSilentWhenScontrolPrintsNoTimestamp(t *testing.T) {
+	stubExecute(t, "ReservationName=maint-158 Duration=02:00:00 NodeCnt=4 CoreCnt=64 Users=root State=ACTIVE\n")
+	log, logs := bufferLogger()
+	c := NewReservationsCollector(log)
+
+	assert.Empty(t, gatheredSeries(t, c, "slurm_reservation_start_time_seconds"))
+	assert.Len(t, gatheredSeries(t, c, "slurm_reservation_info"), 1,
+		"the reservation is still reported")
+	assert.Empty(t, logs.String())
+}
+
+// TestReservationExportsReadableTimestamps guards the other direction: the fix
+// must not stop publishing timestamps that parse.
+func TestReservationExportsReadableTimestamps(t *testing.T) {
+	data, err := os.ReadFile("../../test_data/sreservations.txt")
+	require.NoError(t, err)
+	stubExecute(t, string(data))
+
+	log, logs := bufferLogger()
+	c := NewReservationsCollector(log)
+
+	assert.Equal(t,
+		[]string{fmt.Sprintf(`slurm_reservation_start_time_seconds{reservation_name="pre-reservation-maintenance"} %g`, unixLocal(t, "2025-08-26T07:00:00"))},
+		gatheredSeries(t, c, "slurm_reservation_start_time_seconds"))
+	assert.Equal(t,
+		[]string{fmt.Sprintf(`slurm_reservation_end_time_seconds{reservation_name="pre-reservation-maintenance"} %g`, unixLocal(t, "2025-08-29T20:00:00"))},
+		gatheredSeries(t, c, "slurm_reservation_end_time_seconds"))
+	assert.Empty(t, logs.String(), "a reservation that parses cleanly must stay silent")
+}

--- a/test_data/sreservations_relative_time.txt
+++ b/test_data/sreservations_relative_time.txt
@@ -1,0 +1,6 @@
+ReservationName=maint-158 StartTime=14:24:22 EndTime=16:24:22 Duration=02:00:00
+   Nodes=c[1-4] NodeCnt=4 CoreCnt=64 Features=(null) PartitionName=(null) Flags=MAINT,SPEC_NODES
+   TRES=cpu=128
+   AllowedPartitions=(null) QOS=(null)
+   Users=root Groups=(null) Accounts=(null) Licenses=(null) State=ACTIVE BurstBuffer=(null)
+   MaxStartDelay=(null)


### PR DESCRIPTION
Fixes #158.

`slurm_reservation_start_time_seconds` and `slurm_reservation_end_time_seconds`
published `-62135596800` whenever `scontrol` printed a date the parser rejects.
The parse error was discarded, leaving the zero `time.Time`, and the collector
published it unconditionally.

## What changes

Each timestamp is judged on its own. One that could not be read is omitted
rather than published as year 1, the reservation keeps its other metrics, and a
`WARN` names the reservation, the field, the raw value and the expected layout.
A field `scontrol` never printed stays silent, since that is not something
`SLURM_TIME_FORMAT` can explain.

Same shape as the drain timestamp fix in #141.

## Reproduced on a live cluster

`scripts/testing`, Slurm 25.11.2, one reservation, the exporter started with
`SLURM_TIME_FORMAT=relative` in its environment. `Execute` never sets `cmd.Env`,
so the variable reaches every Slurm command.

```
$ scontrol show reservation
ReservationName=maint-158 StartTime=2026-07-22T14:24:22 EndTime=2026-07-22T16:24:22

$ SLURM_TIME_FORMAT=relative scontrol show reservation
ReservationName=maint-158 StartTime=14:24:22 EndTime=16:24:22
```

Before, on `bb2b381`:

```
slurm_reservation_start_time_seconds{reservation_name="maint-158"} -6.21355968e+10
slurm_reservation_end_time_seconds{reservation_name="maint-158"} -6.21355968e+10
```

Nothing was logged: `grep -i "warn\|error"` on the exporter log came back empty.

After:

```
slurm_reservation_core_count{reservation_name="maint-158"} 64
slurm_reservation_info{flags="MAINT,SPEC_NODES",...,reservation_name="maint-158"} 1
slurm_reservation_node_count{reservation_name="maint-158"} 4
```

```
level=WARN msg="Unreadable reservation timestamp from scontrol; the metric is omitted for this reservation"
  reservation=maint-158 field=StartTime value=14:24:22 expected_layout=2006-01-02T15:04:05
  hint="SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment"
```

Nominal, with the variable unset, both binaries agree to the second:

```
slurm_reservation_start_time_seconds{reservation_name="maint-158"} 1.784730262e+09  # 2026-07-22T14:24:22 UTC
slurm_reservation_end_time_seconds{reservation_name="maint-158"}   1.784737462e+09  # 2026-07-22T16:24:22 UTC
```

## Exposition impact

`bb2b381` and this branch were run side by side against the same cluster, on
`:9342` and `:9341`, and their full `/metrics` output compared with values
stripped.

| Environment | master | branch | difference |
|---|---|---|---|
| `SLURM_TIME_FORMAT` unset | 454 series | 454 series | none, byte for byte |
| `SLURM_TIME_FORMAT=relative` | 454 series | 452 series | the two year-1 series are gone |

No other series moves in either direction, so no panel and no rule can observe
anything except the defect being removed.

`monitoring/grafana/dashboards/06-slurm-reservations.json` reads both metrics in
three panel expressions. Screenshot after the fix, nominal: Reservation Info
shows `Duration 2.0` h, and the two time panels show `07/22/2026, 02:24:22 PM`
and `07/22/2026, 04:24:22 PM`.

## Tests

Four tests in `internal/collector/reservations_timestamp_test.go`, three of which
fail on `bb2b381`:

```
--- FAIL: TestReservationOmitsUnreadableTimestamps
    Should be empty, but was [slurm_reservation_start_time_seconds{reservation_name="maint-158"} -6.21355968e+10]
    Should be empty, but was [slurm_reservation_end_time_seconds{reservation_name="maint-158"} -6.21355968e+10]
    "" does not contain "maint-158"
--- FAIL: TestReservationOmitsOnlyTheUnreadableTimestamp
    Should be empty, but was [slurm_reservation_end_time_seconds{reservation_name="maint-158"} -6.21355968e+10]
--- PASS: TestReservationExportsReadableTimestamps
```

`test_data/sreservations_relative_time.txt` is real `scontrol` output captured on
the cluster under `SLURM_TIME_FORMAT=relative`, not a hand-written approximation.

The first commit moves the three helpers introduced with the drain tests to
`helpers_test.go` under neutral names, since a second collector test needed
them, and adds `bufferLogger` so a test can assert that a collector reported a
problem instead of staying silent.

Coverage: 84.7% to 85.6%. `emitTime` is at 100%.

## Not in this PR

Pinning `SLURM_TIME_FORMAT=standard` in `Execute` closes the whole class rather
than this one collector. It changes `cmd.Env` for every Slurm command, so it
gets its own PR and its own test. #158 stays open until that lands.

## Definition of Done

| Step | Result |
|---|---|
| 1. `make build` | ok |
| 2. `make test` + coverage | 177 tests pass, 84.7% to 85.6% |
| 3. lint | `make check` clean (vet, golangci-lint, govulncheck, actionlint, zizmor, deadcode) |
| 4. cluster setup | 10 nodes, 10 dashboards imported, exporter on `:9341` |
| 5. `workload N=20` | jobs submitted; none reach RUNNING on WSL2, a known limitation of this host rather than of the change |
| 6. Prometheus | `slurm_reservation_start_time_seconds` returns `1784730262`, matching `scontrol` to the second |
| 7. logs | 0 WARN and 0 ERROR from the exporter in nominal mode. `slurmctld.log` holds its usual background noise (`MailProg is invalid`, `slurmd` startup races) plus four `update_node: node cpu-node-01 does not exist` lines timestamped 12:57, which are mine from the #141 session and predate this branch |
| 8. dashboards | `06-slurm-reservations.json` screenshotted, all three affected panels correct |
| 9. cluster stop | clean |
| 10. `act push` | release.yml `test` job green |

Also `make race`: clean.
