### PR TITLE
fix(testing): cap the generated memory request at the smallest node

### DIFF
--- a/scripts/testing/random_jobs.sh
+++ b/scripts/testing/random_jobs.sh
@@ -43,9 +43,21 @@ for p in "${PARTITIONS[@]}"; do
         "$(scontrol show partition "$p" 2>/dev/null | tr ' ' '\n' | sed -n 's/^MaxTime=//p')")
 done
 
+# Slurm refuses a job asking for more memory than a node has, at submission
+# time: the largest CPU draw wanted NCPUS * MEM_PER_CPU = 16384 MB against nodes
+# that have 15867, and a quarter of the workload never existed (#168). Cap
+# against the smallest node so a capped job still fits anywhere.
+NODE_MEM=$(sinfo -h -o '%m' 2>/dev/null | sort -n | head -1)
+case "$NODE_MEM" in
+    ''|*[!0-9]*)
+        echo "  ! unexpected node memory '$NODE_MEM' — not capping" >&2
+        NODE_MEM=0 ;;
+esac
+
 echo "Submitting $NB random jobs..."
 count=0
 clamped=0
+capped=0
 for i in $(seq 1 $NB); do
     USER=${USERS[$RANDOM % ${#USERS[@]}]}
     ACCOUNT=${ACCOUNTS[$RANDOM % ${#ACCOUNTS[@]}]}
@@ -53,6 +65,10 @@ for i in $(seq 1 $NB); do
     DURATION=${DURATIONS[$RANDOM % ${#DURATIONS[@]}]}
     NCPUS=${CPU_COUNTS[$RANDOM % ${#CPU_COUNTS[@]}]}
     MEM=$(($NCPUS * $MEM_PER_CPU))
+    if [ "$NODE_MEM" -gt 0 ] && [ "$MEM" -gt "$NODE_MEM" ]; then
+        MEM=$NODE_MEM
+        capped=$(($capped + 1))
+    fi
     JOBNAME="rand-$(date +%s%N 2>/dev/null | tail -c5 || date +%s | tail -c5)"
 
     MINUTES=$(($DURATION / 60))
@@ -84,5 +100,6 @@ done
 echo ""
 echo "Submitted: $count / $NB jobs"
 [ "$clamped" -gt 0 ] && echo "Clamped:   $clamped job(s) to their partition's MaxTime"
+[ "$capped" -gt 0 ]  && echo "Capped:    $capped job(s) to the smallest node's memory (${NODE_MEM}M)"
 echo ""
 squeue --format="%.6i %.9P %.14j %.8u %.2t %.4C %R" | head -50


### PR DESCRIPTION
Closes #168.

## The defect

`MEM = NCPUS * MEM_PER_CPU` with `CPU_COUNTS=(1 2 4 8)` and `MEM_PER_CPU=2048`,
so the largest draw asks for 16384 MB. The nodes have 15867, and Slurm refuses
the job at submission rather than queueing it:

```
$ sbatch --cpus-per-task=8 --mem=16384M --wrap="sleep 60"
sbatch: error: Memory specification can not be satisfied
sbatch: error: Batch job submission failed: Requested node configuration is not available
```

`random_jobs.sh` prints an `x` and moves on, so the run ends on
`Submitted: 15 / 20` and the loss is only visible to whoever reads the output.
The jobs lost are the 8-CPU ones — precisely those that would exercise the high
end of every distribution the dashboards draw.

## The fix

Cap the request at the smallest `RealMemory` in the cluster, read once from
`sinfo`, so that a capped job still fits on any node. Same shape as the `MaxTime`
clamp from #169: read the limit rather than hardcode it, and report an
unrecognised value on stderr instead of silently skipping the cap.

The boundary is exact, no margin needed:

```
$ sbatch --mem=15867M …   ->  Submitted batch job 108
$ sbatch --mem=15868M …   ->  Memory specification can not be satisfied
```

## Verification

`make -C scripts/testing workload N=20`:

```
Submitted: 20 / 20 jobs
Clamped:   2 job(s) to their partition's MaxTime
Capped:    7 job(s) to the smallest node's memory (15867M)
```

The 8-CPU jobs, by state — every capped job either runs or waits its turn, and
the only failures are the 16G ones from earlier runs, IDs 88 to 106, still
inside `MinJobAge`:

```
111|8|15867M|RUNNING     113|8|15867M|PENDING     88|8|16G|FAILED
114|8|15867M|RUNNING     125|8|15867M|PENDING     93|8|16G|FAILED
118|8|15867M|RUNNING                              94|8|16G|FAILED
124|8|15867M|RUNNING                             101|8|16G|FAILED
126|8|15867M|RUNNING                             106|8|16G|FAILED
```

The exporter on the same cluster, against 11 running / 30 CPUs before this
change:

```
slurm_jobs_running 11
slurm_jobs_pending 9
slurm_cpus_alloc 58
```

`shellcheck -S warning` reports only the pre-existing `SC2034`. Steps 1-3 are
untouched by a shell-only diff; steps 4, 5 and 7 pass on the live cluster; step
8 is not applicable, no dashboard changed.

## What this closes

With #169, #172 and this one, `make workload` finally produces what it claims:
every job is submitted, every job is schedulable, and the largest ones run.
