### PR TITLE
docs(contributing): validate each release on two major Slurm releases (#189)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,9 +252,16 @@ The quick summary:
 8. Open the release PR with the v1.8.2 template structure.
 9. After merge: close integrated community PRs with a thank-you and respond
    to acknowledged-but-deferred issues.
-10. **Test the binary on a real cluster before the final tag.** Approach A
-    (RC tag `vX.Y.Z-rc1` → GitHub pre-release → staging overnight) for
-    breaking/minor releases; approach B (local `make build` → scp to
-    staging) for trivial patches. Decision matrix in the playbook.
+10. **Test the binary on a real cluster before the final tag, against two
+    major Slurm releases.** The exporter parses `squeue` / `sinfo` /
+    `scontrol` / `sacct` output, which drifts between Slurm majors — one green
+    version proves nothing about the others. Validate against the **newest**
+    and the **oldest still-supported** major (SchedMD supports each major for
+    ~18 months). **Re-derive the pair from SchedMD's release list every time**
+    — the window rolls, so never hardcode the numbers here. Approach A (RC tag
+    `vX.Y.Z-rc1` → GitHub pre-release → staging overnight) for breaking/minor
+    releases; approach B (local `make build` → scp to staging) for trivial
+    patches. Decision matrix in the playbook. Harness support for a second
+    major (the upstream test image only publishes one) is tracked in #189.
 11. Tag the final `vX.Y.Z`; CI (`.github/workflows/release.yml`) runs
     `lint → test → goreleaser release` and publishes automatically.


### PR DESCRIPTION
Part of #189 — the documentation half (the harness work to actually bring up a second major is tracked there).

## What

Adds a release gate to `CONTRIBUTING.md` §Releasing (step 10): before the final tag, validate the candidate on **two** major Slurm releases — the **newest** and the **oldest still-supported** — not just the one the test cluster pins.

## Why

The exporter parses `squeue` / `sinfo` / `scontrol` / `sacct` CLI output, and that output drifts between Slurm majors. That is precisely why `test_data/` carries version-specific fixture subdirectories. One green Slurm version proves nothing about the version half of our users run.

## Note on wording

The rule names *no concrete versions*. SchedMD's ~18-month support window rolls (26.05 shipped May 2026; 26.11 is due ~Nov 2026), so the pair is re-derived each release. Hardcoding `24.x`/`25.x` here would be the same version-drift trap #114 just removed from the Makefile.

Doc-only change: no exporter code, no metric, no panel, no alerting rule.