### PR TITLE
perf(info): resolve binary versions once instead of forking --version every scrape (#149)

### DIFF
--- a/internal/collector/slurm_binary_info.go
+++ b/internal/collector/slurm_binary_info.go
@@ -5,11 +5,21 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
+
+// infoSeries is one resolved slurm_info series, held in memory so the versions
+// are probed once rather than re-forked on every scrape (issue #149).
+type infoSeries struct {
+	typ     string
+	binary  string
+	version string
+	value   float64
+}
 
 // SlurmInfoCollector defines a Prometheus collector for Slurm binary and version information
 type SlurmInfoCollector struct {
@@ -17,6 +27,11 @@ type SlurmInfoCollector struct {
 	requiredBinaries []string
 	optionalBinaries []string
 	logger           *logger.Logger
+
+	// Slurm binary versions cannot change while the process runs, so they are
+	// resolved once on the first scrape and served from memory thereafter.
+	resolveOnce sync.Once
+	series      []infoSeries
 }
 
 func NewSlurmInfoCollector(logger *logger.Logger) *SlurmInfoCollector {
@@ -46,23 +61,39 @@ func (c *SlurmInfoCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *SlurmInfoCollector) Collect(ch chan<- prometheus.Metric) {
-	version, found := GetBinaryVersion(c.logger, "sinfo")
-	versionValue := 0.0
-	if found {
-		versionValue = 1.0
+	c.resolveOnce.Do(c.resolve)
+	for _, s := range c.series {
+		ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, s.value, s.typ, s.binary, s.version)
 	}
+}
 
-	ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, versionValue, "general", "", version)
+// resolve probes every binary's version once and builds the series to emit on
+// every scrape. Called through resolveOnce so the `<binary> --version` forks
+// happen a single time for the process lifetime rather than on each scrape
+// (issue #149). A Slurm upgrade under a running exporter is not a supported
+// state — the process is restarted by whatever performed the upgrade.
+func (c *SlurmInfoCollector) resolve() {
+	// sinfo is probed once and reused for both the "general" series and its
+	// entry in requiredBinaries, removing the duplicate fork.
+	version, found := GetBinaryVersion(c.logger, "sinfo")
+	generalValue := 0.0
+	if found {
+		generalValue = 1.0
+	}
+	series := []infoSeries{{typ: "general", binary: "", version: version, value: generalValue}}
 
 	// Required binaries: always emit a series (value=0 with version="not_found"
 	// if the binary is missing, so absence is visible in alerts).
 	for _, binary := range c.requiredBinaries {
-		binVersion, binFound := GetBinaryVersion(c.logger, binary)
+		binVersion, binFound := version, found
+		if binary != "sinfo" {
+			binVersion, binFound = GetBinaryVersion(c.logger, binary)
+		}
 		binValue := 0.0
 		if binFound {
 			binValue = 1.0
 		}
-		ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, binValue, "binary", binary, binVersion)
+		series = append(series, infoSeries{typ: "binary", binary: binary, version: binVersion, value: binValue})
 	}
 
 	// Optional binaries: emit only if the binary is found on disk. No log,
@@ -76,8 +107,10 @@ func (c *SlurmInfoCollector) Collect(ch chan<- prometheus.Metric) {
 		if !binFound {
 			continue
 		}
-		ch <- prometheus.MustNewConstMetric(c.slurmInfo, prometheus.GaugeValue, 1.0, "binary", binary, binVersion)
+		series = append(series, infoSeries{typ: "binary", binary: binary, version: binVersion, value: 1.0})
 	}
+
+	c.series = series
 }
 
 // binaryAvailable reports whether the given binary can be found on disk

--- a/internal/collector/slurm_binary_info_test.go
+++ b/internal/collector/slurm_binary_info_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,6 +10,46 @@ import (
 
 	"github.com/sckyzo/slurm_exporter/internal/logger"
 )
+
+// TestSlurmInfoCollector_VersionsResolvedOnce is the non-regression test for
+// issue #149: binary versions are immutable for the process lifetime, so the
+// info collector must fork `<binary> --version` at most once per binary — never
+// twice for sinfo in a single scrape, and never again on later scrapes.
+func TestSlurmInfoCollector_VersionsResolvedOnce(t *testing.T) {
+	oldAvail := binaryAvailable
+	defer func() { binaryAvailable = oldAvail }()
+	binaryAvailable = func(binary string) bool { return true } // all present
+
+	oldExecute := Execute
+	defer func() { Execute = oldExecute }()
+	var mu sync.Mutex
+	calls := map[string]int{}
+	Execute = func(l *logger.Logger, command string, args []string) ([]byte, error) {
+		mu.Lock()
+		calls[command]++
+		mu.Unlock()
+		return []byte("slurm 23.11.10"), nil
+	}
+
+	log := logger.NewLogger("error")
+	c := NewSlurmInfoCollector(log)
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+
+	// Two scrapes: versions cannot change between them.
+	_, err := reg.Gather()
+	require.NoError(t, err)
+	_, err = reg.Gather()
+	require.NoError(t, err)
+
+	for _, binary := range []string{
+		"sinfo", "squeue", "sdiag", "scontrol", "sacct", // required
+		"sbatch", "salloc", "srun", // optional (all present here)
+	} {
+		assert.Equal(t, 1, calls[binary],
+			"%s --version must be forked exactly once for the whole process, not per scrape (and sinfo not twice)", binary)
+	}
+}
 
 // TestSlurmInfoCollector_OptionalBinariesSilentlySkipped verifies that the
 // optional job-submission binaries (sbatch/salloc/srun) are not emitted as


### PR DESCRIPTION
Closes #149.

## Summary

Slurm binary versions cannot change while the process runs, yet the `info`
collector re-forked `<binary> --version` on **every scrape**: six required forks
plus up to three for the optional job-submission tools — and `sinfo` **twice**,
once for the `type="general"` series and again as the first entry of
`requiredBinaries`.

Versions are now probed **once**, on the first scrape, through a `sync.Once`, and
served from memory afterwards. The single `sinfo` probe feeds both the
`general` series and its `requiredBinaries` entry, so the duplicate fork is
gone.

## No output change

Emitted series, labels and values are identical — same `general` series, same
required binaries (still `version="not_found"`/value=0 when missing so absence
stays alertable), same optional-when-present behaviour. Only the forking is
removed.

A Slurm upgrade under a running exporter is not a supported state (the process
is restarted by whatever performed the upgrade), so caching for the process
lifetime is safe — the approach the issue recommended.

## Validation (scripts/testing cluster, Slurm 25.11)

- New `TestSlurmInfoCollector_VersionsResolvedOnce`: across two scrapes, each
  required and optional binary is forked **exactly once** (was 2/scrape for
  sinfo). The two existing optional-binary tests are unchanged and still pass.
- `make check` green (vet, lint, test, govulncheck, actionlint, zizmor,
  deadcode).
- Live: identical `slurm_info` output (general + 5 required + 3 optional, all
  `25.11.2`), `slurm_exporter_collector_success{info}=1`, and
  `slurm_exporter_collector_duration_seconds{info}` down from ~13ms to ~3.5µs
  once resolved.

## Downstream

No dashboard or alert changes: `slurm_info` keeps its value (read by
`08-slurm-health` and `10-slurm-all-metrics`; no alerting rule reads it). The
visible effect is a lower `collector_duration_seconds{collector="info"}`.