### PR TITLE
fix(testing): pin MariaDB by digest so a floating tag can't abort slurmdbd (#187)

### DIFF
--- a/scripts/testing/_lib.sh
+++ b/scripts/testing/_lib.sh
@@ -91,6 +91,7 @@ MYSQL_USER=slurm
 MYSQL_PASSWORD=password
 MYSQL_DATABASE=slurm_acct_db
 SSH_ENABLE=false
+MARIADB_IMAGE=${MARIADB_IMAGE}
 ENVEOF
     ok ".env written"
 }
@@ -99,7 +100,29 @@ ENVEOF
 cmd_start_cluster() {
     step "3/9" "Starting cluster..."
     cd "$CLUSTER_DIR"
-    docker compose up -d --scale "cpu-worker=${NODES}"
+
+    # Pin MariaDB via an override we own. docker compose up auto-merges
+    # docker-compose.override.yml from the project dir, so this overrides the
+    # clone's floating mariadb:12 without editing its tracked files (#187).
+    if [ -f "$SCRIPT_DIR/docker-compose.override.yml" ]; then
+        cp "$SCRIPT_DIR/docker-compose.override.yml" "$CLUSTER_DIR/docker-compose.override.yml"
+    fi
+
+    if ! docker compose up -d --scale "cpu-worker=${NODES}"; then
+        # A stale var_lib_mysql volume (initialised by an older MariaDB than the
+        # pinned image) makes slurmdbd abort with a bare SIGABRT. Surface the one
+        # thing the operator needs instead of "exited (134)" (#187).
+        if docker logs slurmdbd 2>&1 | grep -q "Column count of mysql.proc is wrong"; then
+            die "slurmdbd aborted: the MySQL data volume was initialised by an older MariaDB
+    than the image now in use, and its system tables cannot be upgraded in place
+    (the root password is random per volume). Rebuild from a clean volume:
+
+        make -C scripts/testing clean && make -C scripts/testing setup
+
+    (this destroys all test-cluster volumes, including Prometheus and Grafana)"
+        fi
+        die "docker compose up failed — see the output above"
+    fi
     ok "Containers started"
 }
 

--- a/scripts/testing/cluster.conf
+++ b/scripts/testing/cluster.conf
@@ -14,6 +14,15 @@ CLUSTER_DIR=
 # Slurm version (must match an available Docker Hub tag: 25.11.2, 25.05.6, ...)
 SLURM_VERSION=25.11.2
 
+# Digest-pinned MariaDB. The clone's docker-compose.yml pins the floating tag
+# mariadb:12, and var_lib_mysql persists across runs — so the day Docker Hub
+# moves 12.x, the volume's system tables are the previous minor's, mysql.proc
+# has the wrong column count, and slurmdbd aborts with SIGABRT (#187). Pinning
+# a digest turns a bump into a deliberate act (one make clean) instead of a
+# silent break. This is 12.3.2; bump it with: docker inspect mariadb:12
+# --format '{{index .RepoDigests 0}}' after a working pull, then make clean.
+MARIADB_IMAGE=mariadb@sha256:628f228f0fd5913a220438693576b29b6fe4dc1fa0a1298c0e98579fae28635f
+
 # Number of CPU compute nodes
 NODES=10
 

--- a/scripts/testing/docker-compose.override.yml
+++ b/scripts/testing/docker-compose.override.yml
@@ -1,0 +1,16 @@
+# Pins the MariaDB image for the giovtorres/slurm-docker-cluster clone.
+#
+# The clone's tracked docker-compose.yml uses the floating tag `mariadb:12`,
+# and its var_lib_mysql volume persists across runs. When Docker Hub moves the
+# tag to a newer 12.x, the volume's system tables belong to the previous minor,
+# mysql.proc gets the wrong column count, and slurmdbd aborts (SIGABRT). See
+# issue #187.
+#
+# `docker compose up` auto-merges docker-compose.override.yml from the project
+# directory, so we own the pin without editing the third-party clone (the same
+# copy-into-$CLUSTER_DIR mechanism already used for docker-compose.monitoring.yml).
+# MARIADB_IMAGE is supplied via the generated .env (cmd_write_env in _lib.sh),
+# sourced from scripts/testing/cluster.conf.
+services:
+  mysql:
+    image: ${MARIADB_IMAGE}


### PR DESCRIPTION
## Problem

`make -C scripts/testing setup` breaks whenever Docker Hub publishes a new
MariaDB 12.x (it broke on 2026-07-24). The clone's `docker-compose.yml` pins the
floating tag `mariadb:12` on a **persistent** `var_lib_mysql` volume. When the
tag moves, the volume's system tables belong to the previous minor, `mysql.proc`
gets the wrong column count, and `slurmdbd` aborts with a bare SIGABRT
(`exited (134)`). This blocks the Definition of Done, whose integration steps
need a running cluster.

The volume can't be repaired in place: the compose file uses
`MYSQL_RANDOM_ROOT_PASSWORD`, so the root password is unrecoverable and
`mariadb-upgrade` can't run. The only recovery is `make clean && make setup`.

## Fix

1. **Pin the image via an override we own.** `docker compose up` auto-merges
   `docker-compose.override.yml` from the project directory. We ship one from
   `scripts/testing/`, copied into `$CLUSTER_DIR` next to the monitoring compose
   file (the exact mechanism already used for `docker-compose.monitoring.yml`),
   pinning `mysql` to a digest-pinned `MARIADB_IMAGE` set in `cluster.conf` and
   passed through the generated `.env`. Bumping the pin becomes a deliberate act
   (one `make clean`) instead of a silent break.

2. **Fail with a usable message.** On `docker compose up` failure, detect the
   `Column count of mysql.proc is wrong` signature in `slurmdbd`'s log and `die`
   with the rebuild instruction instead of leaving the operator with SIGABRT.

## Validation (live cluster)

- `docker compose config` merge: `mysql.image` resolves `mariadb:12` →
  `mariadb@sha256:628f…` with the override.
- `make -C scripts/testing setup` re-converged cleanly: **mysql recreated on the
  pinned digest**, `slurmdbd` healthy, 10/10 nodes registered, 10 dashboards
  imported, exporter log free of ERROR/WARN.
- Override file and `MARIADB_IMAGE` confirmed landed in `$CLUSTER_DIR`.

## Impact

Test-harness only — no exporter code, no metric, no dashboard/alert change.

Closes #187.