### PR TITLE
fix(testing): capture the exporter output so the log check can be performed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,13 @@ This applies equally to PRs from contributors and to internal development.
    → Must return at least one series with a non-NaN value
 
 7. Log check
-   → No unexpected ERROR or WARN in exporter logs:
+   → Scrape once so every collector runs, then read the exporter's own log:
      docker exec slurmctld curl -s http://localhost:9341/metrics > /dev/null
+     make -C scripts/testing exporter-logs | grep -E 'level=(ERROR|WARN)'
+   → No unexpected ERROR or WARN. A collector that fails silently still
+     reports success, so this log is the only signal (see #147)
+   → slurmctld must not show increased error rate:
      docker exec slurmctld cat /var/log/slurm/slurmctld.log | grep -c ERROR
-   → slurmctld must not show increased error rate
 
 8. Dashboard validation (if dashboards were modified)
    → make -C scripts/testing screenshots OUTPUT=/tmp/pr-screenshots

--- a/scripts/testing/Makefile
+++ b/scripts/testing/Makefile
@@ -20,7 +20,7 @@ LIB      := bash $(THIS_DIR)_lib.sh
 # ── Aliases so $(LIB) check-deps can be combined with other targets ───────────
 .PHONY: help setup start stop clean status workload workload-gpu \
         cancel-all node-fail node-restore redeploy redeploy-dashboards \
-        screenshots logs show-config check-deps
+        screenshots logs exporter-logs show-config check-deps
 
 .DEFAULT_GOAL := help
 
@@ -36,6 +36,7 @@ help:
 	@echo "    make start             Start an already-configured cluster"
 	@echo "    make stop              Stop cluster (data preserved)"
 	@echo "    make status            Show nodes, jobs, exporter health"
+	@echo "    make exporter-logs     Print the exporter log from the container"
 	@echo "    make workload [N=30]   Submit random jobs"
 	@echo "    make screenshots       Take Grafana dashboard screenshots"
 	@echo ""
@@ -110,6 +111,9 @@ status:
 	    [ -f "$(THIS_DIR)cluster.local.conf" ] && source "$(THIS_DIR)cluster.local.conf" || true; \
 	    echo "  Grafana    → $${GRAFANA_URL}"; \
 	    echo "  Prometheus → http://localhost:9090"'
+
+exporter-logs:
+	@$(LIB) exporter-logs
 
 # ── Workload ──────────────────────────────────────────────────────────────────
 N ?= 30

--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -85,7 +85,25 @@ make redeploy             Rebuild exporter + reimport dashboards
 make redeploy-dashboards  Reimport dashboards only
 make show-config          Print effective configuration
 make logs                 Follow slurmctld + slurmdbd logs
+make exporter-logs        Print the exporter's own log
 ```
+
+### Reading the exporter log
+
+The exporter runs inside `slurmctld` with its output captured in
+`/tmp/slurm_exporter.log`; `docker logs slurmctld` shows the container's main
+process, not the exporter. Step 7 of the
+[Definition of Done](../../CONTRIBUTING.md#definition-of-done) reads that file:
+
+```bash
+docker exec slurmctld curl -s http://localhost:9341/metrics > /dev/null
+make exporter-logs | grep -E 'level=(ERROR|WARN)'
+```
+
+A collector whose command succeeds but whose output makes no sense still
+reports `slurm_exporter_collector_success` = 1 — the warning in this log is the
+only signal. `make redeploy` truncates the file, so it always belongs to the
+binary currently under test.
 
 ---
 

--- a/scripts/testing/_lib.sh
+++ b/scripts/testing/_lib.sh
@@ -37,6 +37,11 @@ warn()    { echo -e "${YELLOW}  ⚠ $*${NC}"; }
 die()     { echo -e "${RED}  ✗ $*${NC}" >&2; exit 1; }
 step()    { echo -e "${CYAN}[$1]${NC} $2"; }
 
+# ── Exporter under test ───────────────────────────────────────────────────────
+EXPORTER_BIN=/usr/local/bin/slurm_exporter
+EXPORTER_PORT=9341
+EXPORTER_LOG=/tmp/slurm_exporter.log
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 slurm() { docker exec slurmctld "$@" 2>/dev/null; }
 
@@ -229,18 +234,50 @@ cmd_build_exporter() {
 }
 
 # ── deploy-exporter ───────────────────────────────────────────────────────────
+# Stops the exporter inside slurmctld and waits for the process to disappear.
+# The exporter ignores SIGTERM (#139), which is what `killall` and a bare
+# `pkill` send, so the first signal cannot be assumed to have worked. Returns
+# non-zero if a process is still there after the escalation to SIGKILL.
+_stop_exporter() {
+    docker exec slurmctld pkill -f "$EXPORTER_BIN" >/dev/null 2>&1 || true
+    for i in $(seq 1 10); do
+        docker exec slurmctld pgrep -f "$EXPORTER_BIN" >/dev/null 2>&1 || return 0
+        if [ "$i" -eq 3 ]; then
+            docker exec slurmctld pkill -9 -f "$EXPORTER_BIN" >/dev/null 2>&1 || true
+        fi
+        sleep 1
+    done
+    return 1
+}
+
 cmd_deploy_exporter() {
     info "Deploying exporter to slurmctld..."
-    docker cp "$REPO_ROOT/bin/slurm_exporter" slurmctld:/usr/local/bin/slurm_exporter
-    docker exec slurmctld chmod +x /usr/local/bin/slurm_exporter
-    docker exec slurmctld bash -c "killall slurm_exporter 2>/dev/null || true"
-    sleep 1
-    docker exec -d slurmctld /usr/local/bin/slurm_exporter \
-        --web.listen-address=:9341 --log.level=info --command.timeout=10s
+    docker cp "$REPO_ROOT/bin/slurm_exporter" "slurmctld:$EXPORTER_BIN"
+    docker exec slurmctld chmod +x "$EXPORTER_BIN"
+    _stop_exporter || die "An exporter is still running on slurmctld — refusing to
+  start a second one on port ${EXPORTER_PORT}. Its logs would be the old binary's."
+
+    # `docker exec -d` on the binary discards stdout and stderr, which leaves
+    # step 7 of the Definition of Done with nothing to read. Wrap it in a shell
+    # so the output lands in a file `make exporter-logs` can print. The log is
+    # truncated here: it belongs to the binary that is being deployed.
+    docker exec -d slurmctld sh -c \
+        "exec $EXPORTER_BIN --web.listen-address=:${EXPORTER_PORT} \
+             --log.level=info --command.timeout=10s > $EXPORTER_LOG 2>&1"
     sleep 2
-    docker exec slurmctld curl -s http://localhost:9341/healthz 2>/dev/null | grep -q "ok" && \
-        ok "Exporter running on slurmctld:9341" || \
-        warn "Exporter health check failed"
+    if docker exec slurmctld curl -s "http://localhost:${EXPORTER_PORT}/healthz" 2>/dev/null | grep -q "ok"; then
+        ok "Exporter running on slurmctld:${EXPORTER_PORT}  (log: $EXPORTER_LOG)"
+    else
+        warn "Exporter health check failed — last lines of $EXPORTER_LOG:"
+        docker exec slurmctld tail -n 20 "$EXPORTER_LOG" 2>/dev/null || warn "(no log file)"
+    fi
+}
+
+# ── exporter-logs ─────────────────────────────────────────────────────────────
+cmd_exporter_logs() {
+    docker exec slurmctld test -f "$EXPORTER_LOG" 2>/dev/null || die \
+        "No exporter log at slurmctld:$EXPORTER_LOG — deploy the exporter first: make redeploy"
+    docker exec slurmctld cat "$EXPORTER_LOG"
 }
 
 # ── import-dashboards ─────────────────────────────────────────────────────────
@@ -326,7 +363,7 @@ cmd_workload_gpu() {
 # ── stop ──────────────────────────────────────────────────────────────────────
 cmd_stop() {
     info "Stopping cluster (data preserved)..."
-    docker exec slurmctld bash -c "killall slurm_exporter 2>/dev/null || true" 2>/dev/null || true
+    _stop_exporter || warn "Exporter still running — the container is going down anyway"
     if [ -f "$CLUSTER_DIR/docker-compose.monitoring.yml" ]; then
         cd "$CLUSTER_DIR" && docker compose -f docker-compose.monitoring.yml down 2>/dev/null || true
     fi
@@ -337,7 +374,7 @@ cmd_stop() {
 # ── clean ──────────────────────────────────────────────────────────────────────
 cmd_clean() {
     warn "Removing all containers and volumes (irreversible)..."
-    docker exec slurmctld bash -c "killall slurm_exporter 2>/dev/null || true" 2>/dev/null || true
+    _stop_exporter || warn "Exporter still running — the container is going down anyway"
     if [ -f "$CLUSTER_DIR/docker-compose.monitoring.yml" ]; then
         cd "$CLUSTER_DIR" && docker compose -f docker-compose.monitoring.yml down -v 2>/dev/null || true
     fi
@@ -375,6 +412,7 @@ case "$CMD" in
     setup-partitions)   cmd_setup_partitions ;;
     build-exporter)     cmd_build_exporter ;;
     deploy-exporter)    cmd_deploy_exporter ;;
+    exporter-logs)      cmd_exporter_logs ;;
     import-dashboards)  cmd_import_dashboards ;;
     show-config)
         echo "CLUSTER_DIR    = $CLUSTER_DIR"


### PR DESCRIPTION
Closes #147.

## The defect

`docker exec -d` runs the command detached and throws away stdout and stderr.
`_lib.sh` used it on the binary itself, so the exporter's log went nowhere:
`docker logs slurmctld` shows the container's main process, and no file was
written. Step 7 of the Definition of Done — *"No unexpected ERROR or WARN in
exporter logs"* — had nothing to read, on a cluster where a collector that
parses nothing still reports `slurm_exporter_collector_success` = 1 and leaves
a `WARN` as its only trace.

The second half is the redeploy path, measured on the integration cluster at
base `fdc9a68`:

```
$ docker exec slurmctld pgrep -f /usr/local/bin/slurm_exporter
332
$ docker exec slurmctld bash -c "killall slurm_exporter"      # what redeploy did
$ docker exec -d slurmctld /usr/local/bin/slurm_exporter --web.listen-address=:9341 ...
$ docker exec slurmctld pgrep -f /usr/local/bin/slurm_exporter
332                                                            # same process
$ docker exec slurmctld curl -s http://localhost:9341/healthz
ok                                                             # answered by the old one
$ docker exec slurmctld stat -c '%y' /tmp/slurm_exporter.log
2026-07-22 17:28:52                                            # untouched, 49s earlier
```

`killall` sends SIGTERM, which the exporter ignores (#139). The old binary kept
the port, the new one died on `bind: address already in use` with its error
discarded, and `/healthz` still said `ok`. A redeploy could therefore report
success while the metrics — and the log, once there is one — came from the
previous build.

## The fix

- The exporter is started through `sh -c … > /tmp/slurm_exporter.log 2>&1`, and
  `make -C scripts/testing exporter-logs` prints that file. `exec` in the
  wrapper keeps it to a single process, so `pgrep`/`pkill` still match.
- `_stop_exporter` replaces `killall` in `deploy`, `stop` and `clean`: it signals,
  polls for the process to be gone, escalates to SIGKILL after 3s, and returns
  non-zero if something survives. `deploy-exporter` then dies rather than leave
  a stale exporter answering on 9341.
- The log is truncated on each deploy: it belongs to the binary being deployed.
- A failed health check now prints the last 20 lines of the log instead of a
  bare `Exporter health check failed`.

The port check the issue also suggests is covered by this: what makes the port
busy is the process, and the process is now waited on by name.

## Verification

`make -C scripts/testing setup` on Slurm 25.11.2, 10 nodes, then a redeploy:

```
pids               : 572           # was 332 — the new binary really replaced it
log mtime          : 17:29:41      # fresh, truncated on deploy
healthz            : ok
```

Step 7, run as it is now written in `CONTRIBUTING.md`:

```
$ docker exec slurmctld curl -s http://localhost:9341/metrics > /dev/null
$ make -C scripts/testing exporter-logs | grep -E 'level=(ERROR|WARN)'
(no output — 22 lines of INFO)
$ docker exec slurmctld grep -c ERROR /var/log/slurm/slurmctld.log
0
```

Definition of Done: 1-4 pass, 5 partial (jobs sent to `debug` stay pending,
that is #146 and this branch does not touch it), 6-7 above, 8 not applicable
(no dashboard changed), 9 clean — `make stop` leaves no container. `make check`
green: 143 tests, vet, golangci-lint, zizmor and deadcode with no findings.

## Not in scope

`scripts/testing/Makefile` carries two orphan recipe fragments — leftovers of
the same move into `_lib.sh` — that `make clean` and `make logs` execute after
their real work and that end on an unmatched quote. Filed as #162 rather than
folded in here.
