### PR TITLE
test: make per-version fixture discovery honest (#177)

### DIFF
--- a/internal/collector/gpus_test.go
+++ b/internal/collector/gpus_test.go
@@ -26,16 +26,23 @@ type gpuExpect struct {
 	idle  float64
 	other float64
 	util  float64
+	// idleUncovered marks a version whose sinfo_gpus_idle.txt is absent or cannot
+	// be trusted, so the idle and other assertions are skipped for it. See #177:
+	// slurm-23.11.10's idle fixture was a malformed 2-column capture, the version
+	// can no longer be recaptured, and the real 3-column format is covered by
+	// slurm-23.11.10-2.
+	idleUncovered bool
 }
 
 var gpuFixtureExpect = map[string]gpuExpect{
 	"20.11.8": {total: 48, alloc: 7, idle: 41, other: 0, util: 7.0 / 48.0},
 	"21.08.5": {total: 16, alloc: 0, idle: 16, other: 0, util: 0},
-	// 23.11.10's sinfo_gpus_idle.txt has 2 columns, not the 3 IdleGPUsData emits,
-	// so ParseIdleGPUs takes its 2-column branch and idle here is an artefact
-	// (nodes×column) rather than total-alloc. This pins current behaviour only;
-	// recapturing the fixture is tracked in #177.
-	"23.11.10":   {total: 232, alloc: 33, idle: 33, other: 166, util: 33.0 / 232.0},
+	// 23.11.10's idle fixture was a malformed 2-column capture (not the 3 columns
+	// IdleGPUsData emits), so its old idle/other values were artefacts. The version
+	// can no longer be recaptured (23.11.10 is no longer published upstream) and its
+	// real 3-column idle format is already covered by 23.11.10-2, so the idle case is
+	// dropped here (#177). total/alloc/util stay real.
+	"23.11.10":   {total: 232, alloc: 33, util: 33.0 / 232.0, idleUncovered: true},
 	"23.11.10-2": {total: 10, alloc: 6, idle: 4, other: 0, util: 0.6},
 	"25.05":      {total: 4232, alloc: 4226, idle: 6, other: 0, util: 4226.0 / 4232.0},
 	"25.11.1-1":  {total: 154, alloc: 78, idle: 24, other: 52, util: 78.0 / 154.0},
@@ -82,15 +89,17 @@ func TestGPUsMetrics(t *testing.T) {
 			alloc := ParseAllocatedGPUs(readFixture(t, path, "sinfo_gpus_allocated.txt"))
 			assert.Equal(t, want.alloc, alloc, "allocated GPUs")
 
-			idle := ParseIdleGPUs(readFixture(t, path, "sinfo_gpus_idle.txt"))
-			assert.Equal(t, want.idle, idle, "idle GPUs")
+			if !want.idleUncovered {
+				idle := ParseIdleGPUs(readFixture(t, path, "sinfo_gpus_idle.txt"))
+				assert.Equal(t, want.idle, idle, "idle GPUs")
 
-			// Mirror computeGPUsFromSnapshot's clampless derivation and pin the
-			// invariant issue #145 relies on: on real data, total-alloc-idle is
-			// never negative, so no clamp is needed.
-			other := total - alloc - idle
-			assert.Equal(t, want.other, other, "other GPUs")
-			assert.GreaterOrEqual(t, other, 0.0, "other GPUs must never be negative")
+				// Mirror computeGPUsFromSnapshot's clampless derivation and pin
+				// the invariant issue #145 relies on: on real data,
+				// total-alloc-idle is never negative, so no clamp is needed.
+				other := total - alloc - idle
+				assert.Equal(t, want.other, other, "other GPUs")
+				assert.GreaterOrEqual(t, other, 0.0, "other GPUs must never be negative")
+			}
 
 			var util float64
 			if total > 0 {

--- a/internal/collector/partitions_test.go
+++ b/internal/collector/partitions_test.go
@@ -40,12 +40,17 @@ func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 	oldExecute := Execute
 	defer func() { Execute = oldExecute }()
 
-	testDataDirs, _ := filepath.Glob("../../test_data/slurm-*")
+	testDataDirs, err := filepath.Glob("../../test_data/slurm-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, testDataDirs, "no per-version fixtures under ../../test_data/slurm-*")
+
+	ran := false
 	for _, dir := range testDataDirs {
 		slurmVersion := filepath.Base(dir)
 		if slurmVersion != "slurm-25.11.1-1" {
 			continue
 		}
+		ran = true
 		t.Run(slurmVersion, func(t *testing.T) {
 			Execute = func(logger *logger.Logger, command string, args []string) ([]byte, error) {
 				path := pickPartitionFixturePath(dir, command, args)
@@ -78,6 +83,7 @@ func TestParsePartitionsMetricsWithRealOutput(t *testing.T) {
 			assert.Greater(t, metrics["a100"].gpuAllocated, 0.0, "a100 should have allocated GPUs")
 		})
 	}
+	require.True(t, ran, "fixture slurm-25.11.1-1 not found; partition fixtures moved or renamed (#177)")
 }
 
 // TestParsePartitionCPUsStripsAsterisk verifies that the default partition marker (*)

--- a/test_data/slurm-23.11.10/sinfo_gpus_idle.txt
+++ b/test_data/slurm-23.11.10/sinfo_gpus_idle.txt
@@ -1,7 +1,0 @@
-1 gpu:h100:3(IDX:1-3)
-6 gpu:h100:4(IDX:0-3)
-1 gpu:h100:3(IDX:0-2)
-42 gpu:0
-2 gpu:h100:1(IDX:0)
-43 gpu:h100:0(IDX:N/A)
-1 gpu:h100:1(IDX:3)


### PR DESCRIPTION
Closes #177. Two independent test-hygiene fixes, one commit each. Test-only — no exporter code, metric, panel or alerting rule changes; validated by `make check`, no cluster run.

## A — `partitions_test.go` can pass without asserting anything (`ca2ad3d`)

`TestParsePartitionsMetricsWithRealOutput` globbed `test_data/slurm-*`, discarded the glob error, and put its assertions inside a `t.Run` guarded by `if version != "slurm-25.11.1-1" { continue }`. If the fixtures are renamed or moved, every iteration hits `continue`, the subtest never runs, and the test goes green having verified nothing — the #148 silent-skip shape, not yet triggered.

Fix: keep the glob but `require.NotEmpty` and assert the pinned version actually ran (`ran` flag + `require.True`), mirroring the guard `gpuFixtureVersions` already uses.

**Verified:** pointing the version string at a non-existent directory now fails with `fixture slurm-25.11.1-1 not found` instead of passing green.

## B — the 23.11.10 idle fixture was a masked artefact (`b645c3c`)

`test_data/slurm-23.11.10/sinfo_gpus_idle.txt` had **2 columns**, not the 3 `IdleGPUsData` emits (`Nodes,Gres,GresUsed`), so `ParseIdleGPUs` took its 2-column branch and computed `idle = nodes×column` (33) instead of `total-alloc`. `gpuFixtureExpect` then pinned `idle:33`/`other:166` as artefacts of a wrong fixture — masked until #148 made `TestGPUsMetrics` run.

23.11.10 can't be recaptured (no longer published upstream) and its real 3-column idle format is already covered by `slurm-23.11.10-2`, so the idle case is **dropped, not fabricated**: remove the malformed file, add an `idleUncovered` flag that skips the idle/other assertions for this version, keep its real `total`/`alloc`/`util`.

Not a production bug — a live 23.11.10 returns 3 columns and the parser is correct. This only makes the version matrix honest.

## Dashboard and alert impact

None. Test hygiene only.