### PR TITLE
fix(testing): bound the health checks so a mute port cannot hang the harness

### DIFF
--- a/scripts/testing/Makefile
+++ b/scripts/testing/Makefile
@@ -105,7 +105,7 @@ status:
 	@docker exec slurmctld squeue --format="%.6i %.9P %.16j %.8u %.2t %.4C" 2>/dev/null | head -22 || true
 	@echo ""
 	@echo "=== Exporter ==="
-	@docker exec slurmctld curl -s http://localhost:9341/healthz 2>/dev/null || echo "  not running"
+	@docker exec slurmctld curl -s --max-time 5 http://localhost:9341/healthz 2>/dev/null || echo "  not running"
 	@echo ""
 	@bash -c 'source $(THIS_DIR)cluster.conf; \
 	    [ -f "$(THIS_DIR)cluster.local.conf" ] && source "$(THIS_DIR)cluster.local.conf" || true; \

--- a/scripts/testing/_lib.sh
+++ b/scripts/testing/_lib.sh
@@ -146,7 +146,7 @@ cmd_start_monitoring() {
 cmd_wait_grafana() {
     docker ps --format '{{.Names}}' | grep -q grafana || return 0
     for i in $(seq 1 20); do
-        curl -s "${GRAFANA_URL}/api/health" 2>/dev/null | grep -q '"database": "ok"' && \
+        curl -s --max-time 5 "${GRAFANA_URL}/api/health" 2>/dev/null | grep -q '"database": "ok"' && \
             ok "Grafana ready" && return 0
         [ "$i" -eq 20 ] && warn "Grafana not ready after 60s" && return 0
         printf "."; sleep 3
@@ -265,7 +265,7 @@ cmd_deploy_exporter() {
         "exec $EXPORTER_BIN --web.listen-address=:${EXPORTER_PORT} \
              --log.level=info --command.timeout=10s > $EXPORTER_LOG 2>&1"
     sleep 2
-    if docker exec slurmctld curl -s "http://localhost:${EXPORTER_PORT}/healthz" 2>/dev/null | grep -q "ok"; then
+    if docker exec slurmctld curl -s --max-time 5 "http://localhost:${EXPORTER_PORT}/healthz" 2>/dev/null | grep -q "ok"; then
         ok "Exporter running on slurmctld:${EXPORTER_PORT}  (log: $EXPORTER_LOG)"
     else
         warn "Exporter health check failed — last lines of $EXPORTER_LOG:"


### PR DESCRIPTION
Closes #164.

## The defect

Found by exercising the failure branch #163 added, rather than by reading the
code: a `curl` with no timeout against a port that is held but mute never
returns.

```
$ docker exec -d slurmctld python3 -c \
    "import socket;s=socket.socket();s.bind(('0.0.0.0',9341));s.listen(1);__import__('time').sleep(300)"
$ bash scripts/testing/_lib.sh deploy-exporter
  Deploying exporter to slurmctld...
    … nothing, forever …

$ docker exec slurmctld ps -ef | grep [c]url
root  459  0  17:43 ?  00:00:00 curl -s http://localhost:9341/healthz
```

The exporter had already died on `bind: address already in use` and written it
to its log. The harness never got to the branch that prints it. `make setup`,
`make start` and `make redeploy` all reach `deploy-exporter`, so all three hang.

Two other call sites have the same shape and pre-date #163 as well:
`wait-grafana`, where the 20-iteration bound stops meaning anything if the first
call never returns, and `make status`.

## The fix

`--max-time 5` at the three sites. A loopback `/healthz` answers in single-digit
milliseconds, so the bound is three orders of magnitude above the real case.

## Verification

Same mute squatter, on this branch:

```
$ time bash scripts/testing/_lib.sh deploy-exporter
  Deploying exporter to slurmctld...
  ⚠ Exporter health check failed — last lines of /tmp/slurm_exporter.log:
time=…Z level=ERROR msg="Failed to start HTTP server" err="listen tcp :9341: bind: address already in use"
                                                                  4.944 total
```

4.9 seconds instead of forever, and the cause is on screen. That ERROR line is
exactly what `docker exec -d` used to throw away before #163 — the two changes
together turn a silent hang into a diagnosis.

Squatter killed, nominal path unchanged: `deploy-exporter` reports
`Exporter running on slurmctld:9341`, `/healthz` returns `ok`, `make status`
prints `ok`.

Definition of Done: `make check` green (143 tests, vet, golangci-lint, zizmor,
deadcode, no findings); cluster up on Slurm 25.11.2 with 10 nodes; step 7 reads
0 ERROR/WARN in the exporter log and 0 ERROR in slurmctld's; step 9 leaves no
container. Steps 5, 6 and 8 are not applicable — no collector, no metric and no
dashboard is touched.
