### PR TITLE
fix(queue): ask squeue for the terminal job states

### DIFF
--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -62,6 +62,16 @@ var (
 			"Disable on clusters with many users to reduce cardinality.",
 	).Default("true").Bool()
 
+	// queueTerminalStates controls whether squeue is asked for every job state.
+	// Without it squeue reports pending and running jobs only, and the failure,
+	// timeout, cancellation and completion metrics all stay at zero (issue #27).
+	queueTerminalStates = kingpin.Flag(
+		"collector.queue.terminal-states",
+		"Ask squeue for terminal job states (FAILED, TIMEOUT, CANCELLED, COMPLETED, ...) "+
+			"in addition to pending and running ones. Disable to restore the pre-1.9 query "+
+			"if the extra slurmctld work is measurable on your cluster.",
+	).Default("true").Bool()
+
 	// fairshareUserMetrics controls whether per-user fairshare metrics are collected.
 	fairshareUserMetrics = kingpin.Flag(
 		"collector.fairshare.user-metrics",
@@ -106,8 +116,10 @@ var collectorConstructors = map[string]func(logger *logger.Logger) prometheus.Co
 	"node":         func(l *logger.Logger) prometheus.Collector { return collector.NewNodeCollector(l) },
 	"drain_reason": func(l *logger.Logger) prometheus.Collector { return collector.NewDrainReasonCollector(l) },
 	"partitions":   func(l *logger.Logger) prometheus.Collector { return collector.NewPartitionsCollector(l) },
-	"queue":        func(l *logger.Logger) prometheus.Collector { return collector.NewQueueCollector(l, *queueUserLabel) },
-	"scheduler":    func(l *logger.Logger) prometheus.Collector { return collector.NewSchedulerCollector(l) },
+	"queue": func(l *logger.Logger) prometheus.Collector {
+		return collector.NewQueueCollector(l, *queueUserLabel, *queueTerminalStates)
+	},
+	"scheduler": func(l *logger.Logger) prometheus.Collector { return collector.NewSchedulerCollector(l) },
 	"fairshare": func(l *logger.Logger) prometheus.Collector {
 		return collector.NewFairShareCollector(l, *fairshareUserMetrics)
 	},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ For details on the `web-config.yml` format, see the [Exporter Toolkit documentat
 | `--collector.nodes.feature-set` | Include `active_feature_set` label in `slurm_nodes_*` metrics | `true` |
 | `--collector.fairshare.user-metrics` | Collect per-user fairshare metrics (`slurm_user_fairshare_*`). Disable on clusters with many users to reduce cardinality. | `true` |
 | `--collector.queue.user-label` | Include `user` label in `slurm_queue_*` metrics. Disable on clusters with many users to reduce cardinality. | `true` |
+| `--collector.queue.terminal-states` | Ask `squeue` for terminal job states (`FAILED`, `TIMEOUT`, `CANCELLED`, `COMPLETED`, ...) on top of pending and running ones. Disable to restore the pre-1.9 query. | `true` |
 | `--collector.sacct_efficiency` | Enable the sacct_efficiency collector (disabled by default — queries SlurmDBD). | `false` |
 | `--collector.sacct.interval` | Background refresh interval for sacct_efficiency. | `5m` |
 | `--collector.sacct.lookback` | Time window for sacct_efficiency queries. | `1h` |

--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -312,7 +312,7 @@ slurm_partition_jobs_running{partition="gpu"} 18
 
 ## `queue` collector
 
-Command: `squeue -h -o "%P|%T|%C|%r|%u"`
+Command: `squeue -h -o "%P|%T|%C|%r|%u" --states=all`
 
 ### With `--collector.queue.user-label` (default)
 
@@ -366,7 +366,7 @@ slurm_jobs_running 312
 
 # HELP slurm_jobs_failed Total failed jobs in the cluster
 # TYPE slurm_jobs_failed gauge
-slurm_jobs_failed 0
+slurm_jobs_failed 2
 
 # HELP slurm_jobs_cores_running Total cores used by running jobs
 # TYPE slurm_jobs_cores_running gauge
@@ -383,6 +383,38 @@ slurm_jobs_running == 0
 ```
 This works reliably because `slurm_jobs_running` is always present.
 With `sum(slurm_queue_running)`, PromQL returns "No Data" when there are no jobs.
+
+### With `--collector.queue.terminal-states` (default)
+
+`--states=all` brings the states a job ends in into the output, so the six
+terminal totals and their per-user twins carry values instead of a constant
+zero:
+
+```
+# HELP slurm_queue_failed Number of failed jobs
+# TYPE slurm_queue_failed gauge
+slurm_queue_failed{partition="gpu",user="alice"} 1
+slurm_queue_failed{partition="cpu",user="bob"} 1
+
+# HELP slurm_queue_timeout Jobs stopped by timeout
+# TYPE slurm_queue_timeout gauge
+slurm_queue_timeout{partition="cpu",user="bob"} 3
+
+# HELP slurm_jobs_completed Total completed jobs in the cluster
+# TYPE slurm_jobs_completed gauge
+slurm_jobs_completed 41
+```
+
+The window is `MinJobAge` (`slurm.conf`, 300 seconds by default): `slurmctld`
+forgets a terminated job past that age, so these gauges count the last few
+minutes and fall back to zero by themselves. Alert on a rate, never on
+`slurm_jobs_failed > 0`.
+
+### With `--no-collector.queue.terminal-states`
+
+The pre-1.9 query comes back and the same six totals sit at zero, as do the
+`slurm_queue_*` and `slurm_cores_*` series behind them. Only pending and running
+jobs are reported.
 
 ---
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -167,7 +167,7 @@ while the `queue` collector does neither.
 
 Provides detailed metrics on job states and resource usage.
 
-- **Command:** `squeue -h -o "%P|%T|%C|%r|%u"`
+- **Command:** `squeue -h -o "%P|%T|%C|%r|%u" --states=all`
 
 **Per-user/partition metrics** — only emitted when jobs exist in that state:
 
@@ -198,6 +198,33 @@ Provides detailed metrics on job states and resource usage.
 | `slurm_jobs_cancelled` | Total cancelled jobs | (none) |
 | `slurm_jobs_cores_running` | Total cores used by running jobs | (none) |
 | `slurm_jobs_cores_pending` | Total cores requested by pending jobs | (none) |
+
+#### Terminal states and the `MinJobAge` window
+
+`squeue` reports pending and running jobs when it is not told which states to
+view. Everything below counts jobs that only `--states=all` makes visible:
+
+`slurm_jobs_failed`, `slurm_jobs_timeout`, `slurm_jobs_cancelled`,
+`slurm_jobs_preempted`, `slurm_jobs_node_fail`, `slurm_jobs_completed`, and
+their per-user and per-partition twins in `slurm_queue_*` and `slurm_cores_*`.
+
+These are gauges over a sliding window, not counters. `slurmctld` forgets a
+terminated job once it is older than `MinJobAge` (`slurm.conf`, 300 seconds by
+default), so `slurm_jobs_failed` answers "how many jobs failed in the last
+`MinJobAge` seconds", and it drops back to zero on its own. Two consequences:
+
+- A site that shortened `MinJobAge` sees lower numbers for the same failure
+  rate, and one that raised it sees higher numbers. Compare a cluster to itself
+  over time rather than to another cluster.
+- `slurm_jobs_failed > 0` is not an alerting condition, it is the normal state
+  of a busy cluster. Alert on a rate or on a ratio instead. The shipped
+  `SlurmJobFailureRateHigh` rule reads
+  `cluster:slurm_job_failure_rate:ratio15m`, which `rules.yml` computes from the
+  `sdiag` counters rather than from these gauges.
+
+Set `--no-collector.queue.terminal-states` to go back to the pending-and-running
+query if the extra work is measurable on your `slurmctld`. The six totals then
+stay at zero, which is the pre-1.9 behaviour.
 
 ### `reservations` Collector
 

--- a/docs/validation-checklist.md
+++ b/docs/validation-checklist.md
@@ -129,6 +129,7 @@ docker exec slurmctld bash -c '
     --collector.partitions \
     --collector.queue \
     --collector.queue.user-label \
+    --collector.queue.terminal-states \
     --collector.reservations \
     --collector.sacct_efficiency \
     --collector.sacct.interval=30s \

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -37,8 +37,8 @@ type QueueMetrics struct {
 	cNodeFail    NVal
 }
 
-func QueueGetMetrics(logger *logger.Logger) (*QueueMetrics, error) {
-	data, err := QueueData(logger)
+func QueueGetMetrics(logger *logger.Logger, withTerminalStates bool) (*QueueMetrics, error) {
+	data, err := QueueData(logger, withTerminalStates)
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +159,23 @@ func ParseQueueMetrics(input []byte) *QueueMetrics {
 /*
 QueueData executes the squeue command to retrieve queue information.
 Expected squeue output format: "%P,%T,%C,%r,%u" (Partition,State,CPUs,Reason,User).
+
+withTerminalStates adds --states=all. squeue reports pending and running jobs
+when it is not told which states to view, so nine of the eleven states below
+never appeared in its input and every metric built from them read a constant
+zero: slurm_jobs_failed said the cluster had never had a failure. Asking for all
+states is what turns those series back into a measurement. See issue #27.
+
+The window is bounded by MinJobAge (slurm.conf, 300s by default): slurmctld
+forgets a terminated job once it is older than that, so a job counts here for as
+long as the controller still remembers it and no longer.
 */
-func QueueData(logger *logger.Logger) ([]byte, error) {
-	return Execute(logger, "squeue", []string{"-h", "-o", "%P|%T|%C|%r|%u"})
+func QueueData(logger *logger.Logger, withTerminalStates bool) ([]byte, error) {
+	args := []string{"-h", "-o", "%P|%T|%C|%r|%u"}
+	if withTerminalStates {
+		args = append(args, "--states=all")
+	}
+	return Execute(logger, "squeue", args)
 }
 
 /*
@@ -173,7 +187,7 @@ func QueueData(logger *logger.Logger) ([]byte, error) {
 // NewQueueCollector creates a queue metrics collector.
 // When withUserLabel is false, the user label is omitted and counts are
 // aggregated per partition only, reducing cardinality on large clusters.
-func NewQueueCollector(logger *logger.Logger, withUserLabel bool) *QueueCollector {
+func NewQueueCollector(logger *logger.Logger, withUserLabel, withTerminalStates bool) *QueueCollector {
 	var labelsJob, labelsPending []string
 	if withUserLabel {
 		labelsJob = []string{"user", "partition"}
@@ -183,29 +197,30 @@ func NewQueueCollector(logger *logger.Logger, withUserLabel bool) *QueueCollecto
 		labelsPending = []string{"partition", "reason"}
 	}
 	return &QueueCollector{
-		withUserLabel:    withUserLabel,
-		pending:          prometheus.NewDesc("slurm_queue_pending", "Pending jobs in queue", labelsPending, nil),
-		running:          prometheus.NewDesc("slurm_queue_running", "Running jobs in the cluster", labelsJob, nil),
-		suspended:        prometheus.NewDesc("slurm_queue_suspended", "Suspended jobs in the cluster", labelsJob, nil),
-		cancelled:        prometheus.NewDesc("slurm_queue_cancelled", "Cancelled jobs in the cluster", labelsJob, nil),
-		completing:       prometheus.NewDesc("slurm_queue_completing", "Completing jobs in the cluster", labelsJob, nil),
-		completed:        prometheus.NewDesc("slurm_queue_completed", "Completed jobs in the cluster", labelsJob, nil),
-		configuring:      prometheus.NewDesc("slurm_queue_configuring", "Configuring jobs in the cluster", labelsJob, nil),
-		failed:           prometheus.NewDesc("slurm_queue_failed", "Number of failed jobs", labelsJob, nil),
-		timeout:          prometheus.NewDesc("slurm_queue_timeout", "Jobs stopped by timeout", labelsJob, nil),
-		preempted:        prometheus.NewDesc("slurm_queue_preempted", "Number of preempted jobs", labelsJob, nil),
-		nodeFail:         prometheus.NewDesc("slurm_queue_node_fail", "Number of jobs stopped due to node fail", labelsJob, nil),
-		coresPending:     prometheus.NewDesc("slurm_cores_pending", "Pending cores in queue", labelsPending, nil),
-		coresRunning:     prometheus.NewDesc("slurm_cores_running", "Running cores in the cluster", labelsJob, nil),
-		coresSuspended:   prometheus.NewDesc("slurm_cores_suspended", "Suspended cores in the cluster", labelsJob, nil),
-		coresCancelled:   prometheus.NewDesc("slurm_cores_cancelled", "Cancelled cores in the cluster", labelsJob, nil),
-		coresCompleting:  prometheus.NewDesc("slurm_cores_completing", "Completing cores in the cluster", labelsJob, nil),
-		coresCompleted:   prometheus.NewDesc("slurm_cores_completed", "Completed cores in the cluster", labelsJob, nil),
-		coresConfiguring: prometheus.NewDesc("slurm_cores_configuring", "Configuring cores in the cluster", labelsJob, nil),
-		coresFailed:      prometheus.NewDesc("slurm_cores_failed", "Number of failed cores", labelsJob, nil),
-		coresTimeout:     prometheus.NewDesc("slurm_cores_timeout", "Cores stopped by timeout", labelsJob, nil),
-		coresPreempted:   prometheus.NewDesc("slurm_cores_preempted", "Number of preempted cores", labelsJob, nil),
-		coresNodeFail:    prometheus.NewDesc("slurm_cores_node_fail", "Number of cores stopped due to node fail", labelsJob, nil),
+		withUserLabel:      withUserLabel,
+		withTerminalStates: withTerminalStates,
+		pending:            prometheus.NewDesc("slurm_queue_pending", "Pending jobs in queue", labelsPending, nil),
+		running:            prometheus.NewDesc("slurm_queue_running", "Running jobs in the cluster", labelsJob, nil),
+		suspended:          prometheus.NewDesc("slurm_queue_suspended", "Suspended jobs in the cluster", labelsJob, nil),
+		cancelled:          prometheus.NewDesc("slurm_queue_cancelled", "Cancelled jobs in the cluster", labelsJob, nil),
+		completing:         prometheus.NewDesc("slurm_queue_completing", "Completing jobs in the cluster", labelsJob, nil),
+		completed:          prometheus.NewDesc("slurm_queue_completed", "Completed jobs in the cluster", labelsJob, nil),
+		configuring:        prometheus.NewDesc("slurm_queue_configuring", "Configuring jobs in the cluster", labelsJob, nil),
+		failed:             prometheus.NewDesc("slurm_queue_failed", "Number of failed jobs", labelsJob, nil),
+		timeout:            prometheus.NewDesc("slurm_queue_timeout", "Jobs stopped by timeout", labelsJob, nil),
+		preempted:          prometheus.NewDesc("slurm_queue_preempted", "Number of preempted jobs", labelsJob, nil),
+		nodeFail:           prometheus.NewDesc("slurm_queue_node_fail", "Number of jobs stopped due to node fail", labelsJob, nil),
+		coresPending:       prometheus.NewDesc("slurm_cores_pending", "Pending cores in queue", labelsPending, nil),
+		coresRunning:       prometheus.NewDesc("slurm_cores_running", "Running cores in the cluster", labelsJob, nil),
+		coresSuspended:     prometheus.NewDesc("slurm_cores_suspended", "Suspended cores in the cluster", labelsJob, nil),
+		coresCancelled:     prometheus.NewDesc("slurm_cores_cancelled", "Cancelled cores in the cluster", labelsJob, nil),
+		coresCompleting:    prometheus.NewDesc("slurm_cores_completing", "Completing cores in the cluster", labelsJob, nil),
+		coresCompleted:     prometheus.NewDesc("slurm_cores_completed", "Completed cores in the cluster", labelsJob, nil),
+		coresConfiguring:   prometheus.NewDesc("slurm_cores_configuring", "Configuring cores in the cluster", labelsJob, nil),
+		coresFailed:        prometheus.NewDesc("slurm_cores_failed", "Number of failed cores", labelsJob, nil),
+		coresTimeout:       prometheus.NewDesc("slurm_cores_timeout", "Cores stopped by timeout", labelsJob, nil),
+		coresPreempted:     prometheus.NewDesc("slurm_cores_preempted", "Number of preempted cores", labelsJob, nil),
+		coresNodeFail:      prometheus.NewDesc("slurm_cores_node_fail", "Number of cores stopped due to node fail", labelsJob, nil),
 		// Global totals — no labels, always emitted even when 0
 		jobsPending:      prometheus.NewDesc("slurm_jobs_pending", "Total pending jobs in the cluster", nil, nil),
 		jobsRunning:      prometheus.NewDesc("slurm_jobs_running", "Total running jobs in the cluster", nil, nil),
@@ -248,6 +263,9 @@ type QueueCollector struct {
 	coresPreempted   *prometheus.Desc
 	coresNodeFail    *prometheus.Desc
 	withUserLabel    bool
+	// withTerminalStates asks squeue for every job state rather than only the
+	// pending and running ones it reports by default. See issue #27.
+	withTerminalStates bool
 	// Global totals — no labels, always emitted even when 0
 	jobsPending      *prometheus.Desc
 	jobsRunning      *prometheus.Desc
@@ -306,7 +324,7 @@ func (qc *QueueCollector) Describe(ch chan<- *prometheus.Desc) {
 func (qc *QueueCollector) Collect(ch chan<- prometheus.Metric) { _ = qc.tryCollect(ch) }
 
 func (qc *QueueCollector) tryCollect(ch chan<- prometheus.Metric) error {
-	qm, err := QueueGetMetrics(qc.logger)
+	qm, err := QueueGetMetrics(qc.logger, qc.withTerminalStates)
 	if err != nil {
 		qc.logger.Error("Failed to get queue metrics", "err", err)
 		// Emit global totals at 0 so they remain present in Prometheus

--- a/internal/collector/queue_collector_test.go
+++ b/internal/collector/queue_collector_test.go
@@ -22,7 +22,7 @@ func TestQueueCollector_Collect(t *testing.T) {
 	}
 
 	log := logger.NewLogger("error")
-	c := NewQueueCollector(log, true)
+	c := NewQueueCollector(log, true, true)
 	reg := prometheus.NewRegistry()
 	require.NoError(t, reg.Register(c))
 
@@ -41,7 +41,7 @@ func TestQueueCollector_Collect(t *testing.T) {
 
 func TestQueueCollector_Describe(t *testing.T) {
 	log := logger.NewLogger("error")
-	c := NewQueueCollector(log, true)
+	c := NewQueueCollector(log, true, true)
 	ch := make(chan *prometheus.Desc, 50)
 	c.Describe(ch)
 	close(ch)
@@ -69,7 +69,7 @@ func TestQueueCollector_EmitsSuspendedMetrics(t *testing.T) {
 	for _, withUserLabel := range []bool{true, false} {
 		t.Run(fmtBool("withUserLabel", withUserLabel), func(t *testing.T) {
 			log := logger.NewLogger("error")
-			c := NewQueueCollector(log, withUserLabel)
+			c := NewQueueCollector(log, withUserLabel, true)
 			reg := prometheus.NewRegistry()
 			require.NoError(t, reg.Register(c))
 
@@ -124,7 +124,7 @@ func TestQueueCollector_ErrorEmitsGlobalTotals(t *testing.T) {
 	}
 
 	log := logger.NewLogger("error")
-	c := NewQueueCollector(log, false)
+	c := NewQueueCollector(log, false, true)
 	reg := prometheus.NewRegistry()
 	require.NoError(t, reg.Register(c))
 

--- a/internal/collector/queue_terminal_states_test.go
+++ b/internal/collector/queue_terminal_states_test.go
@@ -1,0 +1,113 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// captureExecuteArgs replaces Execute with a stub recording the command line it
+// was handed, so a test can assert on what the exporter asks Slurm for rather
+// than on what it does with the answer. The real Execute is restored afterwards.
+func captureExecuteArgs(t *testing.T, output string) *[]string {
+	t.Helper()
+
+	old := Execute
+	t.Cleanup(func() { Execute = old })
+
+	var got []string
+	Execute = func(_ *logger.Logger, command string, args []string) ([]byte, error) {
+		got = append([]string{command}, args...)
+		return []byte(output), nil
+	}
+	return &got
+}
+
+// TestQueueDataAsksSqueueForTerminalStates is the non-regression test for issue
+// #27.
+//
+// squeue reports pending and running jobs unless told otherwise, so nine of the
+// eleven states the parser knows how to read were never in its output. The six
+// totals built from them, slurm_jobs_failed above all, sat flat at zero on every
+// cluster and read as "nothing has ever failed here" rather than as a missing
+// measurement.
+func TestQueueDataAsksSqueueForTerminalStates(t *testing.T) {
+	args := captureExecuteArgs(t, "")
+
+	_, err := QueueData(logger.NewLogger("error"), true)
+	require.NoError(t, err)
+	assert.Contains(t, *args, "--states=all",
+		"without it squeue hides the terminal states and every failure metric stays at zero")
+}
+
+// TestQueueDataOmitsTerminalStatesWhenDisabled pins the escape hatch. Asking for
+// every state makes slurmctld walk jobs it would otherwise skip, so a site that
+// measures the cost and finds it too high must be able to go back to the old
+// query without pinning an old release.
+func TestQueueDataOmitsTerminalStatesWhenDisabled(t *testing.T) {
+	args := captureExecuteArgs(t, "")
+
+	_, err := QueueData(logger.NewLogger("error"), false)
+	require.NoError(t, err)
+	assert.NotContains(t, *args, "--states=all")
+	assert.Equal(t, []string{"squeue", "-h", "-o", "%P|%T|%C|%r|%u"}, *args,
+		"disabling terminal states must reproduce the query exactly as it was before #27")
+}
+
+// TestQueueCollectorPassesTerminalStatesToSqueue checks the wiring rather than
+// the query builder: the flag has to survive the trip from the collector down to
+// Execute, which is where a knob wired to nothing would go unnoticed.
+func TestQueueCollectorPassesTerminalStatesToSqueue(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		terminalStates bool
+		wantStatesFlag bool
+	}{
+		{name: "enabled", terminalStates: true, wantStatesFlag: true},
+		{name: "disabled", terminalStates: false, wantStatesFlag: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := captureExecuteArgs(t, "")
+
+			c := NewQueueCollector(logger.NewLogger("error"), true, tc.terminalStates)
+			ch := make(chan prometheus.Metric, 128)
+			c.Collect(ch)
+			close(ch)
+
+			if tc.wantStatesFlag {
+				assert.Contains(t, *args, "--states=all")
+			} else {
+				assert.NotContains(t, *args, "--states=all")
+			}
+		})
+	}
+}
+
+// TestQueueCollectorPublishesTerminalStates guards what the flag is for. Feeding
+// the collector the states squeue only returns with --states=all must yield the
+// series that issue #27 reported missing, per user and partition as well as in
+// the cluster-wide totals.
+func TestQueueCollectorPublishesTerminalStates(t *testing.T) {
+	stubExecute(t, "exclusive|FAILED|8|RaisedSignal:53|alice\n"+
+		"exclusive|TIMEOUT|128|TimeLimit|bob\n"+
+		"visualisation|COMPLETED|2|None|alice\n")
+
+	log := logger.NewLogger("error")
+	c := func() prometheus.Collector { return NewQueueCollector(log, true, true) }
+
+	assert.Equal(t, []string{`slurm_queue_failed{partition="exclusive",user="alice"} 1`},
+		gatheredSeries(t, c(), "slurm_queue_failed"))
+	assert.Equal(t, []string{`slurm_cores_failed{partition="exclusive",user="alice"} 8`},
+		gatheredSeries(t, c(), "slurm_cores_failed"))
+	assert.Equal(t, []string{`slurm_queue_timeout{partition="exclusive",user="bob"} 1`},
+		gatheredSeries(t, c(), "slurm_queue_timeout"))
+	assert.Equal(t, []string{`slurm_queue_completed{partition="visualisation",user="alice"} 1`},
+		gatheredSeries(t, c(), "slurm_queue_completed"))
+	assert.Equal(t, []string{"slurm_jobs_failed{} 1"}, gatheredSeries(t, c(), "slurm_jobs_failed"))
+	assert.Equal(t, []string{"slurm_jobs_timeout{} 1"}, gatheredSeries(t, c(), "slurm_jobs_timeout"))
+	assert.Equal(t, []string{"slurm_jobs_completed{} 1"}, gatheredSeries(t, c(), "slurm_jobs_completed"))
+}

--- a/internal/collector/status_execute_failure_test.go
+++ b/internal/collector/status_execute_failure_test.go
@@ -75,7 +75,7 @@ func TestStatusTracker_SuccessIsZeroWhenSlurmCommandsFail(t *testing.T) {
 	tracker.Add("node", NewNodeCollector(log))
 	tracker.Add("drain_reason", NewDrainReasonCollector(log))
 	tracker.Add("partitions", NewPartitionsCollector(log))
-	tracker.Add("queue", NewQueueCollector(log, true))
+	tracker.Add("queue", NewQueueCollector(log, true, true))
 	tracker.Add("scheduler", NewSchedulerCollector(log))
 	tracker.Add("fairshare", NewFairShareCollector(log, true))
 	tracker.Add("users", NewUsersCollector(log))

--- a/test_data/readme.md
+++ b/test_data/readme.md
@@ -61,7 +61,7 @@ and reservation names have been replaced with generic equivalents).
 
 ## `collector/queue.go`
 
-- `squeue -h -o "%P|%T|%C|%r|%u"`: job states, cores, reason, user (pipe-delimited to safely handle commas in reason field).
+- `squeue -h -o "%P|%T|%C|%r|%u" --states=all`: job states, cores, reason, user (pipe-delimited to safely handle commas in reason field). `--states=all` is what brings the terminal states into the output; it is dropped by `--no-collector.queue.terminal-states`.
   - Test file: **`squeue.txt`**
 
 ## `collector/reservations.go`


### PR DESCRIPTION
Closes #27.

## The defect

`squeue` reports pending and running jobs when it is not told which states to
view. Slurm 25.11.2 is explicit about it:

```
-t, --states=states   comma separated list of states to view,
                      default is pending and running,
                      '--states=all' reports all states
```

`ParseQueueMetrics` knows how to read eleven states. Nine of them therefore
never reached it, and every metric built from those nine held a constant zero.
A constant zero reads as a measurement, not as an absence: `slurm_jobs_failed`
said no job had ever failed on the cluster, and the *Terminal Job States Over
Time* panel of `04-slurm-usage` drew a flat line along the bottom of the chart
instead of an error.

Measured on the integration cluster, before and after, same instant, same jobs:

```
$ squeue -h -o "%P|%T|%C|%r|%u"                 # what the exporter asked for
      1 PENDING

$ squeue -h -o "%P|%T|%C|%r|%u" --states=all    # what was there
     19 FAILED
      1 PENDING
```

## The fix

`QueueData` passes `--states=all`. `--collector.queue.terminal-states`, enabled
by default, restores the previous query for a site that measures the extra
`slurmctld` work and finds it too expensive.

The `-a` and `-r` flags the issue also mentions are deliberately left out. They
change *which jobs* are counted, hidden partitions and array elements, rather
than *which states*, so they belong in their own change with their own
cardinality argument.

## Non-regression

Base `7bba984` on `:9342` and this branch on `:9341`, same `slurmctld`, same
instant, series identities diffed with values stripped:

| | base | branch |
|---|---|---|
| `slurm_*` series | 448 | 472 |
| series removed | | **0** |
| series added | | 24 (`slurm_queue_failed`, `slurm_cores_failed`, per user and partition) |
| `slurm_jobs_failed` | 0 | **19** |
| `slurm_jobs_pending` | 1 | 1 |
| `slurm_jobs_running` | 0 | 0 |

Cancellation checked separately: `scancel` on a pending job moved
`slurm_jobs_cancelled` from 0 to 1 and published
`slurm_queue_cancelled{partition="cpu",user="alice"} 1`.

`slurmctld` error count across 30 consecutive scrapes with `--states=all`:
delta 0. Both exporters logged 0 WARN and 0 ERROR.

## The `MinJobAge` window, observed

These are gauges over a sliding window, not counters. `slurmctld` forgets a
terminated job past `MinJobAge` (`slurm.conf`, 300 seconds by default, and the
value the test cluster runs). Sampled every 40 seconds:

```
18:57:27  failed=19 cancelled=1
18:58:08  failed=0  cancelled=1     <- 300s after the 19 jobs ended
18:58:48  failed=0  cancelled=0     <- 300s after the scancel
```

Both bursts rose to their full value and fell back to zero on their own. This is
why `slurm_jobs_failed > 0` is not an alerting condition, and why the
documentation added here says so in as many words.

## Breaking change

The `BREAKING CHANGE:` footer is on the commit. In short: the six terminal
totals stop being constant zeros and start reporting the `MinJobAge` window,
their per-user and per-partition twins appear where they existed for no label
combination before, and a site alert written as `slurm_jobs_failed > 0` against
the old behaviour will fire continuously and has to move to a rate or a ratio.

No shipped rule is affected. `SlurmJobFailureRateHigh` reads
`cluster:slurm_job_failure_rate:ratio15m`, which `rules.yml` computes from the
`sdiag` counters, and no rule in `alerts.yml` or `rules.yml` references any of
the changed metrics. Prometheus showed 0 active alerts throughout.

This lands in the same release as `bb2b381`, which already carries a
`BREAKING CHANGE:` footer, so both migrations cost the operator one version bump
rather than two.

## Tests

`internal/collector/queue_terminal_states_test.go`, four cases: the query
carries `--states=all`; disabling the flag reproduces the pre-#27 argument list
exactly; the flag survives the trip from the collector down to `Execute`; and
the terminal states produce the series the issue reported missing. All four
failed on assertions before the fix.

## Definition of Done

- `make build`, `make check` (vet, golangci-lint 0 issues, 186 tests,
  govulncheck 0, actionlint, zizmor, deadcode), `make race`: clean
- Coverage 85.7% on both base and branch, measured from separate worktrees
- Integration cluster: setup, workload N=20, Prometheus, 30 screenshots,
  logs, stopped clean with no dangling containers
- `act push --workflows release.yml --job test`: job succeeded
