### PR TITLE
test(gpus): run the per-version GPU fixture matrix and assert exact counts

### DIFF
--- a/internal/collector/gpus_test.go
+++ b/internal/collector/gpus_test.go
@@ -1,78 +1,133 @@
 package collector
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
 
+// gpuFixtureExpect holds the GPU counts each per-version fixture in
+// test_data/slurm-* must parse to. The GRES output format changed between
+// Slurm releases (bare "gpu:2", "(null)" typed specs, "gpu:type:count(IDX...)",
+// MIG slices, commas inside the IDX list), so this table is the version matrix
+// that protects the parser and the alert-bearing slurm_gpus_* metrics.
+//
+// other = max(0, total-alloc-idle) and util = alloc/total mirror the derivation
+// in ParseGPUsMetrics; they are asserted independently rather than recomputed so
+// a regression in that formula is caught too.
+type gpuExpect struct {
+	total float64
+	alloc float64
+	idle  float64
+	other float64
+	util  float64
+}
+
+var gpuFixtureExpect = map[string]gpuExpect{
+	"20.11.8": {total: 48, alloc: 7, idle: 41, other: 0, util: 7.0 / 48.0},
+	"21.08.5": {total: 16, alloc: 0, idle: 16, other: 0, util: 0},
+	// 23.11.10's sinfo_gpus_idle.txt has 2 columns, not the 3 IdleGPUsData emits,
+	// so ParseIdleGPUs takes its 2-column branch and idle here is an artefact
+	// (nodes×column) rather than total-alloc. This pins current behaviour only;
+	// recapturing the fixture is tracked in #177.
+	"23.11.10":   {total: 232, alloc: 33, idle: 33, other: 166, util: 33.0 / 232.0},
+	"23.11.10-2": {total: 10, alloc: 6, idle: 4, other: 0, util: 0.6},
+	"25.05":      {total: 4232, alloc: 4226, idle: 6, other: 0, util: 4226.0 / 4232.0},
+	"25.11.1-1":  {total: 154, alloc: 78, idle: 24, other: 52, util: 78.0 / 154.0},
+}
+
+// gpuFixtureVersions globs the per-version fixture directories and asserts the
+// set matches gpuFixtureExpect exactly. Before issue #148 the glob resolved to a
+// non-existent directory, so it returned an empty slice and every test body was
+// skipped while still reporting a pass. require.NotEmpty plus the symmetric
+// membership checks make the suite fail loudly the next time the fixtures move
+// or a new version is captured without expected values.
+func gpuFixtureVersions(t *testing.T) map[string]string {
+	t.Helper()
+
+	paths, err := filepath.Glob("../../test_data/slurm-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "no per-version GPU fixtures found under ../../test_data/slurm-*")
+
+	versions := make(map[string]string, len(paths))
+	for _, p := range paths {
+		v := strings.TrimPrefix(filepath.Base(p), "slurm-")
+		require.Contains(t, gpuFixtureExpect, v,
+			"fixture %s has no entry in gpuFixtureExpect; add its expected GPU counts", v)
+		versions[v] = p
+	}
+	for v := range gpuFixtureExpect {
+		require.Contains(t, versions, v,
+			"gpuFixtureExpect lists %s but no test_data/slurm-%s fixture exists", v, v)
+	}
+	return versions
+}
+
+// TestGPUsMetrics exercises the three pure parsers against every version fixture
+// and asserts the exact counts, so a change in GRES parsing that breaks one
+// Slurm format is caught even if the others still parse.
 func TestGPUsMetrics(t *testing.T) {
-	testDataPaths, _ := filepath.Glob("../test_data/slurm-*")
-	for _, testDataPath := range testDataPaths {
-		slurmVersion := strings.TrimPrefix(testDataPath, "../test_data/slurm-")
-		t.Logf("slurm-%s", slurmVersion)
+	for version, path := range gpuFixtureVersions(t) {
+		t.Run(version, func(t *testing.T) {
+			want := gpuFixtureExpect[version]
 
-		file, err := os.Open(testDataPath + "/sinfo_gpus_allocated.txt")
-		if err != nil {
-			t.Fatalf("Can not open test data: %v", err)
-		}
-		data, _ := io.ReadAll(file)
-		metrics := ParseAllocatedGPUs(data)
-		t.Logf("Allocated: %+v", metrics)
+			total := ParseTotalGPUs(readFixture(t, path, "sinfo_gpus_total.txt"))
+			assert.Equal(t, want.total, total, "total GPUs")
 
-		file, err = os.Open(testDataPath + "/sinfo_gpus_idle.txt")
-		if err != nil {
-			t.Fatalf("Can not open test data: %v", err)
-		}
-		data, _ = io.ReadAll(file)
-		metrics = ParseIdleGPUs(data)
-		t.Logf("Idle: %+v", metrics)
+			alloc := ParseAllocatedGPUs(readFixture(t, path, "sinfo_gpus_allocated.txt"))
+			assert.Equal(t, want.alloc, alloc, "allocated GPUs")
 
-		file, err = os.Open(testDataPath + "/sinfo_gpus_total.txt")
-		if err != nil {
-			t.Fatalf("Can not open test data: %v", err)
-		}
-		data, _ = io.ReadAll(file)
-		metrics = ParseTotalGPUs(data)
-		t.Logf("Total: %+v", metrics)
+			idle := ParseIdleGPUs(readFixture(t, path, "sinfo_gpus_idle.txt"))
+			assert.Equal(t, want.idle, idle, "idle GPUs")
+		})
 	}
 }
 
+// TestGPUsGetMetrics drives the full GPUsGetMetrics path per version through a
+// mocked Execute, covering the other/utilization derivation on top of the raw
+// parsers.
 func TestGPUsGetMetrics(t *testing.T) {
 	oldExecute := Execute
 	defer func() { Execute = oldExecute }()
 
-	testDataPaths, _ := filepath.Glob("../../test_data/slurm-*")
-	for _, testDataPath := range testDataPaths {
-		slurmVersion := strings.TrimPrefix(testDataPath, "../../test_data/slurm-")
-		t.Run(slurmVersion, func(t *testing.T) {
+	for version, path := range gpuFixtureVersions(t) {
+		t.Run(version, func(t *testing.T) {
+			want := gpuFixtureExpect[version]
+
 			Execute = func(logger *logger.Logger, command string, args []string) ([]byte, error) {
 				var file string
 				switch {
 				case strings.Contains(args[2], "GresUsed:") && strings.Contains(args[2], "Gres:"):
-					file = filepath.Join(testDataPath, "sinfo_gpus_idle.txt")
+					file = "sinfo_gpus_idle.txt"
 				case strings.Contains(args[2], "GresUsed:"):
-					file = filepath.Join(testDataPath, "sinfo_gpus_allocated.txt")
+					file = "sinfo_gpus_allocated.txt"
 				case strings.Contains(args[2], "Gres:"):
-					file = filepath.Join(testDataPath, "sinfo_gpus_total.txt")
+					file = "sinfo_gpus_total.txt"
 				}
-				data, err := os.ReadFile(file)
-				if err != nil {
-					return nil, err
-				}
-				return data, nil
+				return os.ReadFile(filepath.Join(path, file))
 			}
 
-			testLogger := logger.NewLogger("debug")
-			metrics, err := GPUsGetMetrics(testLogger)
-			if err != nil {
-				t.Fatalf("GPUsGetMetrics() error: %v", err)
-			}
-			t.Logf("slurm-%s: %+v", slurmVersion, metrics)
+			metrics, err := GPUsGetMetrics(logger.NewLogger("debug"))
+			require.NoError(t, err)
+
+			assert.Equal(t, want.total, metrics.total, "total GPUs")
+			assert.Equal(t, want.alloc, metrics.alloc, "allocated GPUs")
+			assert.Equal(t, want.idle, metrics.idle, "idle GPUs")
+			assert.Equal(t, want.other, metrics.other, "other GPUs")
+			assert.InDelta(t, want.util, metrics.utilization, 1e-9, "GPU utilization")
 		})
 	}
+}
+
+func readFixture(t *testing.T, dir, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	require.NoError(t, err)
+	return data
 }


### PR DESCRIPTION
## Problem

`TestGPUsMetrics` globbed `../test_data/slurm-*` — a directory that does not
exist relative to `internal/collector/`. `filepath.Glob` returned an empty
slice (and a nil error, which was discarded), the `for` body never executed,
and the test passed unconditionally.

The six per-version GPU fixtures in `test_data/slurm-*` exist precisely because
the GRES output format changed between Slurm releases (bare `gpu:2`, `(null)`
typed specs, `gpu:type:count(IDX...)`, MIG slices, commas inside the IDX list).
That version matrix protected nothing — including `slurm_gpus_idle` and
`slurm_gpus_total`, which feed the `SlurmNoGPUsAvailable` **paging** alert.

## Fix

- Correct the glob to `../../test_data/slurm-*` and guard it with
  `require.NotEmpty` so the silent pass can never return.
- Replace the `t.Logf`-only bodies with a shared expectations table asserting
  `total`/`alloc`/`idle` per fixture (exact counts), plus `other`/`utilization`
  through the full `GPUsGetMetrics` path.
- Symmetric membership checks: a new fixture without expected values, or an
  expected version whose fixture disappears, both fail loudly.

Expected values were derived by hand from each fixture, then confirmed against
the parsers. Guarding was proven by re-introducing the buggy glob (→
`require.NotEmpty` fails) and by perturbing one expected value (→ the assertion
fails, naming the version and metric).

## Testing

`make check` (containerised: vet + golangci-lint + test + govulncheck +
actionlint + zizmor + deadcode) — all green.

Integration steps 4–9 are N/A: this is a test-only change. `gpus.go` (metric
emission) is unchanged byte-for-byte, so no metric value, dashboard, or
collector-log behaviour can differ.

Closes #148