### PR TITLE
fix(testing): cancel pending jobs too, not just running ones

### DIFF
--- a/scripts/testing/Makefile
+++ b/scripts/testing/Makefile
@@ -118,8 +118,10 @@ workload-gpu:
 	@$(LIB) workload-gpu
 
 
+# scancel --state takes one value: passing it twice cancelled RUNNING only and
+# left the pending jobs in place, silently (#167).
 cancel-all:
-	@docker exec slurmctld bash -c "scancel --state=PENDING --state=RUNNING 2>/dev/null || true"
+	@docker exec slurmctld bash -c 'for s in PENDING RUNNING; do scancel --state=$$s 2>/dev/null || true; done'
 	@echo "  ✓ All jobs cancelled"
 
 # ── Node simulation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #167.

## The defect

`scancel --state` takes a single value. `cancel-all` passed it twice, so the
second occurrence replaced the first and only `RUNNING` was ever cancelled.

Four jobs deliberately held pending, on `547859d`:

```
$ docker exec slurmctld squeue -h -o '%T|%r' | sort | uniq -c
      4 PENDING|BeginTime

$ make -C scripts/testing cancel-all
  ✓ All jobs cancelled

$ docker exec slurmctld squeue -h -o '%T|%r' | sort | uniq -c
      4 PENDING|BeginTime
```

The target reports success and exits 0, so the queue looks reset when it is not.
Every measurement taken after it inherits whatever was pending — which is how it
surfaced: `cancel-all` between the two runs of the #146 before/after comparison
left the six jobs that fix was meant to eliminate, and only their job IDs, below
the new run's range, showed they belonged to the earlier run.

## The fix

One `scancel` per state.

## Verification

Same four pending jobs, on this branch:

```
$ docker exec slurmctld squeue -h -o '%T|%r' | sort | uniq -c
      4 PENDING|BeginTime
$ make -C scripts/testing cancel-all
  ✓ All jobs cancelled
$ docker exec slurmctld squeue -h -o '%i' | wc -l
0
```

`RUNNING` as well, with three `sleep 300` jobs submitted as root — jobs
submitted with `--uid` die on this host one second in, which turns out to be the
real cause of what was blamed on WSL2 and is filed as #171:

```
$ docker exec slurmctld squeue -h -o '%T' | sort | uniq -c
      4 RUNNING
$ make -C scripts/testing cancel-all
  ✓ All jobs cancelled
$ docker exec slurmctld squeue -h -o '%i' | wc -l
0
$ docker exec slurmctld squeue -h --states=all -o '%T' | sort | uniq -c
      8 CANCELLED
```

Eight cancelled: the four running ones above plus the four pending ones from the
first experiment.

Steps 1-3 and 6-8 of the Definition of Done are not applicable to a one-line
Makefile change with no Go, metric or dashboard involved. The cluster from #169
was up throughout.
