### PR TITLE
chore(make): fix container-first inconsistency and stale versions in Makefile (#114)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 # Project name
 PROJECT_NAME = slurm_exporter
 
-# Go environment configuration
+# Go environment configuration.
+# The host-build fallback (used only when no Go is installed) is derived from
+# go.mod's `go` directive so it can never drift from the module's required
+# version. A hardcoded default here silently targeted 1.22.2 while the module
+# and the containerised tooling had moved to 1.26.x (issue #114).
 GO_INSTALLED_VERSION := $(shell go version 2>/dev/null | awk '{print $$3}' | sed 's/go//g')
-GO_VERSION ?= $(if $(GO_INSTALLED_VERSION),$(GO_INSTALLED_VERSION),1.22.2)
+GO_MODULE_VERSION := $(shell awk '/^go / {print $$2; exit}' go.mod)
+GO_VERSION ?= $(if $(GO_INSTALLED_VERSION),$(GO_INSTALLED_VERSION),$(GO_MODULE_VERSION))
 OS ?= linux
 ARCH ?= amd64
 GOPATH := $(shell pwd)/go/modules
@@ -68,8 +73,9 @@ go/modules/pkg/mod: go.mod
 # ─── Containerised tooling ────────────────────────────────────────────────────
 # The check / report / lint / vet / race targets below run inside a single
 # self-contained image (scripts/docker/tools/) that bundles Go, golangci-lint,
-# gocyclo, misspell, and ineffassign. The only host requirement is Docker —
-# no Go toolchain needed.
+# gocyclo, misspell, and ineffassign. These targets need only Docker on the
+# host — no Go toolchain. (The build / setup / run targets above are the
+# exception: they compile with the host Go directly.)
 
 TOOLS_IMG     := slurm_exporter-tools:latest
 TOOLS_CTX     := scripts/docker/tools
@@ -183,7 +189,7 @@ run: $(GOBIN)
 
 # ─── Docker images (local debug) ─────────────────────────────────────────────
 # Two variants:
-#   - standard  (Dockerfile)         bundles slurm-client 23.11 from Ubuntu
+#   - standard  (Dockerfile)         bundles slurm-client 25.11 from Ubuntu
 #   - minimal   (Dockerfile.minimal) ships only the exporter, mount your own
 # Release images are built and published by GoReleaser on tag push; these
 # targets only exist for local iteration.


### PR DESCRIPTION
Closes #114 — the comment/version half of the issue. The larger "containerise `build`" change is deliberately deferred (see below).

## What changed

All three are Makefile-only and no-op at runtime for hosts that already have Go. No collector code, metric, panel or alerting rule is involved (`Dashboard and alert impact: None`, per the issue).

| # | Finding | Fix |
|---|---------|-----|
| 2 | `GO_VERSION` fallback hardcoded `1.22.2` while go.mod is `1.26.0` and the tools image is `1.26.5` | Derive the no-Go fallback from go.mod's `go` directive (`GO_MODULE_VERSION := $(shell awk '/^go / {print $2; exit}' go.mod)`) so it can never drift again |
| 1 | "The only host requirement is Docker — no Go toolchain needed" read as a global claim, but `build`/`setup`/`run` use the host Go | Reworded to scope the claim to the containerised tooling targets and name the exception |
| 3 | Makefile comment `slurm-client 23.11` vs the Dockerfile's `ubuntu:26.04` (Slurm 25.11.x) | `23.11` → `25.11` |

## Why the fallback is derived, not just bumped

Resetting `1.22.2` to a fresh literal (`1.26.5`) would go stale again on the next Go bump — the exact drift the issue calls out. Deriving from go.mod's `go` directive makes it self-maintaining, and go.mod is the module's *required minimum*, which is the correct semantic source for "what to install when the host has no Go". Hosts that already have Go are unaffected — the installed version still wins the `$(if ...)`.

## Deferred on purpose

Finding 1's other option (containerise `build`, drop `setup`) changes `make build` for every user and is higher-risk. It belongs in its own PR, as the issue itself suggests ("Happy to open a small PR for the comment/version fixes independently of the larger containerise-`build` change if that split is preferred"). This PR is that small one.

## Verification

- `GO_VERSION` resolves to the host Go when present (`1.26.4` on this host) and to go.mod's `1.26.0` when `GO_INSTALLED_VERSION` is forced empty (the no-Go path).
- `make check` green: vet, lint (0 issues), test, vuln, actionlint, zizmor, deadcode.