### PR TITLE
fix(queue): count a job in every partition it is queued in

### DIFF
--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -333,6 +333,15 @@ slurm_cores_running{partition="gpu",user="alice"} 128
 slurm_cores_running{partition="cpu",user="bob"} 384
 ```
 
+A single job submitted with `sbatch -p debug,high` appears once per partition,
+while the cluster-wide total still counts it once:
+
+```
+slurm_queue_pending{partition="debug",reason="JobHeldUser",user="alice"} 1
+slurm_queue_pending{partition="high",reason="JobHeldUser",user="alice"} 1
+slurm_jobs_pending 1
+```
+
 ### With `--no-collector.queue.user-label`
 
 The `user` label is dropped; counts are aggregated per partition.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -199,6 +199,13 @@ Provides detailed metrics on job states and resource usage.
 | `slurm_jobs_cores_running` | Total cores used by running jobs | (none) |
 | `slurm_jobs_cores_pending` | Total cores requested by pending jobs | (none) |
 
+A job submitted to several partitions (`sbatch -p debug,high`) is queued in each
+of them and counts once in each of the per-user/partition metrics above, the
+same rule the `partitions` collector follows. The global totals count it once,
+so `sum(slurm_queue_pending)` can exceed `slurm_jobs_pending` while
+`sum by(partition) (slurm_queue_pending)` names only partitions that exist.
+Alert on `slurm_jobs_pending` when you mean a number of jobs.
+
 #### Terminal states and the `MinJobAge` window
 
 `squeue` reports pending and running jobs when it is not told which states to

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -35,6 +35,13 @@ type QueueMetrics struct {
 	cTimeout     NVal
 	cPreempted   NVal
 	cNodeFail    NVal
+
+	// Cluster-wide counts, keyed by state, incremented once per job. They
+	// cannot be derived from the maps above: a job pending in several
+	// partitions is counted in each of them, while slurm_jobs_pending must
+	// stay a job count — three shipped alerting rules read it as one.
+	jobTotals  map[string]float64
+	coreTotals map[string]float64
 }
 
 func QueueGetMetrics(logger *logger.Logger, withTerminalStates bool) (*QueueMetrics, error) {
@@ -97,6 +104,8 @@ func ParseQueueMetrics(input []byte) *QueueMetrics {
 		cTimeout:     make(NVal),
 		cPreempted:   make(NVal),
 		cNodeFail:    make(NVal),
+		jobTotals:    make(map[string]float64),
+		coreTotals:   make(map[string]float64),
 	}
 	for line := range strings.SplitSeq(string(input), "\n") {
 		if strings.Contains(line, "|") {
@@ -105,51 +114,61 @@ func ParseQueueMetrics(input []byte) *QueueMetrics {
 			if len(fields) < 5 {
 				continue
 			}
-			// Strip the default-partition marker (*) so labels are consistent
-			// with the partitions and nodes collectors. squeue -o "%P" emits
-			// "compute*" for the default partition on some Slurm versions; the
-			// same fix as in partitions.go (issue #20) is applied here so any
-			// PromQL join on the partition label works as expected.
-			part := strings.TrimRight(strings.TrimSpace(fields[0]), "*")
+			// A job submitted to several partitions is reported by squeue
+			// as a comma-separated list, and the default partition carries
+			// a "*" marker. squeuePartitions applies both normalisations —
+			// the same ones parsePartitionJobs needs — so the label always
+			// names a partition that exists (issues #20 and #154).
+			parts := squeuePartitions(fields[0])
 			state := fields[1]
 			coresI, _ := strconv.Atoi(fields[2])
 			cores := float64(coresI)
 			reason := fields[3]
 			user := strings.TrimSpace(fields[4])
+
+			// A job queued in several partitions contends for each, so it is
+			// counted in each — the rule parsePartitionJobs already applies.
+			// The cluster-wide totals stay at one per job.
+			addN := func(jobs, jobCores NVal) {
+				for _, part := range parts {
+					jobs.Incr(user, part, 1)
+					jobCores.Incr(user, part, cores)
+				}
+				qm.jobTotals[state]++
+				qm.coreTotals[state] += cores
+			}
+			addNN := func(jobs, jobCores NNVal) {
+				for _, part := range parts {
+					jobs.Incr2(reason, user, part, 1)
+					jobCores.Incr2(reason, user, part, cores)
+				}
+				qm.jobTotals[state]++
+				qm.coreTotals[state] += cores
+			}
+
 			switch state {
 			case "PENDING":
-				qm.pending.Incr2(reason, user, part, 1)
-				qm.cPending.Incr2(reason, user, part, cores)
+				addNN(qm.pending, qm.cPending)
 			case "RUNNING":
-				qm.running.Incr(user, part, 1)
-				qm.cRunning.Incr(user, part, cores)
+				addN(qm.running, qm.cRunning)
 			case "SUSPENDED":
-				qm.suspended.Incr(user, part, 1)
-				qm.cSuspended.Incr(user, part, cores)
+				addN(qm.suspended, qm.cSuspended)
 			case "CANCELLED":
-				qm.cancelled.Incr(user, part, 1)
-				qm.cCancelled.Incr(user, part, cores)
+				addN(qm.cancelled, qm.cCancelled)
 			case "COMPLETING":
-				qm.completing.Incr(user, part, 1)
-				qm.cCompleting.Incr(user, part, cores)
+				addN(qm.completing, qm.cCompleting)
 			case "COMPLETED":
-				qm.completed.Incr(user, part, 1)
-				qm.cCompleted.Incr(user, part, cores)
+				addN(qm.completed, qm.cCompleted)
 			case "CONFIGURING":
-				qm.configuring.Incr(user, part, 1)
-				qm.cConfiguring.Incr(user, part, cores)
+				addN(qm.configuring, qm.cConfiguring)
 			case "FAILED":
-				qm.failed.Incr(user, part, 1)
-				qm.cFailed.Incr(user, part, cores)
+				addN(qm.failed, qm.cFailed)
 			case "TIMEOUT":
-				qm.timeout.Incr(user, part, 1)
-				qm.cTimeout.Incr(user, part, cores)
+				addN(qm.timeout, qm.cTimeout)
 			case "PREEMPTED":
-				qm.preempted.Incr(user, part, 1)
-				qm.cPreempted.Incr(user, part, cores)
+				addN(qm.preempted, qm.cPreempted)
 			case "NODE_FAIL":
-				qm.nodeFail.Incr(user, part, 1)
-				qm.cNodeFail.Incr(user, part, cores)
+				addN(qm.nodeFail, qm.cNodeFail)
 			}
 		}
 	}
@@ -329,16 +348,9 @@ func (qc *QueueCollector) tryCollect(ch chan<- prometheus.Metric) error {
 		qc.logger.Error("Failed to get queue metrics", "err", err)
 		// Emit global totals at 0 so they remain present in Prometheus
 		// even when squeue is unavailable. Per-user metrics are omitted.
-		empty := &QueueMetrics{
-			pending: make(NNVal), running: make(NVal),
-			suspended: make(NVal), completing: make(NVal),
-			completed: make(NVal), configuring: make(NVal),
-			failed: make(NVal), timeout: make(NVal),
-			preempted: make(NVal), nodeFail: make(NVal),
-			cancelled: make(NVal),
-			cPending:  make(NNVal), cRunning: make(NVal),
-		}
-		qc.emitGlobalTotals(ch, empty)
+		// The zero value is enough: emitGlobalTotals reads jobTotals and
+		// coreTotals, and a nil map reads as 0.
+		qc.emitGlobalTotals(ch, &QueueMetrics{})
 		return err
 	}
 	if qc.withUserLabel {
@@ -403,19 +415,19 @@ func (qc *QueueCollector) tryCollect(ch chan<- prometheus.Metric) error {
 // Called both on success and on squeue error (with empty metrics) so these
 // series are always present in Prometheus, enabling reliable alerting.
 func (qc *QueueCollector) emitGlobalTotals(ch chan<- prometheus.Metric, qm *QueueMetrics) {
-	ch <- prometheus.MustNewConstMetric(qc.jobsPending, prometheus.GaugeValue, sumNNVal(qm.pending))
-	ch <- prometheus.MustNewConstMetric(qc.jobsRunning, prometheus.GaugeValue, sumNVal(qm.running))
-	ch <- prometheus.MustNewConstMetric(qc.jobsSuspended, prometheus.GaugeValue, sumNVal(qm.suspended))
-	ch <- prometheus.MustNewConstMetric(qc.jobsCompleting, prometheus.GaugeValue, sumNVal(qm.completing))
-	ch <- prometheus.MustNewConstMetric(qc.jobsCompleted, prometheus.GaugeValue, sumNVal(qm.completed))
-	ch <- prometheus.MustNewConstMetric(qc.jobsConfiguring, prometheus.GaugeValue, sumNVal(qm.configuring))
-	ch <- prometheus.MustNewConstMetric(qc.jobsFailed, prometheus.GaugeValue, sumNVal(qm.failed))
-	ch <- prometheus.MustNewConstMetric(qc.jobsTimeout, prometheus.GaugeValue, sumNVal(qm.timeout))
-	ch <- prometheus.MustNewConstMetric(qc.jobsPreempted, prometheus.GaugeValue, sumNVal(qm.preempted))
-	ch <- prometheus.MustNewConstMetric(qc.jobsNodeFail, prometheus.GaugeValue, sumNVal(qm.nodeFail))
-	ch <- prometheus.MustNewConstMetric(qc.jobsCancelled, prometheus.GaugeValue, sumNVal(qm.cancelled))
-	ch <- prometheus.MustNewConstMetric(qc.jobsCoresRunning, prometheus.GaugeValue, sumNVal(qm.cRunning))
-	ch <- prometheus.MustNewConstMetric(qc.jobsCoresPending, prometheus.GaugeValue, sumNNVal(qm.cPending))
+	ch <- prometheus.MustNewConstMetric(qc.jobsPending, prometheus.GaugeValue, qm.jobTotals["PENDING"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsRunning, prometheus.GaugeValue, qm.jobTotals["RUNNING"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsSuspended, prometheus.GaugeValue, qm.jobTotals["SUSPENDED"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsCompleting, prometheus.GaugeValue, qm.jobTotals["COMPLETING"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsCompleted, prometheus.GaugeValue, qm.jobTotals["COMPLETED"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsConfiguring, prometheus.GaugeValue, qm.jobTotals["CONFIGURING"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsFailed, prometheus.GaugeValue, qm.jobTotals["FAILED"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsTimeout, prometheus.GaugeValue, qm.jobTotals["TIMEOUT"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsPreempted, prometheus.GaugeValue, qm.jobTotals["PREEMPTED"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsNodeFail, prometheus.GaugeValue, qm.jobTotals["NODE_FAIL"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsCancelled, prometheus.GaugeValue, qm.jobTotals["CANCELLED"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsCoresRunning, prometheus.GaugeValue, qm.coreTotals["RUNNING"])
+	ch <- prometheus.MustNewConstMetric(qc.jobsCoresPending, prometheus.GaugeValue, qm.coreTotals["PENDING"])
 }
 
 // pushAggregatedNVal aggregates NVal (user->partition->count) to {partition},

--- a/internal/collector/queue_collector_test.go
+++ b/internal/collector/queue_collector_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -137,4 +138,82 @@ func TestQueueCollector_ErrorEmitsGlobalTotals(t *testing.T) {
 	}
 	assert.True(t, names["slurm_jobs_running"], "global totals must be emitted even on error")
 	assert.True(t, names["slurm_jobs_pending"])
+}
+
+// gatheredValue returns the value of the series `name` carrying every label in
+// want, and whether it was found at all.
+func gatheredValue(mfs []*dto.MetricFamily, name string, want map[string]string) (float64, bool) {
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+	metric:
+		for _, m := range mf.GetMetric() {
+			got := make(map[string]string, len(m.GetLabel()))
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			for k, v := range want {
+				if got[k] != v {
+					continue metric
+				}
+			}
+			return m.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+// TestQueueCollectorSplitsMultiPartitionJobs is the non-regression test for
+// issue #154. squeue reports a job submitted with `sbatch -p debug,high` as
+// "debug,high", and the collector used to pass that string through as a
+// partition label, naming a partition no cluster has. The two input lines are
+// copied from a capture on the scripts/testing cluster.
+//
+// The job now counts in each partition it is queued in, while
+// slurm_jobs_pending stays a count of jobs: alerts.yml fires on
+// `slurm_jobs_pending > 500` and `> 1000`, so inflating it by the number of
+// partitions a site submits to would move those thresholds.
+func TestQueueCollectorSplitsMultiPartitionJobs(t *testing.T) {
+	input := []byte("debug,high|PENDING|2|JobHeldUser|alice\n" +
+		"debug|PENDING|4|Priority|bob\n")
+
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		return input, nil
+	}
+
+	log := logger.NewLogger("error")
+	c := NewQueueCollector(log, true, true)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, part := range []string{"debug", "high"} {
+		v, ok := gatheredValue(mfs, "slurm_queue_pending",
+			map[string]string{"partition": part, "user": "alice", "reason": "JobHeldUser"})
+		assert.True(t, ok, "alice's job must appear in partition %q", part)
+		assert.Equal(t, 1.0, v)
+
+		cores, ok := gatheredValue(mfs, "slurm_cores_pending",
+			map[string]string{"partition": part, "user": "alice", "reason": "JobHeldUser"})
+		assert.True(t, ok, "alice's cores must appear in partition %q", part)
+		assert.Equal(t, 2.0, cores)
+	}
+
+	_, ok := gatheredValue(mfs, "slurm_queue_pending", map[string]string{"partition": "debug,high"})
+	assert.False(t, ok, "the raw squeue list must never reach a label")
+
+	// Two jobs, one of them queued in two partitions: the cluster-wide count
+	// is 2, not 3.
+	total, ok := gatheredValue(mfs, "slurm_jobs_pending", nil)
+	require.True(t, ok, "slurm_jobs_pending must always be emitted")
+	assert.Equal(t, 2.0, total, "a job queued in two partitions is still one job")
+
+	cores, ok := gatheredValue(mfs, "slurm_jobs_cores_pending", nil)
+	require.True(t, ok)
+	assert.Equal(t, 6.0, cores, "2 cores for alice + 4 for bob, counted once each")
 }

--- a/internal/collector/queue_test.go
+++ b/internal/collector/queue_test.go
@@ -45,6 +45,14 @@ func TestParseQueueMetrics(t *testing.T) {
 	assert.Equal(t, 2.0, qm.pending["Priority"]["carol"]["debug"])
 	assert.Equal(t, 1.0, qm.pending["Resources"]["eve"]["high"])
 
+	// A job held on "debug,high" counts in both partitions, never under the
+	// literal string (#154). Captured from `sbatch --hold -p debug,high`.
+	assert.Equal(t, 1.0, qm.pending["JobHeldUser"]["alice"]["debug"])
+	assert.Equal(t, 1.0, qm.pending["JobHeldUser"]["alice"]["high"])
+	assert.Equal(t, 2.0, qm.cPending["JobHeldUser"]["alice"]["debug"])
+	assert.NotContains(t, qm.pending["JobHeldUser"]["alice"], "debug,high",
+		"the raw list must never reach a label")
+
 	// Suspended, with its cores — regression for the copy-paste that
 	// incremented suspended twice instead of populating cSuspended.
 	assert.Equal(t, 1.0, qm.suspended["bob"]["high"], "suspended job count")
@@ -159,7 +167,9 @@ func TestPushAggregatedNNVal(t *testing.T) {
 	const nodesDown = "Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions"
 	assert.Equal(t, map[string]float64{
 		`partition="debug",reason="` + nodesDown + `"`: 1,
+		`partition="debug",reason="JobHeldUser"`:       2,
 		`partition="debug",reason="Priority"`:          5,
+		`partition="high",reason="JobHeldUser"`:        2,
 		`partition="high",reason="Priority"`:           1,
 		`partition="high",reason="Resources"`:          1,
 	}, got, "slurm_queue_pending: reason must survive aggregation, user must not")
@@ -195,31 +205,38 @@ func TestGlobalQueueMetrics(t *testing.T) {
 
 	qm := ParseQueueMetrics(data)
 
-	assert.Equal(t, 15.0, sumNVal(qm.running), "15 running jobs")
-	assert.Equal(t, 8.0, sumNNVal(qm.pending), "8 pending jobs")
-	assert.Equal(t, 78.0, sumNVal(qm.cRunning), "78 running cores")
-	assert.Equal(t, 38.0, sumNNVal(qm.cPending), "38 pending cores")
+	// The fixture holds two jobs submitted to "debug,high". They are counted
+	// once each cluster-wide and once in each partition, so the two figures
+	// differ by exactly two — the distinction slurm_jobs_pending depends on.
+	assert.Equal(t, 10.0, qm.jobTotals["PENDING"], "10 pending jobs")
+	assert.Equal(t, 12.0, sumNNVal(qm.pending), "12 pending job/partition pairs")
+	assert.Equal(t, 42.0, qm.coreTotals["PENDING"], "42 pending cores")
+	assert.Equal(t, 46.0, sumNNVal(qm.cPending), "46 pending core/partition pairs")
 
-	assert.Equal(t, 1.0, sumNVal(qm.suspended))
-	assert.Equal(t, 24.0, sumNVal(qm.cancelled))
-	assert.Equal(t, 1.0, sumNVal(qm.failed))
-	assert.Equal(t, 1.0, sumNVal(qm.timeout))
-	assert.Equal(t, 1.0, sumNVal(qm.nodeFail))
-	assert.Equal(t, 2.0, sumNVal(qm.completed))
+	// A job runs in one partition, so both figures agree.
+	assert.Equal(t, 15.0, qm.jobTotals["RUNNING"], "15 running jobs")
+	assert.Equal(t, 15.0, sumNVal(qm.running))
+	assert.Equal(t, 78.0, qm.coreTotals["RUNNING"], "78 running cores")
+
+	assert.Equal(t, 1.0, qm.jobTotals["SUSPENDED"])
+	assert.Equal(t, 24.0, qm.jobTotals["CANCELLED"])
+	assert.Equal(t, 1.0, qm.jobTotals["FAILED"])
+	assert.Equal(t, 1.0, qm.jobTotals["TIMEOUT"])
+	assert.Equal(t, 1.0, qm.jobTotals["NODE_FAIL"])
+	assert.Equal(t, 2.0, qm.jobTotals["COMPLETED"])
 
 	// The test cluster cannot produce these three; the parser paths that feed
-	// them are covered by TestParseQueueMetricsUnreachableStates. Asserting 0
-	// here keeps the fixture honest about what it contains.
-	assert.Equal(t, 0.0, sumNVal(qm.preempted))
-	assert.Equal(t, 0.0, sumNVal(qm.completing))
-	assert.Equal(t, 0.0, sumNVal(qm.configuring))
+	// them are covered by TestParseQueueMetricsUnreachableStates.
+	assert.Equal(t, 0.0, qm.jobTotals["PREEMPTED"])
+	assert.Equal(t, 0.0, qm.jobTotals["COMPLETING"])
+	assert.Equal(t, 0.0, qm.jobTotals["CONFIGURING"])
 }
 
 // TestGlobalQueueMetricsEmptyCluster verifies that global totals are 0 (not absent)
 // when the cluster has no jobs — this is the key behavior difference vs per-user metrics.
 func TestGlobalQueueMetricsEmptyCluster(t *testing.T) {
 	qm := ParseQueueMetrics([]byte(""))
-	assert.Equal(t, 0.0, sumNVal(qm.running), "running must be 0, not absent")
-	assert.Equal(t, 0.0, sumNNVal(qm.pending), "pending must be 0, not absent")
-	assert.Equal(t, 0.0, sumNVal(qm.cRunning), "cores_running must be 0, not absent")
+	assert.Equal(t, 0.0, qm.jobTotals["RUNNING"], "running must be 0, not absent")
+	assert.Equal(t, 0.0, qm.jobTotals["PENDING"], "pending must be 0, not absent")
+	assert.Equal(t, 0.0, qm.coreTotals["RUNNING"], "cores_running must be 0, not absent")
 }

--- a/test_data/squeue.txt
+++ b/test_data/squeue.txt
@@ -31,6 +31,8 @@ debug|PENDING|8|Priority|carol
 debug|PENDING|2|Priority|dave
 debug|PENDING|4|Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions|frank
 debug|PENDING|4|Priority|frank
+debug,high|PENDING|2|JobHeldUser|alice
+debug,high|PENDING|2|JobHeldUser|bob
 high|CANCELLED|2|None|alice
 high|CANCELLED|2|None|alice
 high|CANCELLED|8|None|alice


### PR DESCRIPTION
Closes #154.

## The defect

`squeue` reports a job submitted with `sbatch -p debug,high` as `debug,high`.
The queue collector passed that string through as a partition label. Reproduced
on the integration cluster with two held jobs:

```
$ docker exec slurmctld squeue -h -o "%P|%T|%C|%r|%u" --states=all | grep ,
debug,high|PENDING|2|JobHeldUser|alice
debug,high|PENDING|2|JobHeldUser|bob

$ curl -s localhost:9341/metrics | grep 'debug,high'
slurm_queue_pending{partition="debug,high",reason="JobHeldUser",user="alice"} 1
slurm_queue_pending{partition="debug,high",reason="JobHeldUser",user="bob"} 1
slurm_cores_pending{partition="debug,high",reason="JobHeldUser",user="alice"} 2
slurm_cores_pending{partition="debug,high",reason="JobHeldUser",user="bob"} 2
```

`02-slurm-jobs.json` draws `sum by(partition) (slurm_queue_pending)`, so those
jobs became a row for a partition that does not exist, while the two real
partitions were undercounted. Any join against `slurm_partition_*` or
`slurm_node_*` on the partition label missed them entirely.

## The fix

`ParseQueueMetrics` goes through `squeuePartitions`, the helper
`parsePartitionJobs` already uses: it strips the default-partition marker and
splits the list, so the two normalisations live in one place. A job is counted
in each partition it is queued in — the semantics #153 settled on for the
partitions collector.

**The part the issue does not mention.** Splitting alone would have broken the
cluster-wide totals, because `emitGlobalTotals` derived them by summing those
same maps:

```go
ch <- prometheus.MustNewConstMetric(qc.jobsPending, prometheus.GaugeValue, sumNNVal(qm.pending))
```

A job pending in two partitions would then have counted twice in
`slurm_jobs_pending`, and `monitoring/prometheus/alerts.yml` fires on it three
times:

```
$ grep -n "slurm_jobs_pending" monitoring/prometheus/alerts.yml
78:        expr: slurm_jobs_pending > 500
88:        expr: slurm_jobs_pending > 1000
170:        expr: slurm_gpus_idle == 0 and slurm_gpus_total > 0 and slurm_jobs_pending > 10
```

On a site where users routinely submit to three partitions, a 400-job backlog
would have read as 1200 and fired `SlurmQueueCritical`. `QueueMetrics` now
carries `jobTotals` and `coreTotals`, incremented once per job, and
`emitGlobalTotals` reads those. The two figures are deliberately different and
both are tested.

The `switch` on state repeated the same two `Incr` calls eleven times. It now
goes through one closure per map arity, which is what made adding both the loop
and the totals a one-line change per state.

## Dashboard and alert impact

Verified. Consumers of the changed families:

| file | expression | effect |
|---|---|---|
| `02-slurm-jobs.json` | `sum by(partition) (slurm_queue_pending)` | **fixed** — the `debug,high` row disappears, its jobs land in `debug` and `high` |
| `02-slurm-jobs.json` | `sum by(reason) (slurm_queue_pending)` | changes: a multi-partition job now counts once per partition in this sum |
| `10-slurm-all-metrics.json` | `slurm_queue_pending` | raw table, shows the split |
| `alerts.yml` × 3 | `slurm_jobs_pending` | **unchanged by design**, see above |

`sum by(reason)` is the one place where a number moves without being wrong
before: it aggregates a per-partition series, so it now counts partition
memberships rather than jobs. `slurm_jobs_pending` is the metric for a job count
and is what the alerts use.

## The exporter, run locally

Same cluster, same two held jobs, master binary then this branch:

```
                                                    before        after
slurm_jobs_pending                                      10           10
slurm_queue_pending{partition="debug,high",…,alice}      1            —
slurm_queue_pending{partition="debug,high",…,bob}        1            —
slurm_queue_pending{partition="debug",…,alice}           —            1
slurm_queue_pending{partition="high",…,alice}            —            1
slurm_queue_pending{partition="debug",…,bob}             —            1
slurm_queue_pending{partition="high",…,bob}              —            1
```

Step 7: 0 ERROR/WARN in the exporter log.

## Tests

`TestQueueCollectorSplitsMultiPartitionJobs` asserts both halves: the job in
each partition, no series carrying the raw list, and `slurm_jobs_pending` at 2
for two jobs one of which spans two partitions. Run against `master` it fails on
the first assertion — the `debug` series does not exist there.

The fixture gained the two lines captured above, so the parser tests see the
case too: `jobTotals["PENDING"]` is 10 where `sumNNVal(qm.pending)` is 12, and
the difference is exactly the two multi-partition jobs.

`make check` green: 145 tests, vet, golangci-lint, zizmor, deadcode.
