### PR TITLE
refactor(gpus): unify duplicated GPU counting into one helper and one regexp (#150)

### DIFF
--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -32,8 +32,6 @@ func GPUsGetMetrics(logger *logger.Logger) (*GPUsMetrics, error) {
 func ParseAllocatedGPUs(data []byte) float64 {
 	var numGPUs = 0.0
 	sinfoLines := string(data)
-	// Regex to match GPU specifications: gpu:type:count or gpu:count
-	re := regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
 	if len(sinfoLines) > 0 {
 		for _, line := range strings.Split(sinfoLines, "\n") {
 			if len(line) > 0 && strings.Contains(line, "gpu:") {
@@ -43,20 +41,7 @@ func ParseAllocatedGPUs(data []byte) float64 {
 				}
 
 				numNodes, _ := strconv.ParseFloat(fields[0], 64)
-				nodeActiveGPUs := fields[1]
-				numNodeActiveGPUs := 0.0
-
-				// Parse GPU specifications separated by commas
-				for _, gpuSpec := range strings.Split(nodeActiveGPUs, ",") {
-					if strings.Contains(gpuSpec, "gpu:") {
-						matches := re.FindStringSubmatch(gpuSpec)
-						if len(matches) > 2 {
-							gpuCount, _ := strconv.ParseFloat(matches[2], 64)
-							numNodeActiveGPUs += gpuCount
-						}
-					}
-				}
-				numGPUs += numNodes * numNodeActiveGPUs
+				numGPUs += numNodes * parseGPUCount(fields[1])
 			}
 		}
 	}
@@ -72,7 +57,6 @@ func ParseAllocatedGPUs(data []byte) float64 {
 func ParseIdleGPUs(data []byte) float64 {
 	var numGPUs = 0.0
 	sinfoLines := string(data)
-	re := regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
 	if len(sinfoLines) > 0 {
 		for _, line := range strings.Split(sinfoLines, "\n") {
 			if len(line) > 0 && strings.Contains(line, "gpu:") {
@@ -89,12 +73,12 @@ func ParseIdleGPUs(data []byte) float64 {
 					numGPUs += 0
 				case 2:
 					// Two columns: nodes and total GPUs (no allocated info)
-					totalGPUs := parseGPUCount(fields[1], re)
+					totalGPUs := parseGPUCount(fields[1])
 					numGPUs += numNodes * totalGPUs
 				default:
 					// Three or more columns: nodes, total GPUs, allocated GPUs
-					totalGPUs := parseGPUCount(fields[1], re)
-					allocatedGPUs := parseGPUCount(fields[2], re)
+					totalGPUs := parseGPUCount(fields[1])
+					allocatedGPUs := parseGPUCount(fields[2])
 					idleGPUs := totalGPUs - allocatedGPUs
 					numGPUs += numNodes * idleGPUs
 				}
@@ -105,16 +89,27 @@ func ParseIdleGPUs(data []byte) float64 {
 	return numGPUs
 }
 
-// parseGPUCount extracts the total GPU count from a GPU specification string
-func parseGPUCount(gpuSpec string, re *regexp.Regexp) float64 {
+// gpuGresRe matches one GPU entry in a Slurm GRES/GresUsed field —
+// "gpu:<type>:<count>" or "gpu:<count>", with an optional "(null)" type and an
+// optional "(IDX:…)"/"(S:…)" suffix. Capture group 2 is the count. Compiled
+// once at package level rather than per Collect(), the convention the other
+// collectors follow (see nodes.go, scheduler.go).
+var gpuGresRe = regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
+
+// parseGPUCount sums the GPU counts across every gpu: entry in a comma-separated
+// GRES specification. A node can expose several GPU types at once
+// ("gpu:A100:4,gpu:H100:2" → 6), and non-gpu GRES (e.g. "mig:…") is ignored.
+// Shared by the cluster-wide (gpus.go) and per-partition (partitions.go) paths.
+func parseGPUCount(gpuSpec string) float64 {
 	var count = 0.0
 	for _, spec := range strings.Split(gpuSpec, ",") {
-		if strings.Contains(spec, "gpu:") {
-			matches := re.FindStringSubmatch(spec)
-			if len(matches) > 2 {
-				gpuCount, _ := strconv.ParseFloat(matches[2], 64)
-				count += gpuCount
-			}
+		if !strings.Contains(spec, "gpu:") {
+			continue
+		}
+		matches := gpuGresRe.FindStringSubmatch(spec)
+		if len(matches) > 2 {
+			gpuCount, _ := strconv.ParseFloat(matches[2], 64)
+			count += gpuCount
 		}
 	}
 	return count
@@ -128,7 +123,6 @@ func parseGPUCount(gpuSpec string, re *regexp.Regexp) float64 {
 func ParseTotalGPUs(data []byte) float64 {
 	var numGPUs = 0.0
 	sinfoLines := string(data)
-	re := regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
 
 	if len(sinfoLines) > 0 {
 		for _, line := range strings.Split(sinfoLines, "\n") {
@@ -139,7 +133,7 @@ func ParseTotalGPUs(data []byte) float64 {
 				}
 
 				numNodes, _ := strconv.ParseFloat(fields[0], 64)
-				nodeGPUs := parseGPUCount(fields[1], re)
+				nodeGPUs := parseGPUCount(fields[1])
 				numGPUs += numNodes * nodeGPUs
 			}
 		}

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -1,7 +1,6 @@
 package collector
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -41,30 +40,6 @@ type PartitionMetrics struct {
 	jobRunning   float64
 	gpuIdle      float64
 	gpuAllocated float64
-}
-
-var (
-	partitionGpuRe = regexp.MustCompile(`gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?`)
-)
-
-// parseGpuCount sums every gpu:*:N match in a GRES string.
-//
-// A node can expose several GPU types at once ("gpu:A100:4,gpu:H100:2" → 6),
-// so matching only the first entry undercounts slurm_partition_gpus_*.
-// gpus.go::parseGPUCount applies the same rule.
-func parseGpuCount(gpuSpec string, re *regexp.Regexp) float64 {
-	var count = 0.0
-	for _, spec := range strings.Split(gpuSpec, ",") {
-		if !strings.Contains(spec, "gpu:") {
-			continue
-		}
-		matches := re.FindStringSubmatch(spec)
-		if len(matches) > 2 {
-			gpuCount, _ := strconv.ParseFloat(matches[2], 64)
-			count += gpuCount
-		}
-	}
-	return count
 }
 
 // parsePartitionCPUs parses sinfo "%R,%C" output into the partitions map.
@@ -109,8 +84,8 @@ func parsePartitionGPUs(data []byte, partitions map[string]*PartitionMetrics) {
 		// Strip the default-partition marker (*) so labels are consistent with
 		// nodes.go and other partition consumers — see issue #20.
 		partition := strings.TrimRight(fields[1], "*")
-		nodeGpus := parseGpuCount(fields[2], partitionGpuRe)
-		allocatedGpus := parseGpuCount(fields[3], partitionGpuRe)
+		nodeGpus := parseGPUCount(fields[2])
+		allocatedGpus := parseGPUCount(fields[3])
 		if _, exists := partitions[partition]; !exists {
 			partitions[partition] = &PartitionMetrics{}
 		}

--- a/internal/collector/partitions_long_gres_test.go
+++ b/internal/collector/partitions_long_gres_test.go
@@ -14,7 +14,7 @@ import (
 // which silently truncated partition names longer than 30 chars and GRES
 // strings longer than 50 chars.
 //
-// This test also covers the multi-type GPU undercount fix in parseGpuCount.
+// This test also covers the multi-type GPU undercount fix in parseGPUCount.
 // The fixture's GRES line `gpu:nvidia_a100_80gb:8,mig:...,gpu:nvidia_h100_80gb:4`
 // sums to 12 GPUs per node (mig spec ignored by the gpu: regex).
 func TestParsePartitionGPUsLongValues(t *testing.T) {
@@ -30,13 +30,13 @@ func TestParsePartitionGPUsLongValues(t *testing.T) {
 	require.Contains(t, partitions, longName,
 		"long partition name must be preserved (not truncated)")
 
-	// Counts after parseGpuCount fix (sums all gpu: matches):
+	// Counts after parseGPUCount fix (sums all gpu: matches):
 	//   per node total = 8 + 4 = 12 (mig: spec ignored by gpu: regex)
 	//   per node alloc = 3 + 2 = 5
 	//   per node idle  = 12 - 5 = 7
 	//   × 2 nodes → alloc=10, idle=14
 	assert.Equal(t, 10.0, partitions[longName].gpuAllocated,
-		"multi-type GRES counts must be summed (regression test for parseGpuCount fix)")
+		"multi-type GRES counts must be summed (regression test for parseGPUCount fix)")
 	assert.Equal(t, 14.0, partitions[longName].gpuIdle)
 
 	// Short partition baseline (single-type GPU, unambiguous).
@@ -45,10 +45,11 @@ func TestParsePartitionGPUsLongValues(t *testing.T) {
 	assert.Equal(t, 16.0, partitions["short_part"].gpuIdle)
 }
 
-// TestParseGpuCountMultiType is a focused unit test for the
-// parseGpuCount fix in partitions.go. Pre-fix, FindStringSubmatch returned
-// only the first gpu: match; multi-type GRES strings were undercounted.
-func TestParseGpuCountMultiType(t *testing.T) {
+// TestParseGPUCountMultiType is a focused unit test for the shared
+// parseGPUCount helper (gpus.go). Pre-fix, FindStringSubmatch returned only the
+// first gpu: match; multi-type GRES strings were undercounted. This is the one
+// helper both the cluster-wide and per-partition GPU paths now use (issue #150).
+func TestParseGPUCountMultiType(t *testing.T) {
 	cases := []struct {
 		name string
 		gres string
@@ -64,7 +65,7 @@ func TestParseGpuCountMultiType(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseGpuCount(tc.gres, partitionGpuRe)
+			got := parseGPUCount(tc.gres)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
Closes #150.

## Summary

The same GPU-counting logic existed twice under names differing by a single
letter — `parseGPUCount` (gpus.go) and `parseGpuCount` (partitions.go) — and the
identical GRES regexp `gpu:(\(null\)|[^:(]*):?([0-9]+)(\([^)]*\))?` was written
**four times**, three of them recompiled inside `ParseAllocatedGPUs`,
`ParseIdleGPUs` and `ParseTotalGPUs` on every `Collect`. `ParseAllocatedGPUs`
additionally re-inlined the counting loop instead of calling the helper 59 lines
below it.

That duplication already cost a bug once: the multi-type GRES undercount fix
landed in one copy and the other stayed wrong until a later pass.

## Change

- One package-level `gpuGresRe`, compiled once (the convention the other
  collectors document — see nodes.go, scheduler.go).
- One `parseGPUCount` helper (capitalised initialism per `CONTRIBUTING.md`). It
  reads the package regexp directly, so the per-call `re` parameter is gone.
- `ParseAllocatedGPUs` now calls the helper instead of re-inlining it.
- The duplicate `parseGpuCount` and `partitionGpuRe` are deleted; partitions.go
  no longer imports `regexp`.

Net −30 lines.

## No value change (the constraint from the issue)

`slurm_gpus_idle`/`slurm_gpus_total` page via `SlurmNoGPUsAvailable`, so the
counts must stay **exact**, not merely close. They do, provably: the two helpers
were byte-equivalent (one used `if contains {…}`, the other `if !contains
{continue}`) and the four regexps were identical, so nothing about the
computation changed.

Verified on real GPU data, not just synthetic unit tests:
- The version-matrix GPU tests (6 Slurm releases) pass unchanged.
- `TestGPUsSnapshotSingleCall` on the anonymised **prod-captured** snapshot from
  #145 still yields 64/18/46/0.
- `TestParseGPUCountMultiType` and the long-GRES truncation test (multi-type +
  MIG) pass through the unified helper.
- `make check` green (vet, lint, test, govulncheck, actionlint, zizmor,
  **deadcode**). On the `scripts/testing` cluster (no GPUs) the `gpus` and
  `partitions` collectors report `success=1` with no errors and `slurm_gpus_*`
  present.

## Downstream

No dashboard or alert changes — values are identical. `gpus.go` feeds
`slurm_gpus_idle`/`total` (SlurmNoGPUsAvailable + `04-slurm-usage`);
`partitions.go` feeds `slurm_partition_gpus_*` (`10-slurm-all-metrics`, no rule).