### PR TITLE
feat(testing): build unpublished Slurm majors from source to validate releases against two majors (#189)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -224,6 +224,15 @@ make -C scripts/testing setup     # Step 2 — bring up cluster + deploy binary
 # Step 10 — visual Grafana dashboard pass
 ```
 
+**Run this against two Slurm majors, not one.** Slurm CLI output drifts between
+majors, so a green run on the version the harness happens to pin proves nothing
+about the version half our users run. Execute Steps 2–9 once on the **newest**
+supported major and once on the **oldest still-supported** one — set
+`SLURM_VERSION` via `scripts/testing/cluster.local.conf`; majors with no
+published image are built from source automatically. See
+[validation-checklist § Which Slurm major](validation-checklist.md#step-2--bring-up-the-docker-test-cluster)
+and [CONTRIBUTING § Releasing](../CONTRIBUTING.md#releasing) (#189).
+
 ### Spot-check the release theme
 
 For v1.8.2 we explicitly verified:

--- a/docs/validation-checklist.md
+++ b/docs/validation-checklist.md
@@ -95,6 +95,38 @@ Specifically:
 - Dashboard import fails: check `docker logs grafana`; usually a Grafana
   startup delay, retry `make -C scripts/testing redeploy-dashboards`.
 
+### Which Slurm major — and why you run this twice
+
+`make setup` brings the cluster up on the Slurm version in
+`scripts/testing/cluster.conf` (`SLURM_VERSION`). Override it without touching
+the tracked config by creating `scripts/testing/cluster.local.conf` (gitignored):
+
+```bash
+echo 'SLURM_VERSION=26.05.2' > scripts/testing/cluster.local.conf
+```
+
+The harness resolves the image in three ways, cheapest first: reuse a local
+image, pull the published upstream tag (only recent **25.11.x** are published),
+or **build from source** for any other supported major (`26.05.*`, `25.05.*`,
+`24.11.*`) — it fetches the SchedMD source tarball and compiles Slurm, which
+takes tens of minutes on a cold cache.
+
+**Release gate (#189):** the exporter parses `squeue` / `sinfo` / `scontrol` /
+`sacct` output, and that output drifts between Slurm majors — one green version
+proves nothing about the other. For a release, run Steps 2–9 **twice**: once on
+the **newest** supported major and once on the **oldest still-supported** one
+(the two ends of SchedMD's ~2-year window — re-derive both at release time, see
+[CONTRIBUTING § Releasing](../CONTRIBUTING.md#releasing)). Switch major from a
+clean slate — the MariaDB and Slurm state volumes are version-sensitive (#187):
+
+```bash
+make -C scripts/testing clean
+echo 'SLURM_VERSION=<other-major>' > scripts/testing/cluster.local.conf
+make -C scripts/testing setup
+```
+
+Delete `cluster.local.conf` when done to fall back to the default version.
+
 ---
 
 ## Step 3 — Restart the exporter with all collectors + debug logs
@@ -482,6 +514,11 @@ Tick each as you go:
 - [ ] Step 10 — All Grafana dashboards render with data
 - [ ] Step 11 — Cluster teardown
 
-Once every box is ticked, the release is ready for the **real-platform
-validation** step described in
+For a **release** (not a per-PR check), tick this list **twice** — once on the
+newest and once on the oldest supported Slurm major (see
+[Step 2 § Which Slurm major](#step-2--bring-up-the-docker-test-cluster)). A green
+run on a single major does not validate the release (#189).
+
+Once every box is ticked (on both majors), the release is ready for the
+**real-platform validation** step described in
 [release-process.md § Test on a real platform before the final tag](release-process.md#test-on-a-real-platform-before-the-final-tag).

--- a/scripts/testing/_lib.sh
+++ b/scripts/testing/_lib.sh
@@ -73,11 +73,48 @@ cmd_check_deps() {
 }
 
 # ── pull-image ────────────────────────────────────────────────────────────────
+# ── prepare-image ─────────────────────────────────────────────────────────────
+# Ensure the local image slurm-docker-cluster:${SLURM_VERSION} exists — the tag
+# the clone's compose file references for every Slurm service. Three paths,
+# cheapest first:
+#   1. already present locally (a prior run)         → reuse, nothing to do
+#   2. a published upstream tag (recent 25.11.x)     → pull + retag (fast)
+#   3. no published tag (26.05.*, 25.05.*, 24.11.*)  → build from source
+#
+# Upstream (giovtorres) only publishes recent 25.11 bare tags, so validating a
+# release against the newest and oldest supported Slurm majors (#189) needs the
+# build fallback. The clone's Dockerfile fetches slurm-${SLURM_VERSION}.tar.bz2
+# from SchedMD and rpmbuilds it (build owner: the slurmdbd service); this
+# compiles Slurm and is slow (tens of minutes on a cold cache).
 cmd_pull_image() {
-    step "1/9" "Pulling Docker image giovtorres/slurm-docker-cluster:${SLURM_VERSION}..."
-    docker pull "giovtorres/slurm-docker-cluster:${SLURM_VERSION}" 2>&1 | grep -E 'Pull|Status|already' || true
-    docker tag "giovtorres/slurm-docker-cluster:${SLURM_VERSION}" "slurm-docker-cluster:${SLURM_VERSION}" 2>/dev/null || true
-    ok "Image ready"
+    local local_tag="slurm-docker-cluster:${SLURM_VERSION}"
+    step "1/9" "Preparing image ${local_tag}..."
+
+    if docker image inspect "$local_tag" >/dev/null 2>&1; then
+        ok "Image already present (reusing)"
+        return 0
+    fi
+
+    if docker pull "giovtorres/slurm-docker-cluster:${SLURM_VERSION}" >/dev/null 2>&1; then
+        docker tag "giovtorres/slurm-docker-cluster:${SLURM_VERSION}" "$local_tag"
+        ok "Image pulled and tagged"
+        return 0
+    fi
+
+    warn "No published tag for ${SLURM_VERSION} — building from source (compiles Slurm, slow)"
+    cd "$CLUSTER_DIR"
+    # Pass the version explicitly: .env is written by the next step, and compose
+    # reads SLURM_VERSION from the shell env with precedence. MARIADB_IMAGE is
+    # supplied too so a stale docker-compose.override.yml (#187) doesn't warn on
+    # an unset variable while parsing the (unbuilt) mysql service.
+    if ! SLURM_VERSION="$SLURM_VERSION" MARIADB_IMAGE="$MARIADB_IMAGE" \
+            docker compose build slurmdbd; then
+        die "Build from source failed for Slurm ${SLURM_VERSION}.
+    Verify the source tarball exists (SchedMD publishes only supported majors):
+        https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2
+    Re-derive the version from SchedMD at release time — the support window rolls (#189)."
+    fi
+    ok "Image built from source"
 }
 
 # ── write-env ─────────────────────────────────────────────────────────────────

--- a/scripts/testing/cluster.conf
+++ b/scripts/testing/cluster.conf
@@ -11,7 +11,13 @@
 # Leave empty for auto-detection.
 CLUSTER_DIR=
 
-# Slurm version (must match an available Docker Hub tag: 25.11.2, 25.05.6, ...)
+# Slurm version to run the cluster on.
+#   - Recent 25.11.x majors are pulled from Docker Hub (giovtorres/slurm-docker-cluster:<ver>).
+#   - Any other supported major (e.g. 26.05.2, 25.05.8, 24.11.x) has NO published
+#     tag, so the harness builds it from source — it must be a version SchedMD
+#     still ships a tarball for: https://download.schedmd.com/slurm/slurm-<ver>.tar.bz2
+# Switching major between two runs needs a `make clean` first: the MariaDB and
+# Slurm state volumes are version-sensitive and are not shared across majors (#187, #189).
 SLURM_VERSION=25.11.2
 
 # Digest-pinned MariaDB. The clone's docker-compose.yml pins the floating tag


### PR DESCRIPTION
## What

Before a release, the candidate must be validated against **two** Slurm majors —
the newest and the oldest still-supported (#189) — because `squeue` / `sinfo` /
`scontrol` / `sacct` output drifts between majors. But the test harness only
*pulled* `giovtorres/slurm-docker-cluster:<ver>`, and upstream publishes only
recent 25.11 bare tags, so neither end of the support window (today 26.05 + 25.05)
could be brought up: a plain `SLURM_VERSION=26.05.2` just 404s on pull.

## Change

- **`scripts/testing/_lib.sh`** — `cmd_pull_image` now resolves the image in
  three ways, cheapest first: reuse a local image → pull the published tag →
  **build from source** when no tag exists. The clone's compose file already
  carries a `build:` section (the `slurmdbd` service) that fetches
  `slurm-<ver>.tar.bz2` from SchedMD and rpmbuilds it; the harness now drives it
  explicitly, instead of relying on an accidental implicit `compose up` build
  behind a misleading "Image ready".
- **`scripts/testing/cluster.conf`** — corrected the stale `25.05.6` tag hint
  (that tag is gone upstream); documents pull-vs-build and the `make clean`
  needed when switching majors (state volumes are version-sensitive, #187).
- **`docs/validation-checklist.md` / `docs/release-process.md`** — the release
  now runs DoD steps 4–9 against **both** majors, with how to pick and switch
  versions via `cluster.local.conf`.

## Validation — live, from source, both ends of the support window

Built each major from source (no published image) and ran the full setup + a
workload end-to-end:

| Major | Build | Setup | Collectors | `slurm_info` | Workload | Exporter log |
|-------|-------|-------|-----------|--------------|----------|--------------|
| **26.05.2** (newest) | ✅ from source | 9/9 · 10/10 nodes | 15/15 `success=1` | 26.05.2 on all binaries | 13 run / 5 pend / 58 cores | no ERROR/WARN |
| **25.05.8** (oldest) | ✅ from source | 9/9 · 10/10 nodes | 15/15 `success=1` | 25.05.8 on all binaries | 9 run / 5 pend / 44 cores | no ERROR/WARN |

No exporter code, metric, dashboard, or alerting-rule change — test harness +
release docs only, so there is no operator-visible impact.

Closes #189.
