### PR TITLE
fix(lint): enable the unused linter and delete the declarations it finds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,14 @@ linters:
     # --- Correctness ---
     - errcheck       # Unchecked errors (silent failures from strconv, io, etc.)
     - govet          # Reports suspicious constructs (shadow, printf misuse, etc.)
-    - staticcheck    # Comprehensive static analysis (supersedes gosimple, stylecheck, unused)
+    - staticcheck    # Comprehensive static analysis (v2 merged gosimple + stylecheck into it)
     - ineffassign    # Detects assignments whose value is never used
+    # unused is a SEPARATE linter in golangci-lint v2 — the v2 merge folded
+    # gosimple and stylecheck into staticcheck, not unused. With `default: none`
+    # it is off unless listed here, which is how an unreferenced package-level
+    # regexp and a write-only struct field survived every `make check`: the
+    # deadcode target only reports unreachable functions — see issue #151.
+    - unused         # Unused constants, variables, functions, types and struct fields
 
     # --- Security ---
     - gosec          # Security checks (G103 unsafe, G304 file inclusion, G401 weak crypto, etc.)
@@ -28,6 +34,13 @@ linters:
     - whitespace     # Unnecessary blank lines
 
   settings:
+    unused:
+      # A field that is only ever written is dead weight: it makes a reader
+      # assume a dimension the collector does not have. Keeping the default
+      # (true) hid NodesMetrics.total, allocated by newNodesMetrics() and never
+      # read — slurm_nodes_total comes from SlurmGetTotal(). See issue #151.
+      field-writes-are-uses: false
+
     gosec:
       # G304 (file path from variable) is expected in test helpers that read fixture files
       excludes:

--- a/internal/collector/nodes.go
+++ b/internal/collector/nodes.go
@@ -41,7 +41,6 @@ type NodesMetrics struct {
 	resv    map[string]float64
 	other   map[string]float64
 	planned map[string]float64
-	total   map[string]float64
 }
 
 // newNodesMetrics returns a NodesMetrics with every per-feature-set bucket
@@ -62,7 +61,6 @@ func newNodesMetrics() *NodesMetrics {
 		resv:    make(map[string]float64),
 		other:   make(map[string]float64),
 		planned: make(map[string]float64),
-		total:   make(map[string]float64),
 	}
 }
 

--- a/internal/collector/reservation_nodes.go
+++ b/internal/collector/reservation_nodes.go
@@ -11,7 +11,6 @@ import (
 
 // Pre-compiled regexes for parsing scontrol show nodes -o output.
 var (
-	resvNodeNameRe  = regexp.MustCompile(`NodeName=(\S+)`)
 	resvNodeStateRe = regexp.MustCompile(`State=(\S+)`)
 	resvNodeResvRe  = regexp.MustCompile(`ReservationName=(\S+)`)
 )


### PR DESCRIPTION
Closes #151.

## The gate, not just the dead code

The issue notes that `make deadcode` does not catch these and has to be found by reading. The reason turned out to be one level up: **`unused` was never running.**

golangci-lint v2 merged `gosimple` and `stylecheck` into `staticcheck` — **not `unused`**, which stayed a separate linter. `.golangci.yml` claimed otherwise in a comment, and with `default: none` the linter was simply off. So the class had no gate at all: `deadcode` reports unreachable *functions*, not unreferenced package-level variables or write-only struct fields.

This PR turns the gate on and deletes what it finds, so the next one is caught by CI instead of by a reader.

## What the gate reports

`field-writes-are-uses: false` is needed for the second class — a field that is only ever written is exactly the shape of dead weight this issue is about. Measured on the current tree: **two findings, zero false positives.**

```
internal/collector/reservation_nodes.go:14  var resvNodeNameRe is unused
internal/collector/nodes.go:44              field total is unused
```

- **`resvNodeNameRe`** — as described in the issue: compiled at package init, referenced nowhere.
- **`NodesMetrics.total`** — not in the issue. Allocated by `newNodesMetrics()`, never written, never read. It made the struct look like it carried a per-feature-set node total; it does not. `slurm_nodes_total` comes from `SlurmGetTotal()` and is untouched.

I also tried `exported-fields-are-used: false`. It finds nothing extra here — including nothing on a `DrainReasonMetrics.Partition` re-added on purpose to test it — so it is not shipped. No config that cannot be justified by a finding.

## `DrainReasonMetrics.Partition`

Already gone: removed in bb2b381 (#157), which predates the issue text.

## Verification

`make check` green end to end (vet, lint, test, govulncheck, actionlint, zizmor, deadcode).

Red/green on the new gate:

```
before deletion → 2 issues (unused)
after deletion  → 0 issues
```

**On the `scripts/testing` cluster** (Slurm 25.11.2, 10 nodes, 25 jobs), master on `:9342` and this branch on `:9341` scraped back to back against the same cluster:

| | master | branch |
|---|---|---|
| Slurm series (name + labels) | 345 | 345 — `diff` empty |
| `slurm_nodes_*`, `slurm_node_*`, `slurm_reservation_nodes_*`, `slurm_node_drain_*` | 158 lines | byte-for-byte equal |
| `slurm_nodes_total` | 10 | 10 |

No `ERROR` / `WARN` / panic in the exporter log; `slurm_exporter_collector_success` is `1` for every collector.

## Dashboard and alert impact

None, and checked rather than assumed:

- `slurm_node_drain_reason_info` — 0 occurrences under `monitoring/`, as the issue says.
- `slurm_nodes_total` — **8 references across 4 dashboards**, but only the dead field was removed, not the `Desc` or its emission (`nodes.go:341`). Proven unchanged live above, and `nodes_collector_test.go:46` already asserts the series is emitted.
- `slurm_nodes_down` (2 alerting rules) — bucket untouched.

## Note on the documentation error

`CLAUDE.md` is gitignored in this repository, so the `drain_reason` collector line (`sinfo`, `scontrol` → `sinfo` only) is fixed locally and cannot appear in this diff. No tracked doc under `docs/` makes that claim.