### PR TITLE
fix(testing): drop the orphan recipe fragments left in the test Makefile

### DIFF
--- a/scripts/testing/Makefile
+++ b/scripts/testing/Makefile
@@ -88,14 +88,6 @@ stop:
 clean:
 	@$(LIB) clean
 
-	    [ -f "$(THIS_DIR)cluster.local.conf" ] && source "$(THIS_DIR)cluster.local.conf" || true; \
-	    [ -z "$${CLUSTER_DIR:-}" ] && CLUSTER_DIR="$${HOME}/slurm-docker-cluster"; \
-	    docker exec slurmctld bash -c "pkill -f slurm_exporter 2>/dev/null || true" 2>/dev/null || true; \
-	    [ -f "$${CLUSTER_DIR}/docker-compose.monitoring.yml" ] && \
-	        cd "$${CLUSTER_DIR}" && docker compose -f docker-compose.monitoring.yml down -v 2>/dev/null || true; \
-	    cd "$${CLUSTER_DIR}" && docker compose down -v'
-	@echo "  ✓ Full clean complete"
-
 # ── Status ────────────────────────────────────────────────────────────────────
 status:
 	@echo "=== Nodes ==="
@@ -163,9 +155,6 @@ show-config:
 
 logs:
 	@$(LIB) logs
-
-	    [ -f "$(THIS_DIR)cluster.local.conf" ] && source "$(THIS_DIR)cluster.local.conf" || true; \
-	    cd "$${CLUSTER_DIR}" && docker compose logs -f slurmctld slurmdbd'
 
 check-deps:
 	@$(LIB) check-deps


### PR DESCRIPTION
Closes #162.

## The defect

`clean` and `logs` each carried a leftover shell fragment below their real
recipe line. The blank line between them does not end a recipe — every line
below it starts with a tab, so `make` kept them — and both fragments end on the
unmatched quote of a `bash -c '` that was removed when the logic moved into
`_lib.sh`.

Run on `c6bd714`:

```
$ make -C scripts/testing clean
  ⚠ Removing all containers and volumes (irreversible)...
  ✓ Full clean complete
    [ -f "…/cluster.local.conf" ] && source "…/cluster.local.conf" || true; \
    …
    cd "${CLUSTER_DIR}" && docker compose down -v'
/bin/sh: 6: Syntax error: Unterminated quoted string
make: *** [Makefile:90: clean] Error 2
```

The teardown does happen — `$(LIB) clean` runs first — then the target exits 2.
Anything scripting `make clean` reads that as a failed teardown.

`logs` was masked: `$(LIB) logs` blocks on `docker compose logs -f`, so its
fragment only ran once the user interrupted it, where the error reads as part of
the Ctrl-C.

## The fix

Delete both. Nothing references them; `$(LIB) clean` and `$(LIB) logs` have done
the work since the move.

The confirmation `@echo` under `clean` goes with them: `_lib.sh` already prints
`✓ Full clean complete`, so the target announced itself twice. `stop` keeps its
own, which adds "(data preserved)" rather than repeating.

## Verification

```
$ make -C scripts/testing clean          # after
  ⚠ Removing all containers and volumes (irreversible)...
  ✓ Full clean complete
exit=0

$ make -C scripts/testing logs           # cluster down, returns instead of erroring
exit=0
```

`make -n` on both targets now prints one command each.

Definition of Done: step 4 re-run from the destroyed state — `make setup`
rebuilds 10 nodes, 4 accounts, 6 users, 4 partitions, exporter on 9341, 10
dashboards imported, 0 failed. Step 7 reads 0 ERROR/WARN in the exporter log and
0 ERROR in slurmctld's. Steps 5, 6 and 8 are not applicable: no Go file, no
metric and no dashboard is touched. `make check` is unchanged by a Makefile-only
diff and was green on the parent commit.
