### PR TITLE
fix(testing): send job output to /dev/null so workload jobs can start

### DIFF
--- a/scripts/testing/random_jobs.sh
+++ b/scripts/testing/random_jobs.sh
@@ -71,6 +71,7 @@ for i in $(seq 1 $NB); do
         --mem="${MEM}M" \
         --time="$MINUTES" \
         --job-name="$JOBNAME" \
+        --output=/dev/null \
         --wrap="sleep $DURATION" \
         --uid="$USER" 2>/dev/null; then
         count=$(($count + 1))


### PR DESCRIPTION
Closes #171.

## The defect

`docker exec` lands in `/data`, and that directory belongs to root:

```
$ docker exec slurmctld ls -ld /data
drwxr-xr-x 2 root root 4096 Jul 22 18:11 /data
```

`random_jobs.sh` submits with `--uid=<user>` and no `--output`, so the batch step
tried to create `/data/slurm-<jobid>.out` under that user's identity, failed, and
died before running anything:

```
[18:10:53.601] Launching batch JobId=80 for UID 1000
[18:10:53.635] [80.batch] JobId=80 completed with slurm_rc = 0, job_rc = 4021
```

`4021 & 127 = 53`. That is where `RaisedSignal:53(Real-time signal 19)` comes
from — a signal number standing in for a file that could not be created.

Five jobs, identical but for the working directory and the output path:

| job | flags | outcome |
|-----|-------|---------|
| 79 | no `--uid` (runs as root) | **RUNNING** for its full 60 s |
| 84 | `--uid=alice` | FAILED, `RaisedSignal:53`, 35 ms |
| 85 | `--uid=alice --chdir=/tmp --output=/tmp/j2.out` | **RUNNING** |
| 86 | `--uid=alice --chdir=/home/alice --output=…` | **RUNNING** |
| 87 | `--uid=alice --output=/dev/null` | **RUNNING** |

## The fix

`--output=/dev/null`, which `cmd_workload_gpu` already passes — and why the GPU
path never showed this. Job 87 is the one that decides it: the flag alone is
enough, no `--chdir`, no directory to create for six users on ten workers.

The job output itself is not a loss: every job is `sleep N`.

## Why this matters more than a test script

Step 5 of the Definition of Done had never once been satisfied. Steps 6 and 8
take their data from the same workload, so every Prometheus check and every
dashboard screenshot in this repository's history was taken against a cluster
where no job had ever run.

The symptom was attributed to the WSL2 kernel, in #146 and in the reviewer notes
that followed it. That was wrong: a plain `sbatch` as root runs fine on the same
host, same `ProctrackType`, same `TaskPlugin`.

## Verification

`make -C scripts/testing workload N=20`, then step 5 as `CONTRIBUTING.md` writes
it:

```
$ docker exec slurmctld squeue --state=RUNNING -h -o '%i %P %u %T %C %l'
92  cpu   alice RUNNING 2 2:00:00
95  cpu   dave  RUNNING 4 4:00:00
96  cpu   eve   RUNNING 2 30:00
97  cpu   alice RUNNING 2 2:00:00
98  cpu   dave  RUNNING 2 4:00:00
90  high  carol RUNNING 4 2:00:00
91  high  carol RUNNING 2 30:00
100 high  frank RUNNING 2 1:00:00
…
RUNNING : 11
PENDING : 4   (3 Priority, 1 Resources — ordinary backpressure)
```

Step 6, the exporter on the same cluster, reporting a live cluster for the first
time instead of zeros:

```
slurm_jobs_running 11
slurm_jobs_pending 4
slurm_jobs_completed 3
slurm_jobs_failed 7
slurm_cpus_alloc 30
```

Step 7: 0 ERROR/WARN in the exporter log. Steps 1-3 are untouched by a shell-only
diff. `shellcheck -S warning` unchanged.

The five jobs of twenty still refused at submission are #168, the memory request
that exceeds `RealMemory`, not this.
