### PR TITLE
docs(contributing): align release Slurm-version window with Slurm's own policy (#189)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,10 +255,13 @@ The quick summary:
 10. **Test the binary on a real cluster before the final tag, against two
     major Slurm releases.** The exporter parses `squeue` / `sinfo` /
     `scontrol` / `sacct` output, which drifts between Slurm majors — one green
-    version proves nothing about the others. Validate against the **newest**
-    and the **oldest still-supported** major (SchedMD supports each major for
-    ~18 months). **Re-derive the pair from SchedMD's release list every time**
-    — the window rolls, so never hardcode the numbers here. Approach A (RC tag
+    version proves nothing about the others. A validated release supports the
+    same window Slurm itself does: SchedMD ships a major every 6 months and
+    supports in-place upgrades from the previous three majors, so the window is
+    the newest major plus the previous three (~2 years). Validate the **two
+    ends** of that window and **re-derive them each release** — the window
+    rolls, so never hardcode the numbers here (e.g. against Slurm 26.05 the ends
+    are 24.11 and 26.05). Approach A (RC tag
     `vX.Y.Z-rc1` → GitHub pre-release → staging overnight) for breaking/minor
     releases; approach B (local `make build` → scp to staging) for trivial
     patches. Decision matrix in the playbook. Harness support for a second


### PR DESCRIPTION
Follow-up to the release gate added in `209d52a` (#189). Wording-only correction — the gate itself is unchanged.

## Why

That gate described the validation pair as "newest + oldest **still-supported** major (SchedMD ~18 months)". That number came from a web search. The authoritative policy — SchedMD's upgrade guide, confirmed via context7 — is:

- **6-month** major release cycle;
- in-place upgrades supported from the **previous three majors**.

So a validated slurm_exporter release supports the **newest major plus the previous three (~2 years)**, mirroring Slurm's own window. Concretely, against Slurm 26.05 that span is **24.11 → 26.05**.

## Change

Step 10 now frames the window as Slurm's own (6-month cycle, previous three majors), says to validate the **two ends** and **re-derive them each release** (never hardcode), with `24.11`/`26.05` as a time-stamped example rather than a fixed value.

Doc-only: no exporter code, no metric, no panel, no alerting rule. The harness work to actually stand up a second major is still tracked in #189.