### PR TITLE
fix(execute): pin SLURM_TIME_FORMAT=standard on every Slurm command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,21 @@ This requires disabling all other collectors individually.
 
 ---
 
+## 🌍 Environment
+
+Slurm commands run with the environment the exporter itself was started with, so
+anything set in the systemd unit or the container reaches `sinfo`, `squeue`,
+`scontrol`, `sdiag`, `sshare` and `sacct`. `SLURM_CONF` is the usual one to set,
+when the configuration file is not where the Slurm binaries look for it.
+
+One variable is not inherited. `SLURM_TIME_FORMAT` is pinned to `standard` on
+every command, because the exporter parses the timestamps that come back and can
+read only that layout. Setting it for the exporter process has no effect.
+`standard` is also what Slurm uses when the variable is unset, so this changes
+nothing for a site that never set it.
+
+---
+
 ## 📡 Prometheus Configuration
 
 ```yaml

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -216,11 +216,11 @@ Provides metrics about active Slurm reservations.
 | `slurm_reservation_core_count` | The number of cores allocated to the reservation | `reservation_name` |
 
 Either timestamp is absent, rather than zero, when `scontrol` prints a value the
-exporter cannot read. The expected format is the `scontrol` default
-(`2026-07-22T14:24:22`); setting `SLURM_TIME_FORMAT` to anything other than
-`standard` in the exporter's environment makes the field unreadable, which is
-logged at `WARN` with the raw value. The other metrics of the reservation are
-still published.
+exporter cannot read. The exporter pins `SLURM_TIME_FORMAT=standard` on every
+Slurm command, so the field comes back as `2026-07-22T14:24:22` whatever the
+exporter's own environment holds. A value that still fails to parse is logged at
+`WARN` with the raw string, and the other metrics of the reservation are still
+published.
 
 ### `reservation_nodes` Collector
 
@@ -341,10 +341,10 @@ and why:
 
 `slurm_node_drain_since_timestamp_seconds` is absent for a node whose reason
 carries no timestamp, rather than zero, so the subtraction above never reports a
-drain that started in 1970. The exporter reads the timestamp in the default
-`sinfo` format (`2026-04-01T10:00:00`); setting `SLURM_TIME_FORMAT` to anything
-other than `standard` in the exporter's environment makes the field unreadable,
-which is logged at `WARN` once per affected node per scrape.
+drain that started in 1970. The exporter pins `SLURM_TIME_FORMAT=standard` on
+every Slurm command, so the field comes back as `2026-04-01T10:00:00` whatever
+the exporter's own environment holds. A value that still fails to parse is
+logged at `WARN` once per affected node per scrape.
 
 ---
 

--- a/internal/collector/execute.go
+++ b/internal/collector/execute.go
@@ -98,6 +98,22 @@ func RegisterExecMetrics(reg prometheus.Registerer) {
 	})
 }
 
+// slurmCommandEnv returns the environment every Slurm command is run with: the
+// exporter's own, plus SLURM_TIME_FORMAT pinned to Slurm's "standard" layout.
+//
+// Slurm renders every timestamp according to that variable, and the exporter can
+// only read one layout. Inheriting it meant a value set for interactive use, in
+// /etc/profile.d or in a systemd unit, silently reached sinfo, squeue, scontrol,
+// sdiag, sshare and sacct, and the timestamps came back in a shape the parsers
+// reject. "standard" is already what Slurm uses when the variable is unset, so
+// pinning it changes nothing for a site that never set it. See issue #158.
+//
+// The rest of the environment is kept: Slurm commands need it, SLURM_CONF above
+// all. Duplicate keys are allowed here because exec keeps the last value.
+func slurmCommandEnv() []string {
+	return append(os.Environ(), "SLURM_TIME_FORMAT=standard")
+}
+
 // Execute is a wrapper around exec.CommandContext providing logging, timeout,
 // and performance instrumentation (duration histogram + error counter).
 // When binPath is set, command is resolved as filepath.Join(binPath, command).
@@ -115,6 +131,7 @@ var Execute = func(log *logger.Logger, command string, args []string) ([]byte, e
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bin, args...) //nolint:gosec // G204: command is always a controlled Slurm binary, never user input
+	cmd.Env = slurmCommandEnv()
 	out, err := cmd.CombinedOutput()
 
 	elapsed := time.Since(start).Seconds()

--- a/internal/collector/execute_env_test.go
+++ b/internal/collector/execute_env_test.go
@@ -1,0 +1,82 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// echoEnvBinary installs a fake Slurm binary that prints one environment
+// variable, so a test can read the environment the child process was actually
+// given instead of the one the exporter holds. binPath and commandTimeout are
+// package-level state, so both are restored when the test ends.
+func echoEnvBinary(t *testing.T, name, variable string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' \"$%s\"\n", variable)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+
+	oldBinPath, oldTimeout := binPath, commandTimeout
+	SetBinPath(dir)
+	SetCommandTimeout(5 * time.Second)
+	t.Cleanup(func() {
+		SetBinPath(oldBinPath)
+		SetCommandTimeout(oldTimeout)
+	})
+}
+
+// TestExecutePinsSlurmTimeFormat is the non-regression test for the second half
+// of issue #158.
+//
+// Every Slurm command renders its timestamps according to SLURM_TIME_FORMAT.
+// Execute inherited whatever the exporter's own environment held, so a value set
+// for interactive use, in /etc/profile.d or in a systemd unit, reached sinfo,
+// squeue, scontrol, sdiag, sshare and sacct alike and made their timestamps
+// unreadable to the parsers. Pinning the format is what makes the collectors'
+// layout a fact rather than a hope.
+func TestExecutePinsSlurmTimeFormat(t *testing.T) {
+	t.Setenv("SLURM_TIME_FORMAT", "relative")
+	echoEnvBinary(t, "scontrol", "SLURM_TIME_FORMAT")
+
+	out, err := Execute(logger.NewLogger("error"), "scontrol", []string{"show", "reservation"})
+	require.NoError(t, err)
+	assert.Equal(t, "standard", string(out),
+		"the exporter's own environment must not decide how Slurm renders timestamps")
+}
+
+// TestExecutePinsSlurmTimeFormatWhenUnset pins the format even where nothing set
+// it, so the child process does not depend on Slurm keeping "standard" as its
+// implicit default.
+func TestExecutePinsSlurmTimeFormatWhenUnset(t *testing.T) {
+	// t.Setenv records the original value and restores it at the end of the
+	// test; unsetting afterwards is what puts the process in the "never set"
+	// state without leaking it into the rest of the package.
+	t.Setenv("SLURM_TIME_FORMAT", "")
+	require.NoError(t, os.Unsetenv("SLURM_TIME_FORMAT"))
+	echoEnvBinary(t, "sinfo", "SLURM_TIME_FORMAT")
+
+	out, err := Execute(logger.NewLogger("error"), "sinfo", []string{"-h"})
+	require.NoError(t, err)
+	assert.Equal(t, "standard", string(out))
+}
+
+// TestExecuteKeepsTheRestOfTheEnvironment guards the other direction. Slurm
+// commands need the environment they were started with, SLURM_CONF above all:
+// replacing it rather than extending it would point every command at the wrong
+// cluster, or at no cluster at all.
+func TestExecuteKeepsTheRestOfTheEnvironment(t *testing.T) {
+	t.Setenv("SLURM_CONF", "/etc/slurm/slurm.conf")
+	echoEnvBinary(t, "squeue", "SLURM_CONF")
+
+	out, err := Execute(logger.NewLogger("error"), "squeue", []string{"-h"})
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/slurm/slurm.conf", string(out))
+}

--- a/internal/collector/node_drain.go
+++ b/internal/collector/node_drain.go
@@ -25,9 +25,11 @@ type DrainReasonMetrics struct {
 // sinfo renders the field in the local zone of the host running the command,
 // which is the exporter host, so that is the zone it is read back in. Slurm
 // documents the "standard" SLURM_TIME_FORMAT as
-// year-month-dateThour:minute:second; a site that exports another value, or the
-// "relative" preset, produces strings this layout rejects. Those return 0, which
-// the collector treats as "no timestamp" rather than as 1970.
+// year-month-dateThour:minute:second, and Execute pins that format on every
+// Slurm command, so a string this layout rejects is a layout the exporter does
+// not know rather than a site that configured its environment differently.
+// Those return 0, which the collector treats as "no timestamp" rather than as
+// 1970.
 func parseDrainTime(since string) float64 {
 	t, err := time.ParseInLocation(slurmTimeLayout, since, time.Local)
 	if err != nil {
@@ -153,7 +155,7 @@ func (c *DrainReasonCollector) tryCollect(ch chan<- prometheus.Metric) error {
 		if !drainTimeIsUnset(m.Since) {
 			c.logger.Warn("Unreadable drain timestamp from sinfo; no slurm_node_drain_since_timestamp_seconds for this node",
 				"node", m.Node, "since", m.Since, "expected_layout", slurmTimeLayout,
-				"hint", "SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment")
+				"hint", "the exporter pins SLURM_TIME_FORMAT=standard, so this layout is one it does not know: please report it with your Slurm version")
 		}
 	}
 

--- a/internal/collector/node_drain_since_test.go
+++ b/internal/collector/node_drain_since_test.go
@@ -45,11 +45,11 @@ func TestDrainReasonExportsSinceAsATimestamp(t *testing.T) {
 }
 
 // TestDrainReasonOmitsTimestampWhenSinfoReportsNone guards the other direction.
-// sinfo prints "Unknown" when the reason carries no time, and SLURM_TIME_FORMAT
-// can make it print something this parser does not read. Either way the node is
-// still drained and its reason still matters, but the timestamp must be absent
-// rather than zero: zero reads as 1970 and makes every time() subtraction wrong
-// by decades.
+// sinfo prints "Unknown" when the reason carries no time, and a layout the
+// parser does not read reaches the same place. Either way the node is still
+// drained and its reason still matters, but the timestamp must be absent rather
+// than zero: zero reads as 1970 and makes every time() subtraction wrong by
+// decades.
 func TestDrainReasonOmitsTimestampWhenSinfoReportsNone(t *testing.T) {
 	stubExecute(t, "c1|disk failure|Unknown|drained\n")
 	log := logger.NewLogger("error")

--- a/internal/collector/reservations.go
+++ b/internal/collector/reservations.go
@@ -123,9 +123,10 @@ func (c *ReservationsCollector) tryCollect(ch chan<- prometheus.Metric) error {
 // The zero time.Time was published as -62135596800, which places the reservation
 // in year 1 and reads as data: dashboards subtract it, thresholds compare it, and
 // nothing marks it invalid. An absent series is the only answer a consumer can
-// tell apart from a measurement. The WARN carries the raw value because that is
-// what points at the cause, almost always SLURM_TIME_FORMAT in the exporter's
-// environment. See issue #158.
+// tell apart from a measurement. The WARN carries the raw value because Execute
+// pins SLURM_TIME_FORMAT, so a value that still fails to parse is a layout the
+// exporter does not know, and the raw string is what identifies it. See issue
+// #158.
 func (c *ReservationsCollector) emitTime(ch chan<- prometheus.Metric, desc *prometheus.Desc, name, field string, t time.Time, raw string) {
 	if !t.IsZero() {
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(t.Unix()), name)
@@ -136,7 +137,7 @@ func (c *ReservationsCollector) emitTime(ch chan<- prometheus.Metric, desc *prom
 	}
 	c.logger.Warn("Unreadable reservation timestamp from scontrol; the metric is omitted for this reservation",
 		"reservation", name, "field", field, "value", raw, "expected_layout", slurmTimeLayout,
-		"hint", "SLURM_TIME_FORMAT must be unset or 'standard' in the exporter environment")
+		"hint", "the exporter pins SLURM_TIME_FORMAT=standard, so this layout is one it does not know: please report it with your Slurm version")
 }
 
 /*

--- a/internal/collector/reservations_timestamp_test.go
+++ b/internal/collector/reservations_timestamp_test.go
@@ -13,8 +13,9 @@ import (
 
 // relativeTimeReservation is real `scontrol show reservation` output, captured on
 // the scripts/testing cluster running Slurm 25.11.2 with SLURM_TIME_FORMAT set to
-// "relative". Execute never sets cmd.Env, so whatever value the exporter's own
-// environment holds reaches every Slurm command.
+// "relative". Execute now pins that variable, so this is no longer something a
+// site can cause; it is kept as the one real sample of a layout the parser has
+// to survive, for the day Slurm prints one the exporter does not know.
 func relativeTimeReservation(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile("../../test_data/sreservations_relative_time.txt")
@@ -66,9 +67,9 @@ func TestReservationOmitsOnlyTheUnreadableTimestamp(t *testing.T) {
 }
 
 // TestReservationStaysSilentWhenScontrolPrintsNoTimestamp separates the two ways
-// a timestamp can be missing. A field scontrol never printed is not something an
-// operator can fix by changing SLURM_TIME_FORMAT, so it must not raise that
-// warning. Only a field that was printed and could not be read does.
+// a timestamp can be missing. A field scontrol never printed is normal and says
+// nothing about the layout, so it must not raise the warning. Only a field that
+// was printed and could not be read does.
 func TestReservationStaysSilentWhenScontrolPrintsNoTimestamp(t *testing.T) {
 	stubExecute(t, "ReservationName=maint-158 Duration=02:00:00 NodeCnt=4 CoreCnt=64 Users=root State=ACTIVE\n")
 	log, logs := bufferLogger()


### PR DESCRIPTION
Closes #158.

`Execute` builds every Slurm command with `exec.CommandContext` and never set
`cmd.Env`, so the exporter's own environment reached `sinfo`, `squeue`,
`scontrol`, `sdiag`, `sshare` and `sacct`. `SLURM_TIME_FORMAT` decides how all of
them render timestamps, and the exporter can read only one layout.

#153 and #159 fixed the two collectors that parse timestamps, so an unreadable
value became an absent series instead of a date in year 1. That is the honest
answer, but the measurement is still lost. This pins the format, so it parses.

## The defect, on a live cluster

Slurm 25.11.2, `scripts/testing`. With `SLURM_TIME_FORMAT=relative` exported to
the exporter process, both commands print a bare time:

```
$ scontrol show reservation | head -1
ReservationName=maint-158b StartTime=16:10:48 EndTime=18:10:48 Duration=02:00:00

$ sinfo -h -N -o "%N|%E|%H|%T"
c5|issue-158b test drain|16:10:48|drained
```

The `75a52ef` build and this build were then run side by side against that same
cluster, both started with `SLURM_TIME_FORMAT=relative`:

| | `75a52ef` on `:9342` | this branch on `:9341` |
|---|---|---|
| `slurm_reservation_start_time_seconds` | absent | `1784736648` |
| `slurm_reservation_end_time_seconds` | absent | `1784743848` |
| `slurm_node_drain_since_timestamp_seconds` | absent | `1784736648` |
| `WARN` lines | 12 | 0 |

`1784736648` is `2026-07-22T16:10:48` UTC, which is exactly what `scontrol`
reports with the variable unset. Through Prometheus,
`(end - start) / 3600` returns `2`, and the reservations dashboard renders
`07/22/2026, 04:10:48 PM` to `06:10:48 PM`.

## No change for anyone else

`standard` is already Slurm's behaviour when the variable is unset, so a site
that never set it sees nothing new. Full `/metrics` was captured from both
builds in nominal mode and diffed with values stripped: 520 series on each side,
the only differing line being `go_build_info` (ldflags).

The rest of the environment is passed through unchanged. `SLURM_CONF` is the one
that matters, and `TestExecuteKeepsTheRestOfTheEnvironment` pins it: replacing
the environment rather than extending it would point every command at the wrong
cluster.

## Tests

`internal/collector/execute_env_test.go` installs a fake Slurm binary that prints
one variable, so the assertions read the environment the child process was
actually given:

- `TestExecutePinsSlurmTimeFormat` — parent holds `relative`, child must see
  `standard`. Fails on `75a52ef` with `actual: "relative"`.
- `TestExecutePinsSlurmTimeFormatWhenUnset` — nothing set, child must still see
  `standard`, so the exporter does not depend on Slurm keeping it as the implicit
  default. Fails on `75a52ef` with `actual: ""`.
- `TestExecuteKeepsTheRestOfTheEnvironment` — guard, passes both before and after.

Coverage 85.6% to 85.7%, `slurmCommandEnv` at 100%.

## Warnings that now point somewhere else

#153 and #159 both told operators to check `SLURM_TIME_FORMAT` in the exporter
environment. The pin makes that cause unreachable, so the hint would send them
after a setting that no longer has any effect. Both warnings now say the layout
is one the exporter does not know and ask for the Slurm version, and the two
paragraphs in `docs/metrics.md` were corrected the same way.

`docs/configuration.md` gains a short Environment section: the commands inherit
the exporter's environment, `SLURM_CONF` included, except for this one variable.

## Definition of Done

- `make build`, `make check` (vet, golangci-lint, 180 tests, govulncheck,
  actionlint, zizmor, deadcode), `make race`: all clean
- Integration cluster: 10 nodes, 10 dashboards, workload of 20 jobs
- Prometheus scrape verified, dashboard screenshot verified
- Exporter log: 0 `WARN`, 0 `ERROR`. `slurmctld.log` shows only
  `Configured MailProg is invalid`, present at every startup of the test cluster
  since well before this branch, and `_find_node_record` errors from `12:57:11`,
  which predate it. `slurmdbd.log` shows only the container's innodb tuning
  notice.
- Cluster stopped, no dangling containers
