### PR TITLE
fix(testing): clamp generated job time limits to the partition MaxTime

### DIFF
--- a/scripts/testing/random_jobs.sh
+++ b/scripts/testing/random_jobs.sh
@@ -17,8 +17,35 @@ DURATIONS=(1800 3600 7200 14400)
 CPU_COUNTS=(1 2 4 8)
 MEM_PER_CPU=2048
 
+# Slurm accepts a job whose time limit exceeds its partition's cap, then leaves
+# it PENDING with reason PartitionTimeLimit for as long as the cluster lives.
+# Read each partition's MaxTime once and clamp against it, so that changing a
+# partition definition in cluster.conf cannot strand the workload again (#146).
+
+# "UNLIMITED" or "[days-]hours:minutes:seconds" -> minutes, 0 meaning no cap.
+to_minutes() {
+    local raw="$1" days=0 h m s
+    case "$raw" in
+        UNLIMITED|INFINITE|"") echo 0; return ;;
+        *-*) days=${raw%%-*}; raw=${raw#*-} ;;
+    esac
+    IFS=: read -r h m s <<< "$raw"
+    if [ -z "$s" ]; then
+        echo "  ! unexpected MaxTime format '$1' — not clamping this partition" >&2
+        echo 0; return
+    fi
+    echo $((10#$days * 1440 + 10#$h * 60 + 10#$m))
+}
+
+declare -A PART_MAX_MINUTES
+for p in "${PARTITIONS[@]}"; do
+    PART_MAX_MINUTES[$p]=$(to_minutes \
+        "$(scontrol show partition "$p" 2>/dev/null | tr ' ' '\n' | sed -n 's/^MaxTime=//p')")
+done
+
 echo "Submitting $NB random jobs..."
 count=0
+clamped=0
 for i in $(seq 1 $NB); do
     USER=${USERS[$RANDOM % ${#USERS[@]}]}
     ACCOUNT=${ACCOUNTS[$RANDOM % ${#ACCOUNTS[@]}]}
@@ -28,13 +55,21 @@ for i in $(seq 1 $NB); do
     MEM=$(($NCPUS * $MEM_PER_CPU))
     JOBNAME="rand-$(date +%s%N 2>/dev/null | tail -c5 || date +%s | tail -c5)"
 
+    MINUTES=$(($DURATION / 60))
+    MAX_MINUTES=${PART_MAX_MINUTES[$PARTITION]:-0}
+    if [ "$MAX_MINUTES" -gt 0 ] && [ "$MINUTES" -gt "$MAX_MINUTES" ]; then
+        MINUTES=$MAX_MINUTES
+        DURATION=$(($MINUTES * 60))
+        clamped=$(($clamped + 1))
+    fi
+
     if sbatch \
         --account="$ACCOUNT" \
         --partition="$PARTITION" \
         --ntasks=1 \
         --cpus-per-task="$NCPUS" \
         --mem="${MEM}M" \
-        --time="$(($DURATION/60))" \
+        --time="$MINUTES" \
         --job-name="$JOBNAME" \
         --wrap="sleep $DURATION" \
         --uid="$USER" 2>/dev/null; then
@@ -47,5 +82,6 @@ done
 
 echo ""
 echo "Submitted: $count / $NB jobs"
+[ "$clamped" -gt 0 ] && echo "Clamped:   $clamped job(s) to their partition's MaxTime"
 echo ""
 squeue --format="%.6i %.9P %.14j %.8u %.2t %.4C %R" | head -50


### PR DESCRIPTION
Closes #146.

## The defect

`random_jobs.sh` draws a duration from `DURATIONS=(1800 3600 7200 14400)` and a
partition from `PARTITIONS=(cpu debug high)`, independently. `debug` caps jobs at
thirty minutes, so three of the four durations produce a job Slurm accepts and
then never runs:

```
$ docker exec slurmctld squeue -h -o '%i|%P|%T|%r|%l'
30|debug|PENDING|PartitionTimeLimit|1:00:00
25|debug|PENDING|PartitionTimeLimit|1:00:00
21|debug|PENDING|PartitionTimeLimit|4:00:00
15|debug|PENDING|PartitionTimeLimit|1:00:00
 9|debug|PENDING|PartitionTimeLimit|4:00:00
 2|debug|PENDING|PartitionTimeLimit|4:00:00
```

Six of thirty, pending for as long as the cluster lives, counted as submitted by
the script. Step 5 of the Definition of Done asks for running jobs in `squeue`,
and a fifth of the workload could never get there.

## The fix

Each partition's `MaxTime` is read once from `scontrol show partition` and the
requested time is clamped to it, along with the `sleep` the job wraps so the two
keep agreeing. Reading the cap rather than hardcoding thirty minutes means
changing `PARTITIONS` in `cluster.conf` cannot strand the workload again — which
is what the issue asks for.

`UNLIMITED` partitions are left alone. A `MaxTime` the parser does not recognise
is reported on stderr and that partition is left unclamped, rather than silently
skipping the clamp and reintroducing the bug in disguise.

## Verification

`to_minutes` against the formats Slurm emits, plus the ones it does not:

```
  ok   unlimited                    UNLIMITED    -> 0
  ok   infinite                     INFINITE     -> 0
  ok   empty (partition gone)       ""           -> 0
  ok   30 minutes                   00:30:00     -> 30
  ok   2 hours                      02:00:00     -> 120
  ok   1 day                        1-00:00:00   -> 1440
  ok   leading zeros not octal      08:09:00     -> 489
  ok   2 days 3h30                  2-03:30:00   -> 3090
  ok   bad format -> no clamp       30:00        -> 0
       ! unexpected MaxTime format '30:00' — not clamping this partition
```

Then thirty jobs on the integration cluster, before and after, same partitions:

| | before | after |
|---|---|---|
| stuck in `debug` on `PartitionTimeLimit` | 6 | **0** |
| `debug` jobs that reached the scheduler | 3 | 9 |
| clamped, reported by the script | — | 6 |

The jobs still visible on `PartitionTimeLimit` after the run are the six from
the *before* run: their IDs are 2 to 30, below the new run's range. `make
cancel-all` had failed to remove them, which is #167, filed separately.

Step 5 remains partly out of reach on this host: the jobs now reach the
scheduler and are killed one second in by `RaisedSignal:53`, a WSL2 limitation
of the container, not a repository defect. What this change fixes is the half
that was ours — jobs that never got scheduled at all.

`shellcheck -S warning` reports only the pre-existing `SC2034` on the loop
variable. Steps 1-3 are untouched by a shell-only diff; step 4 ran green earlier
today on this cluster; step 7 reads 0 ERROR/WARN in the exporter log and 0 ERROR
in slurmctld's; steps 6 and 8 are not applicable.

## Found while verifying, filed separately

- #167 — `make cancel-all` only cancels running jobs, so the queue is not reset
  between two measurements.
- #168 — the largest CPU draw asks for 16384 MB against nodes that have 15867,
  so seven jobs of thirty are refused at submission.
