### PR TITLE
feat(collector): make the code the single source of truth for Slurm commands (#195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,10 @@ jobs:
           cache: false
       - name: Build
         run: go build -v ./...
+      # test_data/readme.md is generated from the command registry in
+      # internal/collector. Regenerating it here would hide the drift; failing
+      # is the point (issue #195).
+      - name: Derived docs are current
+        run: go run ./tools/gen-fixture-doc -check
       - name: Test (race + coverage)
         run: go test -race -count=1 -coverprofile=coverage.out ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,20 @@ Integration tests (steps 4-9) are required for any change to:
 Every new collector must have:
 
 1. A `*Data(logger)` function calling `Execute()`
-2. A `Parse*()` function with pure logic (no I/O — testable without cluster)
-3. A `*Collector` struct implementing `prometheus.Collector`
-4. A `New*Collector()` constructor
-5. A `test_data/<command_output>.txt` fixture with anonymized real output
-6. A `*_test.go` file covering:
+2. An entry in `CommandRegistry` (`internal/collector/command_registry.go`) for
+   every Slurm command it runs — the single source of truth the docs and the
+   capture tooling are generated from. `command_registry_test.go` runs your
+   `*Data()` function behind a stubbed `Execute` and fails if the entry does not
+   match what it really passes, so this is checked, not trusted.
+3. A `Parse*()` function with pure logic (no I/O — testable without cluster)
+4. A `*Collector` struct implementing `prometheus.Collector`
+5. A `New*Collector()` constructor
+6. A `test_data/<command_output>.txt` fixture with anonymized real output,
+   declared in the registry entry's `Fixtures` with a `Why` saying what it
+   protects. No fixture at all is allowed, but then `NoFixtureReason` has to say
+   whether that is deliberate or work still to do — a gap left implicit reads as
+   coverage.
+7. A `*_test.go` file covering:
    - The parser with at least: happy path, empty input, malformed lines, edge cases
    - The collector via `Execute` mock using the test_data fixture
    - `Describe()` descriptor count
@@ -179,7 +188,10 @@ All fixtures in `test_data/` must be anonymized:
 - Real account names → `account_a`, `hpc_team`, `ml_group`
 - Real node names → `c1`, `c2`, `a001`, `b001`
 
-See `test_data/readme.md` for the mapping of commands to fixture files.
+`test_data/readme.md` maps commands to fixture files. It is **generated** from
+`internal/collector/command_registry.go` — edit the registry and run
+`make generate`, never the readme itself. `make check` and CI fail on a stale
+one, which is what stops the two from drifting apart again (issue #195).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,24 @@ race: tools-image
 	@echo "Running tests with race detector (containerised)"
 	@$(IN_TOOLS) -c 'CGO_ENABLED=1 go test -race -count=1 ./...'
 
+# Regenerate the documentation derived from the command registry, currently
+# test_data/readme.md (in container). The registry in internal/collector is the
+# single source of truth for every Slurm CLI call the exporter makes; run this
+# after changing one.
+.PHONY: generate
+generate: tools-image
+	@echo "Regenerating derived docs (containerised)"
+	@$(IN_TOOLS) -c 'go generate ./...'
+
+# Fail when a generated file on disk no longer matches the registry (in
+# container). Part of `check`, so a command change that skipped `make generate`
+# cannot reach master — which is how test_data/readme.md drifted in the first
+# place (issue #195).
+.PHONY: generate-check
+generate-check: tools-image
+	@echo "Checking derived docs are current (containerised)"
+	@$(IN_TOOLS) -c 'go run ./tools/gen-fixture-doc -check'
+
 # go vet (in container).
 .PHONY: vet
 vet: tools-image
@@ -164,7 +182,7 @@ deadcode: tools-image
 
 # Full pre-commit / pre-release verification — mirrors what CI runs.
 .PHONY: check
-check: vet lint test vuln actionlint zizmor deadcode
+check: vet lint test vuln actionlint zizmor deadcode generate-check
 
 # Offline equivalent of the goreportcard.com checks (in container).
 # Runs gofmt -s, go vet, gocyclo, ineffassign, misspell, and a LICENSE check,

--- a/internal/collector/command_registry.go
+++ b/internal/collector/command_registry.go
@@ -1,0 +1,602 @@
+package collector
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// ── The command contract ─────────────────────────────────────────────────────
+//
+// CommandRegistry is the single source of truth for every Slurm CLI invocation
+// the exporter makes.
+//
+// This list used to exist in three places — the *Data() functions, the prose in
+// test_data/readme.md, and the memory of whoever last captured a fixture — with
+// nothing checking them against each other. They drifted: the readme documented
+// a fixed-width sinfo format that the code had already abandoned, pointed at a
+// fixture deleted two releases earlier, and omitted the mandatory --endtime on
+// sacct. A contributor followed the documentation and had to redo the work
+// (issue #195).
+//
+// Everything is now derived from this table:
+//
+//   - command_registry_test.go asserts every entry against what the real
+//     *Data() function actually passes to Execute, so changing a command
+//     without updating the table fails CI;
+//   - tools/gen-fixture-doc regenerates test_data/readme.md from it;
+//   - tools/fixture-capture generates the cluster capture script from it.
+//
+// Adding a Slurm call means adding an entry here. Nothing else is maintained
+// by hand.
+
+// Fixture is one captured file under test_data/ and the reason it exists.
+//
+// Why carries most of the value here. Six of the fixtures on disk are the
+// regression nets for the subtlest bugs this exporter has had (long-name
+// truncation, the default-partition marker, long GRES strings, relative
+// reservation timestamps, the empty reservation list), and until issue #195
+// none could be traced back to its bug by reading the documentation.
+type Fixture struct {
+	// File is the path relative to test_data/.
+	File string
+	// Why states what this capture protects: the bug it caught, or the format
+	// quirk it pins. One sentence, written for whoever has to decide years from
+	// now whether the file can still be deleted.
+	Why string
+	// Slurm is the version the capture was taken on. Empty means the
+	// provenance was never recorded; new fixtures must set it.
+	Slurm string
+}
+
+// Placeholder marks an argument the exporter computes at call time, so the
+// contract test can match it and the capture script can reproduce it.
+type Placeholder struct {
+	// Token is the literal that stands in for the value in Command.Args.
+	Token string
+	// Match is what a real value looks like. The contract test accepts any
+	// argument matching it in the token's position.
+	Match *regexp.Regexp
+	// Shell is a POSIX sh expression producing an equivalent value, used by the
+	// generated capture script. GNU date is assumed: every supported Slurm
+	// controller platform ships it.
+	Shell string
+}
+
+// Command is one Slurm CLI invocation made by the exporter.
+type Command struct {
+	// Name is a stable identifier, used as the anchor in generated docs and as
+	// the fixture-capture step name. Renaming one is a documentation change.
+	Name string
+	// Binary is the Slurm executable. Empty when EachBinary is set.
+	Binary string
+	// EachBinary makes the command run once per listed binary, with Binary
+	// bound to each in turn. Only slurm_binary_info.go needs it.
+	EachBinary []string
+	// Args are the exact arguments passed to Execute, with Placeholder tokens
+	// standing in for values computed at call time. nil means no arguments.
+	Args []string
+	// Placeholders declares every token appearing in Args.
+	Placeholders []Placeholder
+	// Source is the collector file that owns the call.
+	Source string
+	// Consumers are the other collector files that read the same output,
+	// usually through a shared cache.
+	Consumers []string
+	// Doc is the prose for the generated readme: what the command returns and
+	// why it is shaped this way.
+	Doc string
+	// Notes are the caveats worth carrying next to the command in the docs.
+	Notes []string
+	// OptIn names the flag that must be set for the command to run at all.
+	// Empty means the command runs on every scrape by default.
+	OptIn string
+	// Fixtures are the captures under test_data/ that back this command.
+	Fixtures []Fixture
+	// NoFixtureReason is required when Fixtures is empty, and forbidden
+	// otherwise. A command running against no captured output is a coverage
+	// gap, and a gap left implicit reads as coverage, so the generated readme
+	// names every one of them and says whether it is a deliberate choice or
+	// work still to do. Same principle #177 applied to the GPU matrix: an
+	// absent fixture has to be asserted rather than assumed.
+	NoFixtureReason string
+	// invoke calls the real production path so the contract test observes what
+	// the collector genuinely passes to Execute, rather than a copy of it.
+	// Unexported: only the in-package test needs it, and it keeps the table
+	// consumable by tools/ without exporting a way to shell out.
+	invoke func(log *logger.Logger, binary string)
+}
+
+// slurmTimestamp is the layout Slurm accepts for --starttime / --endtime, and
+// the one sacct_efficiency.go formats with.
+var slurmTimestamp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$`)
+
+// versionedBinaries are the binaries slurm_binary_info.go probes for a version:
+// the required set, always reported, plus the job-submission tools, reported
+// only when present. sshare is deliberately absent: the fairshare collector
+// executes it, but nothing ever probes its version.
+var versionedBinaries = []string{
+	"sinfo", "squeue", "sdiag", "scontrol", "sacct",
+	"sbatch", "salloc", "srun",
+}
+
+// CommandRegistry lists every Slurm CLI invocation the exporter makes.
+//
+//go:generate go run ../../tools/gen-fixture-doc -out ../../test_data/readme.md
+var CommandRegistry = []Command{
+	{
+		Name:   "squeue_jobs",
+		Binary: "squeue",
+		Args:   []string{"-a", "-r", "-h", "-O", squeueJobsColumns},
+		Source: "squeue_jobs.go",
+		Consumers: []string{
+			"accounts.go", "users.go", "partitions.go",
+		},
+		Doc: "One consolidated snapshot of the whole job queue, cached per scrape and " +
+			"shared by the accounts, users and partitions collectors. Before issue #144 " +
+			"these issued up to five separate full-queue dumps to slurmctld every scrape; " +
+			"they now project their views from this single call. The -a -r flags and the " +
+			"default state set match what each collector requested individually, so no " +
+			"metric value changes.",
+		Notes: []string{
+			"queue.go is deliberately NOT a consumer: it omits -a/-r and toggles " +
+				"--states=all, and folding it in here would change job-array counts.",
+			"The trailing colon on every field forces variable-width columns. Without " +
+				"it squeue caps a field at 20 characters and silently drops the tail " +
+				"(issues #10 and #35).",
+			"tres-alloc (effective total allocation) is used instead of the legacy %b " +
+				"(TRES per node) so jobs submitted with --gpus or --gpus-per-node are " +
+				"accounted for (issue #35).",
+		},
+		Fixtures: []Fixture{
+			{
+				File: "squeue_jobs.txt",
+				Why: "The consolidated layout itself: RUNNING/PENDING/SUSPENDED jobs across " +
+					"several accounts, users and partitions, plus a multi-partition (cpu,gpu) " +
+					"pending job that the partitions projection has to split.",
+				Slurm: "25.11",
+			},
+			{
+				File: "squeue_tres.txt",
+				Why: "Backs ParseAccountsMetrics, which the accounts projection re-emits " +
+					"verbatim: proves the projection produces the layout the parser expects.",
+			},
+			{
+				File: "squeue_tres_users.txt",
+				Why: "Same contract as squeue_tres.txt for the users projection " +
+					"(ParseUsersMetrics).",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = SqueueJobsData(log) },
+	},
+	{
+		Name:   "queue_all_states",
+		Binary: "squeue",
+		Args:   []string{"-h", "-o", "%P|%T|%C|%r|%u", "--states=all"},
+		Source: "queue.go",
+		Doc: "Job states, cores, reason and user, pipe-delimited so commas inside the " +
+			"reason field stay inside their column. --states=all is what brings the " +
+			"terminal states into the output: squeue reports only pending and running " +
+			"jobs when it is not told which states to view, so nine of the eleven states " +
+			"the collector counts never appeared and every metric built from them read a " +
+			"constant zero. slurm_jobs_failed said the cluster had never had a failure " +
+			"(issue #27).",
+		Notes: []string{
+			"The window is bounded by MinJobAge (slurm.conf, 300s by default): slurmctld " +
+				"forgets a terminated job once it is older than that.",
+			"Dropped by --no-collector.queue.terminal-states, which restores the " +
+				"pre-1.9 query, the queue_default_states entry below.",
+		},
+		Fixtures: []Fixture{
+			{
+				File: "squeue.txt",
+				Why: "Eight states in one capture: RUNNING, PENDING, SUSPENDED, CANCELLED, " +
+					"COMPLETED, FAILED, TIMEOUT, NODE_FAIL. PREEMPTED needs PreemptType " +
+					"configured, COMPLETING lasts as long as an epilog and CONFIGURING as long " +
+					"as a node boots, so those three are covered by a hand-written input in " +
+					"TestParseQueueMetricsUnreachableStates instead.",
+				Slurm: "25.11.2",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = QueueData(log, true) },
+	},
+	{
+		Name:   "queue_default_states",
+		Binary: "squeue",
+		Args:   []string{"-h", "-o", "%P|%T|%C|%r|%u"},
+		Source: "queue.go",
+		OptIn:  "--no-collector.queue.terminal-states",
+		Doc: "The same query without --states=all, restoring the pre-1.9 behaviour for " +
+			"sites that would rather not ask slurmctld for the terminal states.",
+		NoFixtureReason: "Deliberate: the output is a subset of squeue.txt and the parser is the " +
+			"same one, so a second capture would protect nothing. What the flag changes is " +
+			"the query itself, which the contract test pins.",
+		invoke: func(log *logger.Logger, _ string) { _, _ = QueueData(log, false) },
+	},
+	{
+		Name:   "cpus",
+		Binary: "sinfo",
+		Args:   []string{"-h", "-o", "%C"},
+		Source: "cpus.go",
+		Doc:    "Cluster-wide CPU states as allocated/idle/other/total.",
+		Fixtures: []Fixture{
+			{File: "sinfo_cpus.txt", Why: "The single A/I/O/T line the parser splits on slashes."},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = CPUsData(log) },
+	},
+	{
+		Name:   "fairshare",
+		Binary: "sshare",
+		Args: []string{"-a", "-P", "-n", "-o",
+			"Account,User,RawShares,NormShares,RawUsage,NormUsage,FairShare"},
+		Source: "fairshare.go",
+		Doc: "Fairshare factor, shares and decay-weighted usage per account and per " +
+			"user.",
+		Notes: []string{
+			"Lines with RawShares=parent are skipped: they inherit from the parent account.",
+			"Lines with an empty Account field are skipped.",
+			"User-level metrics require --collector.fairshare.user-metrics (default on).",
+		},
+		Fixtures: []Fixture{
+			{
+				File: "sshare_users.txt",
+				Why: "An account tree with both the parent rows that must be skipped and the " +
+					"user rows that must not.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = FairShareData(log) },
+	},
+	{
+		Name:   "gpus_snapshot",
+		Binary: "sinfo",
+		Args:   []string{"-a", "-h", "--Format=Nodes: ,StateLong: ,Gres: ,GresUsed:"},
+		Source: "gpus.go",
+		Doc: "One consolidated snapshot (node count, state, total GRES and used GRES) " +
+			"from which total, allocated, idle and other GPUs are all derived. A single " +
+			"call removes the race between the three separate snapshots this replaced " +
+			"(issue #145).",
+		Notes: []string{
+			"The trailing colon on each field forces variable column widths; fixed widths " +
+				"silently truncate rich GRES specs on busy GPU nodes: multi-type GPUs, MIG " +
+				"slices (issue #10).",
+			"The per-version slurm-*/sinfo_gpus_{allocated,idle,total}.txt fixtures still " +
+				"back the version matrix in gpus_test.go, which exercises the individual GRES " +
+				"parsers across Slurm releases. splitGPUViews feeds those same parsers from " +
+				"this consolidated snapshot, so the version fixtures keep protecting the GRES " +
+				"parsing even though the three commands they were captured from are retired.",
+			"Coverage gap: the format of the command executed today, meaning four --Format " +
+				"fields in a given order plus the (null) path, is validated on a single Slurm " +
+				"version, while the retired commands are covered on six. See issue #195, gap A.",
+		},
+		Fixtures: []Fixture{
+			{
+				File:  "sinfo_gpus_snapshot.txt",
+				Why:   "The four-column consolidated layout the collector parses today.",
+				Slurm: "25.05.3",
+			},
+			{
+				File: "sinfo_gpus_total_long_gres.txt",
+				Why: "A GRES string long enough to be truncated by a fixed-width --Format, " +
+					"which is what the trailing colons exist to prevent (issue #10).",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = GPUsSnapshotData(log) },
+	},
+	{
+		Name:   "node_detail",
+		Binary: "sinfo",
+		Args: []string{"-h", "-N", "-O",
+			"NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition:"},
+		Source: "node.go",
+		Doc:    "Per-node CPU and memory detail, one row per node.",
+		Notes: []string{
+			"The trailing colon on each field forces variable column widths. Without it " +
+				"node names longer than 20 characters — the default NodeList width — collide " +
+				"with the next column and produce fewer than six whitespace-separated tokens, " +
+				"silently dropping those nodes (issue #10).",
+		},
+		Fixtures: []Fixture{
+			{File: "sinfo_mem.txt", Why: "The nominal six-column per-node layout."},
+			{
+				File: "sinfo_default_partition.txt",
+				Why: "A node in the default partition, whose name carries the * marker that " +
+					"has to be stripped before it becomes a label value.",
+			},
+			{
+				File: "sinfo_long_names_fixed.txt",
+				Why: "A 25-character node name alongside short ones, in the variable-width " +
+					"output the trailing colons produce (_fixed meaning after the fix). Under " +
+					"the old fixed-width format that name collided with the next column and the " +
+					"node vanished from the metrics map; the regression net for issue #10.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = NodeData(log) },
+	},
+	{
+		Name:   "nodes_global",
+		Binary: "sinfo",
+		Args:   []string{"-h", "-o", "%R|%D|%T|%b"},
+		Source: "nodes.go",
+		Doc: "Node counts by partition, state and feature set, for every partition in " +
+			"one call. This replaced N per-partition calls (sinfo -p <partition>), " +
+			"cutting the RPC load on slurmctld on clusters with many partitions; the " +
+			"single-partition path was removed as unreachable in #100.",
+		NoFixtureReason: "Still to do. test_data/sinfo.txt backed this command until " +
+			"d52d93f (#100, v1.8.4) deleted it, and nodes_test.go has worked on inline strings " +
+			"ever since. The most central command of the nodes collector has no captured " +
+			"cluster output at all. Capturing one is the first job of tools/fixture-capture.",
+		invoke: func(log *logger.Logger, _ string) { _, _ = NodesDataGlobal(log) },
+	},
+	{
+		Name:      "scontrol_nodes",
+		Binary:    "scontrol",
+		Args:      []string{"show", "nodes", "-o"},
+		Source:    "reservation_nodes.go",
+		Consumers: []string{"nodes.go"},
+		Doc: "Full node detail, one node per line. Read by two collectors — " +
+			"reservation_nodes for per-reservation node membership and state, nodes for " +
+			"the cluster-wide total — behind scontrolNodesCache, so the RPC is sent once " +
+			"per scrape rather than twice.",
+		Fixtures: []Fixture{
+			{
+				File: "scontrol_nodes_reservation.txt",
+				Why: "Nodes carrying reservation membership, including the drained-but-up " +
+					"case that decides whether a reserved node counts as healthy.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = ReservationNodesData(log) },
+	},
+	{
+		Name:   "partitions_cpu",
+		Binary: "sinfo",
+		Args:   []string{"-h", "-o", "%R,%C"},
+		Source: "partitions.go",
+		Doc:    "CPU states per partition.",
+		Fixtures: []Fixture{
+			{
+				File:  "slurm-25.11.1-1/sinfo_partitions_cpu.txt",
+				Why:   "Per-partition A/I/O/T lines.",
+				Slurm: "25.11.1-1",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = PartitionsData(log) },
+	},
+	{
+		Name:   "partitions_gpu",
+		Binary: "sinfo",
+		Args: []string{"-h", "--Format=Nodes: ,Partition: ,Gres: ,GresUsed:",
+			"--state=idle,allocated"},
+		Source: "partitions.go",
+		Doc:    "GPU totals and usage per partition, restricted to idle and allocated nodes.",
+		Fixtures: []Fixture{
+			{
+				File:  "slurm-25.11.1-1/sinfo_partitions_gpu.txt",
+				Why:   "The nominal four-column per-partition GRES layout.",
+				Slurm: "25.11.1-1",
+			},
+			{
+				File: "sinfo_partitions_gpu_long.txt",
+				Why: "GRES strings long enough to overflow a fixed-width column, the " +
+					"per-partition counterpart of the issue #10 trap.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = PartitionsGpuData(log) },
+	},
+	{
+		Name:   "drain_reason",
+		Binary: "sinfo",
+		Args:   []string{"-h", "-N", "-o", "%N|%E|%H|%T"},
+		Source: "node_drain.go",
+		Doc:    "Drain or down reason per node, with the timestamp the state was set.",
+		NoFixtureReason: "Deliberate: the output depends entirely on which nodes happen to be drained " +
+			"when the capture is taken, so a capture would document one cluster's bad day " +
+			"rather than a format. The tests use inline inputs that pin the timestamp and " +
+			"reason shapes instead.",
+		invoke: func(log *logger.Logger, _ string) { _, _ = DrainReasonData(log) },
+	},
+	{
+		Name:   "reservations",
+		Binary: "scontrol",
+		Args:   []string{"show", "reservation"},
+		Source: "reservations.go",
+		Doc: "Active reservation details as key=value blocks, one blank-line-separated " +
+			"block per reservation.",
+		Fixtures: []Fixture{
+			{File: "sreservations.txt", Why: "The nominal multi-reservation block layout."},
+			{
+				File: "sreservations_empty.txt",
+				Why: "What scontrol prints when no reservation exists, which is a sentence of " +
+					"prose rather than an empty file. The parser has to produce no metrics from " +
+					"it, rather than one bogus one.",
+			},
+			{
+				File: "sreservations_relative_time.txt",
+				Why: "Reservation timestamps in the relative form Slurm emits for near-term " +
+					"reservations, which the absolute-layout parser must not silently accept.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) {
+			_, _ = NewReservationsCollector(log).reservationsData()
+		},
+	},
+	{
+		Name:   "licenses",
+		Binary: "scontrol",
+		Args:   []string{"show", "licenses", "-o"},
+		Source: "licenses.go",
+		Doc:    "License total, used, free and reserved counts, one license per line.",
+		Fixtures: []Fixture{
+			{File: "slicense.txt", Why: "Several licenses with distinct total/used/free splits."},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = LicenseData(log) },
+	},
+	{
+		Name:   "scheduler",
+		Binary: "sdiag",
+		Args:   nil,
+		Source: "scheduler.go",
+		Doc:    "slurmctld internal scheduler statistics, including per-RPC counters.",
+		Fixtures: []Fixture{
+			{
+				File: "sdiag.txt",
+				Why: "The header counters (jobs submitted/started/completed/canceled/failed), " +
+					"the main schedule statistics block and the backfill block. It stops there: " +
+					"the Remote Procedure Call tables that scheduler.go also parses, per " +
+					"operation and per user, are absent from this capture, so the RPC metrics " +
+					"rest on TestSchedulerRPCLineRe_HyphenatedUsername alone: one inline line " +
+					"against one regexp, with no captured report behind them.",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) { _, _ = SchedulerData(log) },
+	},
+	{
+		Name:       "binary_version",
+		EachBinary: versionedBinaries,
+		Args:       []string{"--version"},
+		Source:     "slurm_binary_info.go",
+		Doc: "The version of each Slurm binary, probed once per process rather than on " +
+			"every scrape (issue #149): a Slurm upgrade under a running exporter is not " +
+			"a supported state, the process is restarted by whatever performed it.",
+		Notes: []string{
+			"sinfo, squeue, sdiag, scontrol and sacct are required: a missing one is " +
+				"reported with version=\"not_found\" and value 0 so operators can alert on it.",
+			"sbatch, salloc and srun are optional and emit nothing when absent. The " +
+				"exporter never invokes them, so requiring them would block monitoring-only " +
+				"deployments (issue #24).",
+			"sshare is executed by the fairshare collector but never version-probed.",
+		},
+		NoFixtureReason: "Deliberate: the parser reads one field of a one-line output, and the value " +
+			"it reads is the Slurm version of whichever host runs the capture. A fixture " +
+			"would pin that host's version, not a format.",
+		invoke: func(log *logger.Logger, binary string) { _, _ = GetBinaryVersion(log, binary) },
+	},
+	{
+		Name:   "sacct_efficiency",
+		Binary: "sacct",
+		Args: []string{
+			"-P", "-n",
+			"--starttime", "{{starttime}}",
+			"--endtime", "{{endtime}}",
+			"--format", "JobID,User,Account,AllocCPUS,Elapsed,TotalCPU,CPUTime,MaxRSS,ReqMem",
+			"--state", "COMPLETED,FAILED,TIMEOUT,CANCELLED",
+		},
+		Placeholders: []Placeholder{
+			{
+				Token: "{{starttime}}",
+				Match: slurmTimestamp,
+				Shell: `$(date -d "-1 hour" +%Y-%m-%dT%H:%M:%S)`,
+			},
+			{
+				Token: "{{endtime}}",
+				Match: slurmTimestamp,
+				Shell: `$(date +%Y-%m-%dT%H:%M:%S)`,
+			},
+		},
+		Source: "sacct_efficiency.go",
+		OptIn:  "--collector.sacct_efficiency",
+		Doc: "Completed-job CPU and memory efficiency over the lookback window. " +
+			"Disabled by default because it queries SlurmDBD, which is expensive on a " +
+			"busy cluster; refreshed in the background on --collector.sacct.interval " +
+			"rather than on the scrape path.",
+		Notes: []string{
+			"--endtime is mandatory: with --state and only --starttime, sacct returns no " +
+				"rows at all: Slurm bounds a state-filtered search to [starttime, endtime] " +
+				"and the default endtime does not cover the window. Without it the whole " +
+				"collector reported nothing, not just memory (issue #143).",
+			"No -X: MaxRSS is a step-level statistic and is empty on the allocation line, " +
+				"so the step lines (<jobid>.batch, <jobid>.0, …) are read and their peak " +
+				"MaxRSS attributed back to the job by JobID. JobID therefore leads --format.",
+			"Populating TotalCPU and MaxRSS requires a working JobAcctGatherType in " +
+				"slurm.conf.",
+		},
+		Fixtures: []Fixture{
+			{
+				File: "sacct_efficiency.txt",
+				Why: "Allocation lines with their step lines, so the JobID correlation and the " +
+					"MaxRSS attribution are both exercised. The line format is a real capture; " +
+					"the MaxRSS values are representative rather than captured, because the " +
+					"containerised test cluster runs proctrack/linuxproc, which does not gather " +
+					"MaxRSS and leaves the column empty. A cluster with proctrack/cgroup fills " +
+					"it in exactly this shape (issue #143).",
+				Slurm: "25.11",
+			},
+		},
+		invoke: func(log *logger.Logger, _ string) {
+			NewSacctEfficiencyCollector(log, time.Hour, time.Hour).refresh()
+		},
+	},
+}
+
+// ── Fixture directories ──────────────────────────────────────────────────────
+
+// FixtureDir is one versioned subdirectory of test_data/.
+//
+// GPU sinfo output changed shape between Slurm releases, so the GRES parsers
+// are exercised against a matrix of captures rather than a single one.
+type FixtureDir struct {
+	// Path is the directory name under test_data/.
+	Path string
+	// Slurm is the release the capture was taken on.
+	Slurm string
+	// Supported reports whether the release is inside the support window
+	// declared in CONTRIBUTING (newest major plus the previous three). A
+	// directory below the floor is kept as free regression protection, not as
+	// a peer of the supported ones.
+	Supported bool
+	// Notes is what makes this capture worth keeping.
+	Notes string
+}
+
+// FixtureDirs describes the versioned GPU fixture matrix.
+//
+// The support window rolls with every Slurm major, so Supported is re-derived
+// rather than frozen: see CONTRIBUTING § Releasing and issue #195, gap B. As of
+// Slurm 26.05 the window is 24.11 → 26.05, and neither end has a fixture.
+var FixtureDirs = []FixtureDir{
+	{
+		Path:      "slurm-20.11.8",
+		Slurm:     "20.11.8",
+		Supported: false,
+		Notes:     "Classic GRES format.",
+	},
+	{
+		Path:      "slurm-21.08.5",
+		Slurm:     "21.08.5",
+		Supported: false,
+		Notes: "IDX format. sinfo_gpus_allocated.txt is empty on purpose — a cluster " +
+			"with GPUs and none allocated — and gpus_test.go asserts a 0 result rather " +
+			"than skipping the case.",
+	},
+	{
+		Path:      "slurm-23.11.10",
+		Slurm:     "23.11.10",
+		Supported: false,
+		Notes: "No idle fixture. The file was a two-column capture where IdleGPUsData emits " +
+			"three, so the idle and other counts derived from it were artefacts of the " +
+			"malformation; #177 deleted it. It cannot be recaptured — 23.11.10 is no longer " +
+			"published upstream — and the real three-column idle format is already covered " +
+			"by 23.11.10-2, so the gap is marked with idleUncovered in gpus_test.go rather " +
+			"than filled.",
+	},
+	{
+		Path:      "slurm-23.11.10-2",
+		Slurm:     "23.11.10 patch 2",
+		Supported: false,
+	},
+	{
+		Path:      "slurm-25.05",
+		Slurm:     "25.05.x",
+		Supported: true,
+		Notes: "nvidia_gb200 GPU type on a large machine: 1058 nodes on the total line, " +
+			"1056 on the allocated one. Four-digit node counts are what overflow a " +
+			"fixed-width Nodes: column, so this is the capture that shows why the " +
+			"--Format fields end with colons.",
+	},
+	{
+		Path:      "slurm-25.11.1-1",
+		Slurm:     "25.11.1-1",
+		Supported: true,
+		Notes:     "Also carries the per-partition CPU and GPU captures.",
+	},
+}

--- a/internal/collector/command_registry_test.go
+++ b/internal/collector/command_registry_test.go
@@ -1,0 +1,250 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sckyzo/slurm_exporter/internal/logger"
+)
+
+// testDataDir is where the fixtures live, relative to this package.
+const testDataDir = "../../test_data"
+
+// placeholderToken matches the {{name}} form used in Command.Args for values
+// the exporter computes at call time.
+var placeholderToken = regexp.MustCompile(`{{[a-z]+}}`)
+
+// resetSharedCaches gives the test fresh instances of the caches that sit
+// between a collector and Execute, so invoking two entries backed by the same
+// cache reaches Execute twice instead of once. Without it, whichever of
+// scontrol_nodes and squeue_jobs ran second would observe no call at all, and
+// the contract would silently stop being checked.
+func resetSharedCaches(t *testing.T) {
+	t.Helper()
+	oldNodes, oldJobs := scontrolNodesCache, squeueJobsCache
+	t.Cleanup(func() {
+		scontrolNodesCache, squeueJobsCache = oldNodes, oldJobs
+	})
+	scontrolNodesCache = &timedCache{ttl: oldNodes.ttl}
+	squeueJobsCache = &timedCache{ttl: oldJobs.ttl}
+}
+
+// observeCommand runs one registry entry through its real production path with
+// Execute stubbed, and reports what that path actually asked for.
+func observeCommand(t *testing.T, cmd Command, binary string) (string, []string) {
+	t.Helper()
+	resetSharedCaches(t)
+
+	var (
+		gotBin  string
+		gotArgs []string
+		calls   int
+	)
+	old := Execute
+	t.Cleanup(func() { Execute = old })
+	Execute = func(_ *logger.Logger, command string, args []string) ([]byte, error) {
+		calls++
+		gotBin, gotArgs = command, args
+		return nil, nil
+	}
+
+	log, _ := bufferLogger()
+	cmd.invoke(log, binary)
+
+	require.Equalf(t, 1, calls,
+		"%s reached Execute %d times, expected exactly once — a registry entry maps to "+
+			"one command, so either the collector changed or the entry needs splitting",
+		cmd.Name, calls)
+	return gotBin, gotArgs
+}
+
+// requireArgsMatch compares observed arguments to the table, accepting any
+// value in a placeholder position as long as it has the declared shape.
+func requireArgsMatch(t *testing.T, cmd Command, got []string) {
+	t.Helper()
+
+	byToken := make(map[string]Placeholder, len(cmd.Placeholders))
+	for _, p := range cmd.Placeholders {
+		byToken[p.Token] = p
+	}
+
+	require.Equalf(t, len(cmd.Args), len(got),
+		"%s passes %d arguments, the registry declares %d\n  registry: %v\n  code:     %v",
+		cmd.Name, len(got), len(cmd.Args), cmd.Args, got)
+
+	for i, want := range cmd.Args {
+		if p, ok := byToken[want]; ok {
+			require.Regexpf(t, p.Match, got[i],
+				"%s argument %d is the %s placeholder, but %q does not have the declared shape",
+				cmd.Name, i, p.Token, got[i])
+			continue
+		}
+		require.Equalf(t, want, got[i],
+			"%s argument %d drifted\n  registry: %q\n  code:     %q",
+			cmd.Name, i, want, got[i])
+	}
+}
+
+// TestRegistryMatchesCollectors is what makes the registry a mirror of the code
+// rather than a fourth copy of it. Every entry is invoked through its real
+// *Data() path, and what that path passes to Execute has to be what the table
+// says. Changing a Slurm command without updating the table fails here.
+func TestRegistryMatchesCollectors(t *testing.T) {
+	for _, cmd := range CommandRegistry {
+		t.Run(cmd.Name, func(t *testing.T) {
+			require.NotNilf(t, cmd.invoke, "%s declares no invoke func, so nothing checks it", cmd.Name)
+
+			binaries := cmd.EachBinary
+			if len(binaries) == 0 {
+				binaries = []string{cmd.Binary}
+			}
+			for _, binary := range binaries {
+				gotBin, gotArgs := observeCommand(t, cmd, binary)
+				require.Equalf(t, binary, gotBin, "%s ran the wrong binary", cmd.Name)
+				requireArgsMatch(t, cmd, gotArgs)
+			}
+		})
+	}
+}
+
+// TestRegistryEntriesAreWellFormed pins the invariants the doc and capture
+// generators rely on, so a malformed entry fails here rather than producing a
+// broken readme or an unrunnable capture script.
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	seen := make(map[string]bool, len(CommandRegistry))
+
+	for _, cmd := range CommandRegistry {
+		t.Run(cmd.Name, func(t *testing.T) {
+			require.NotEmpty(t, cmd.Name, "every entry needs a name: it is the doc anchor and the capture step id")
+			require.Falsef(t, seen[cmd.Name], "duplicate registry name %q", cmd.Name)
+			seen[cmd.Name] = true
+			// The name is used verbatim as a GitHub heading anchor in the
+			// generated readme and as a shell identifier in the generated
+			// capture script; both stop working outside this alphabet.
+			require.Regexpf(t, `^[a-z0-9_]+$`, cmd.Name,
+				"registry name %q must be lowercase words joined by underscores", cmd.Name)
+
+			require.NotEmptyf(t, cmd.Source, "%s must name the collector file that owns it", cmd.Name)
+			require.NotEmptyf(t, cmd.Doc, "%s must say what it returns: the readme is generated from this", cmd.Name)
+
+			if len(cmd.EachBinary) == 0 {
+				require.NotEmptyf(t, cmd.Binary, "%s must set Binary or EachBinary", cmd.Name)
+			} else {
+				require.Emptyf(t, cmd.Binary, "%s sets both Binary and EachBinary", cmd.Name)
+			}
+
+			// Every placeholder token used must be declared, and every declared
+			// placeholder must be used — an undeclared token would be compared
+			// literally and an unused one would silently rot.
+			declared := make(map[string]bool, len(cmd.Placeholders))
+			for _, p := range cmd.Placeholders {
+				require.NotNilf(t, p.Match, "%s placeholder %s has no Match", cmd.Name, p.Token)
+				require.NotEmptyf(t, p.Shell, "%s placeholder %s has no Shell expression, so it cannot be captured", cmd.Name, p.Token)
+				declared[p.Token] = true
+			}
+			used := make(map[string]bool)
+			for _, arg := range cmd.Args {
+				for _, tok := range placeholderToken.FindAllString(arg, -1) {
+					require.Truef(t, declared[tok], "%s uses undeclared placeholder %s", cmd.Name, tok)
+					used[tok] = true
+				}
+			}
+			for tok := range declared {
+				require.Truef(t, used[tok], "%s declares placeholder %s but never uses it", cmd.Name, tok)
+			}
+
+			for _, f := range cmd.Fixtures {
+				require.NotEmptyf(t, f.Why, "%s fixture %s must say what it protects", cmd.Name, f.File)
+			}
+
+			// A command with no capture behind it is a coverage gap. Requiring
+			// the reason in the table is what stops the gap from reading as
+			// coverage in the generated readme.
+			if len(cmd.Fixtures) == 0 {
+				require.NotEmptyf(t, cmd.NoFixtureReason,
+					"%s has no fixture: set NoFixtureReason to say whether that is deliberate "+
+						"or work still to do", cmd.Name)
+			} else {
+				require.Emptyf(t, cmd.NoFixtureReason,
+					"%s has %d fixtures but still carries a NoFixtureReason",
+					cmd.Name, len(cmd.Fixtures))
+			}
+		})
+	}
+}
+
+// TestRegistryFixturesExist catches the drift that sent a contributor to a file
+// deleted two releases earlier: test_data/sinfo.txt was removed by d52d93f
+// (#100) and the documentation kept pointing at it (issue #195, drift 2).
+func TestRegistryFixturesExist(t *testing.T) {
+	for _, cmd := range CommandRegistry {
+		for _, f := range cmd.Fixtures {
+			path := filepath.Join(testDataDir, f.File)
+			_, err := os.Stat(path)
+			require.NoErrorf(t, err,
+				"%s declares fixture %s, which is not on disk — either capture it or drop the entry",
+				cmd.Name, f.File)
+		}
+	}
+}
+
+// TestEveryFixtureIsClaimed is the other direction. A capture nobody documents
+// cannot be traced back to the bug it protects, and six of the twenty fixtures
+// were in that state (issue #195, drift 7). Adding a file under test_data/ now
+// means saying why it is there.
+func TestEveryFixtureIsClaimed(t *testing.T) {
+	claimed := make(map[string]bool)
+	for _, cmd := range CommandRegistry {
+		for _, f := range cmd.Fixtures {
+			claimed[filepath.ToSlash(f.File)] = true
+		}
+	}
+	dirs := make(map[string]bool, len(FixtureDirs))
+	for _, d := range FixtureDirs {
+		dirs[d.Path] = true
+	}
+
+	entries, err := os.ReadDir(testDataDir)
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			require.Truef(t, dirs[name],
+				"test_data/%s/ is not described in FixtureDirs: say which Slurm release it "+
+					"was captured on and whether that release is still in the support window", name)
+			continue
+		}
+		if name == "readme.md" {
+			continue
+		}
+		require.Truef(t, claimed[name],
+			"test_data/%s is read by a test but no registry entry claims it — add it to the "+
+				"owning command's Fixtures with a Why, or delete it", name)
+	}
+
+	// Versioned fixtures named individually must sit in a declared directory.
+	for file := range claimed {
+		if dir, _, found := strings.Cut(file, "/"); found {
+			require.Truef(t, dirs[dir],
+				"fixture %s lives in test_data/%s/, which is not declared in FixtureDirs", file, dir)
+		}
+	}
+}
+
+// TestFixtureDirsExist keeps the versioned matrix honest in the direction the
+// dynamic discovery in gpus_test.go cannot: a directory declared here but
+// absent from disk would silently document coverage that does not exist.
+func TestFixtureDirsExist(t *testing.T) {
+	for _, d := range FixtureDirs {
+		info, err := os.Stat(filepath.Join(testDataDir, d.Path))
+		require.NoErrorf(t, err, "FixtureDirs declares test_data/%s/, which is not on disk", d.Path)
+		require.Truef(t, info.IsDir(), "test_data/%s is declared as a fixture directory but is a file", d.Path)
+		require.NotEmptyf(t, d.Slurm, "test_data/%s/ must record the Slurm release it was captured on", d.Path)
+	}
+}

--- a/test_data/readme.md
+++ b/test_data/readme.md
@@ -1,163 +1,355 @@
-# Slurm Commands Used in slurm_exporter
+<!--
+GENERATED FILE. DO NOT EDIT.
 
-This file documents all Slurm shell commands executed by `slurm_exporter` and the test
-data files that correspond to each command's output.
+Source of truth: internal/collector/command_registry.go
+Regenerate with:  make generate   (or: go generate ./...)
 
-All test data files are anonymized (real cluster node names, user names, account names
-and reservation names have been replaced with generic equivalents).
+Editing this file by hand is pointless: CI regenerates it and fails on the diff.
+Change the registry instead. command_registry_test.go then proves that the
+registry still matches what the collectors actually run.
+-->
 
-## Shared squeue snapshot (`collector/squeue_jobs.go`)
+# Slurm commands used by slurm_exporter
 
-- `squeue -a -r -h -O "JobID:|,Account:|,UserName:|,Partition:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:"`:
-  one consolidated snapshot of the whole job queue, cached per scrape and shared
-  by the `accounts`, `users` and `partitions` collectors. Before issue #144
-  these issued up to five separate full-queue dumps to `slurmctld` every scrape;
-  they now project their views from this single call. `-a -r` and the default
-  state set match what each collector requested individually, so no metric value
-  changes. `queue.go` is deliberately **not** a consumer (it omits `-a`/`-r` and
-  toggles `--states=all`; sharing it would change job-array counts).
-  - Test file: **`squeue_jobs.txt`** — captured on the `scripts/testing` cluster
-    (Slurm 25.11), covering RUNNING/PENDING/SUSPENDED jobs across several
-    accounts, users and partitions, plus a multi-partition (`cpu,gpu`) pending
-    job.
+Every Slurm CLI invocation the exporter makes, and the fixture under `test_data/`
+that protects it.
 
-## `collector/accounts.go`
+This mapping is derived from `internal/collector/command_registry.go`, which is
+itself checked against the real collectors: `TestRegistryMatchesCollectors` invokes
+each `*Data()` function with `Execute` stubbed and compares what it genuinely
+passes to what the table declares. A command cannot change without this file
+changing with it.
 
-- Projects the account view (`JobID|Account|State|NumNodes|NumCPUs|tres-alloc`)
-  from the shared snapshot above: job/CPU/GPU counts by account.
-  - Test file: **`squeue_tres.txt`** — still backs `ParseAccountsMetrics`, which
-    is unchanged; the projection re-emits exactly this layout.
-  - Uses `tres-alloc` (effective allocation, total) instead of the legacy `%b`
-    (TRES per node) so that jobs submitted with `--gpus` or `--gpus-per-node`
-    are accounted for (see issue #35).
+All fixtures are anonymised: cluster, node, user, account and reservation names
+are replaced with generic equivalents. See `CONTRIBUTING.md` § Test Data.
 
-## `collector/cpus.go`
 
-- `sinfo -h -o "%C"`: CPU state (allocated/idle/other/total) for the cluster.
-  - Test file: **`sinfo_cpus.txt`**
+## Index
 
-## `collector/fairshare.go`
+| Command | Binary | Owned by | Fixtures |
+|---|---|---|---|
+| [`squeue_jobs`](#squeue_jobs) | `squeue` | `squeue_jobs.go` | 3 |
+| [`queue_all_states`](#queue_all_states) | `squeue` | `queue.go` | 1 |
+| [`queue_default_states`](#queue_default_states) | `squeue` | `queue.go` | none |
+| [`cpus`](#cpus) | `sinfo` | `cpus.go` | 1 |
+| [`fairshare`](#fairshare) | `sshare` | `fairshare.go` | 1 |
+| [`gpus_snapshot`](#gpus_snapshot) | `sinfo` | `gpus.go` | 2 |
+| [`node_detail`](#node_detail) | `sinfo` | `node.go` | 3 |
+| [`nodes_global`](#nodes_global) | `sinfo` | `nodes.go` | none |
+| [`scontrol_nodes`](#scontrol_nodes) | `scontrol` | `reservation_nodes.go` | 1 |
+| [`partitions_cpu`](#partitions_cpu) | `sinfo` | `partitions.go` | 1 |
+| [`partitions_gpu`](#partitions_gpu) | `sinfo` | `partitions.go` | 2 |
+| [`drain_reason`](#drain_reason) | `sinfo` | `node_drain.go` | none |
+| [`reservations`](#reservations) | `scontrol` | `reservations.go` | 3 |
+| [`licenses`](#licenses) | `scontrol` | `licenses.go` | 1 |
+| [`scheduler`](#scheduler) | `sdiag` | `scheduler.go` | 1 |
+| [`binary_version`](#binary_version) | `8 binaries` | `slurm_binary_info.go` | none |
+| [`sacct_efficiency`](#sacct_efficiency) | `sacct` | `sacct_efficiency.go` | 1 |
 
-- `sshare -a -P -n -o Account,User,RawShares,NormShares,RawUsage,NormUsage,FairShare`: fairshare factor, shares and decay-weighted usage per account and user.
-  - Test file: **`sshare_users.txt`**
-  - Lines with `RawShares=parent` are skipped (inherit from parent account).
-  - Lines with an empty Account field are skipped.
-  - User-level metrics require `--collector.fairshare.user-metrics=true` (default).
+## Commands
 
-## `collector/gpus.go`
+### squeue_jobs
 
-- `sinfo -a -h --Format=Nodes: ,StateLong: ,Gres: ,GresUsed:`: one consolidated
-  snapshot — node count, state, total GRES and used GRES — from which total,
-  allocated, idle and other GPUs are all derived. A single call removes the race
-  between the three separate snapshots this replaced (issue #145).
-  - Test file: **`sinfo_gpus_snapshot.txt`**
+```sh
+squeue -a -r -h -O 'JobID:|,Account:|,UserName:|,Partition:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:'
+```
 
-  The per-version **`slurm-*/sinfo_gpus_{allocated,idle,total}.txt`** fixtures
-  still back the version matrix in `gpus_test.go`, which exercises the individual
-  GRES parsers (`ParseAllocatedGPUs`, `ParseIdleGPUs`, `ParseTotalGPUs`) across
-  Slurm releases. `splitGPUViews` feeds those same parsers from the consolidated
-  snapshot, so the version fixtures keep protecting the GRES parsing.
+One consolidated snapshot of the whole job queue, cached per scrape and shared by the accounts, users and partitions collectors. Before issue #144 these issued up to five separate full-queue dumps to slurmctld every scrape; they now project their views from this single call. The -a -r flags and the default state set match what each collector requested individually, so no metric value changes.
 
-## `collector/node.go`
+Owned by `squeue_jobs.go`. Also read by `accounts.go`, `users.go` and `partitions.go`.
 
-- `sinfo -h -N -O NodeList,AllocMem,Memory,CPUsState,StateLong,Partition`: per-node detail.
-  - Test file: **`sinfo_mem.txt`**
+- queue.go is deliberately NOT a consumer: it omits -a/-r and toggles --states=all, and folding it in here would change job-array counts.
+- The trailing colon on every field forces variable-width columns. Without it squeue caps a field at 20 characters and silently drops the tail (issues #10 and #35).
+- tres-alloc (effective total allocation) is used instead of the legacy %b (TRES per node) so jobs submitted with --gpus or --gpus-per-node are accounted for (issue #35).
 
-## `collector/nodes.go`
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `squeue_jobs.txt` | 25.11 | The consolidated layout itself: RUNNING/PENDING/SUSPENDED jobs across several accounts, users and partitions, plus a multi-partition (cpu,gpu) pending job that the partitions projection has to split. |
+| `squeue_tres.txt` | unrecorded | Backs ParseAccountsMetrics, which the accounts projection re-emits verbatim: proves the projection produces the layout the parser expects. |
+| `squeue_tres_users.txt` | unrecorded | Same contract as squeue_tres.txt for the users projection (ParseUsersMetrics). |
 
-- `sinfo -h -o "%D|%T|%b" -p <partition>`: node counts by state and feature set.
-  - Test file: **`sinfo.txt`**
-- `scontrol show nodes -o`: total node count.
-- `sinfo -h -o "%R"`: partition list.
+### queue_all_states
 
-## `collector/partitions.go`
+```sh
+squeue -h -o '%P|%T|%C|%r|%u' --states=all
+```
 
-- `sinfo -h -o "%R,%C"`: CPU state per partition.
-  - Test files: **`slurm-25.11.1-1/sinfo_partitions_cpu.txt`**
-- `sinfo -h --Format=Nodes: ,Partition: ,Gres: ,GresUsed: --state=idle,allocated`: GPU state per partition.
-  - Test files: **`slurm-25.11.1-1/sinfo_partitions_gpu.txt`**
-- Pending and running job counts per partition are projected from the shared
-  squeue snapshot (see above), filtering the consolidated output by state
-  instead of issuing `squeue -o "%P" --states=PENDING` and `--states=RUNNING`
-  separately (issue #144). Multi-partition jobs keep their comma-separated
-  partition list, which is split across partitions.
-  - Test file: **`squeue_jobs.txt`** (shared).
+Job states, cores, reason and user, pipe-delimited so commas inside the reason field stay inside their column. --states=all is what brings the terminal states into the output: squeue reports only pending and running jobs when it is not told which states to view, so nine of the eleven states the collector counts never appeared and every metric built from them read a constant zero. slurm_jobs_failed said the cluster had never had a failure (issue #27).
 
-## `collector/queue.go`
+Owned by `queue.go`.
 
-- `squeue -h -o "%P|%T|%C|%r|%u" --states=all`: job states, cores, reason, user (pipe-delimited to safely handle commas in reason field). `--states=all` is what brings the terminal states into the output; it is dropped by `--no-collector.queue.terminal-states`.
-  - Test file: **`squeue.txt`** — captured on the `scripts/testing` cluster
-    (Slurm 25.11.2, 10 nodes) and covering eight states: RUNNING, PENDING,
-    SUSPENDED, CANCELLED, COMPLETED, FAILED, TIMEOUT and NODE_FAIL. PREEMPTED
-    needs `PreemptType` configured, COMPLETING lasts as long as an epilog and
-    CONFIGURING as long as a node boots, so those three are covered by a
-    hand-written input in `TestParseQueueMetricsUnreachableStates` instead.
+- The window is bounded by MinJobAge (slurm.conf, 300s by default): slurmctld forgets a terminated job once it is older than that.
+- Dropped by --no-collector.queue.terminal-states, which restores the pre-1.9 query, the queue_default_states entry below.
 
-## `collector/reservations.go`
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `squeue.txt` | 25.11.2 | Eight states in one capture: RUNNING, PENDING, SUSPENDED, CANCELLED, COMPLETED, FAILED, TIMEOUT, NODE_FAIL. PREEMPTED needs PreemptType configured, COMPLETING lasts as long as an epilog and CONFIGURING as long as a node boots, so those three are covered by a hand-written input in TestParseQueueMetricsUnreachableStates instead. |
 
-- `scontrol show reservation`: active reservation details.
-  - Test file: **`sreservations.txt`**
+### queue_default_states
 
-## `collector/reservation_nodes.go`
+```sh
+squeue -h -o '%P|%T|%C|%r|%u'
+```
 
-- `scontrol show nodes -o`: node states with reservation membership.
-  - Test file: **`scontrol_nodes_reservation.txt`**
+The same query without --states=all, restoring the pre-1.9 behaviour for sites that would rather not ask slurmctld for the terminal states.
 
-## `collector/scheduler.go`
+Owned by `queue.go`. Runs only with `--no-collector.queue.terminal-states`.
 
-- `sdiag`: `slurmctld` internal scheduler statistics.
-  - Test file: **`sdiag.txt`**
+**No fixture.** Deliberate: the output is a subset of squeue.txt and the parser is the same one, so a second capture would protect nothing. What the flag changes is the query itself, which the contract test pins.
 
-## `collector/slurm_binary_info.go`
+### cpus
 
-- `<binary> --version` for: `sinfo`, `squeue`, `sdiag`, `scontrol`, `sacct`, `sbatch`, `salloc`, `srun`.
+```sh
+sinfo -h -o '%C'
+```
 
-## `collector/licenses.go`
+Cluster-wide CPU states as allocated/idle/other/total.
 
-- `scontrol show licenses -o`: license total/used/free/reserved counts.
-  - Test file: **`slicense.txt`**
+Owned by `cpus.go`.
 
-## `collector/sacct_efficiency.go`
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sinfo_cpus.txt` | unrecorded | The single A/I/O/T line the parser splits on slashes. |
 
-- `sacct -P -n --starttime <window> --format JobID,User,Account,AllocCPUS,Elapsed,TotalCPU,CPUTime,MaxRSS,ReqMem --state COMPLETED,FAILED,TIMEOUT,CANCELLED`: job efficiency data.
-  - Test file: **`sacct_efficiency.txt`**
-  - Requires `JobAcctGatherType=jobacct_gather/linux` (or similar) in slurm.conf to populate TotalCPU/MaxRSS.
-  - No `-X`: `MaxRSS` is a step-level field, empty on the allocation line, so the
-    step lines (`<jobid>.batch`, `<jobid>.0`, …) are read and their peak `MaxRSS`
-    is attributed back to the job by `JobID`.
-  - The line **format** was captured from the test cluster (Slurm 25.11). The
-    `MaxRSS` values on the step lines are representative rather than captured: the
-    containerised cluster uses `proctrack/linuxproc`, which does not gather
-    `MaxRSS`, so a real capture leaves that column empty. A cluster with a working
-    `JobAcctGather` (`proctrack/cgroup`) populates it exactly in this shape.
-  - Disabled by default (`--collector.sacct_efficiency` to enable).
+### fairshare
 
-## `collector/node_drain.go`
+```sh
+sshare -a -P -n -o Account,User,RawShares,NormShares,RawUsage,NormUsage,FairShare
+```
 
-- `sinfo -h -N -o "%N|%E|%H|%T"`: node drain/down reason and timestamp.
-  - No dedicated test file (data varies by cluster state, tested with inline fixtures).
+Fairshare factor, shares and decay-weighted usage per account and per user.
 
-## `collector/users.go`
+Owned by `fairshare.go`.
 
-- Projects the user view (`JobID|UserName|State|NumNodes|NumCPUs|tres-alloc`)
-  from the shared squeue snapshot (see the top of this file): job/CPU/GPU counts
-  by user.
-  - Test file: **`squeue_tres_users.txt`** — still backs `ParseUsersMetrics`,
-    which is unchanged; the projection re-emits exactly this layout.
-  - Same `tres-alloc` rationale as accounts (issue #35).
+- Lines with RawShares=parent are skipped: they inherit from the parent account.
+- Lines with an empty Account field are skipped.
+- User-level metrics require --collector.fairshare.user-metrics (default on).
 
----
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sshare_users.txt` | unrecorded | An account tree with both the parent rows that must be skipped and the user rows that must not. |
 
-## Versioned GPU test data
+### gpus_snapshot
 
-GPU sinfo output format varies between Slurm versions. Each subdirectory contains
-`sinfo_gpus_allocated.txt`, `sinfo_gpus_idle.txt`, and `sinfo_gpus_total.txt`:
+```sh
+sinfo -a -h '--Format=Nodes: ,StateLong: ,Gres: ,GresUsed:'
+```
 
-| Directory | Slurm version | Notes |
-|-----------|---------------|-------|
-| `slurm-20.11.8/` | 20.11.8 | Classic format |
-| `slurm-21.08.5/` | 21.08.5 | IDX format |
-| `slurm-23.11.10/` | 23.11.10 | |
-| `slurm-23.11.10-2/` | 23.11.10 patch 2 | |
-| `slurm-25.05/` | 25.05.x | `nvidia_gb200` GPU type; demonstrates column-overflow bug with 1056+ nodes and `--Format=Nodes: ,GresUsed:` |
-| `slurm-25.11.1-1/` | 25.11.1-1 | Latest; also contains partition test data |
+One consolidated snapshot (node count, state, total GRES and used GRES) from which total, allocated, idle and other GPUs are all derived. A single call removes the race between the three separate snapshots this replaced (issue #145).
+
+Owned by `gpus.go`.
+
+- The trailing colon on each field forces variable column widths; fixed widths silently truncate rich GRES specs on busy GPU nodes: multi-type GPUs, MIG slices (issue #10).
+- The per-version slurm-*/sinfo_gpus_{allocated,idle,total}.txt fixtures still back the version matrix in gpus_test.go, which exercises the individual GRES parsers across Slurm releases. splitGPUViews feeds those same parsers from this consolidated snapshot, so the version fixtures keep protecting the GRES parsing even though the three commands they were captured from are retired.
+- Coverage gap: the format of the command executed today, meaning four --Format fields in a given order plus the (null) path, is validated on a single Slurm version, while the retired commands are covered on six. See issue #195, gap A.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sinfo_gpus_snapshot.txt` | 25.05.3 | The four-column consolidated layout the collector parses today. |
+| `sinfo_gpus_total_long_gres.txt` | unrecorded | A GRES string long enough to be truncated by a fixed-width --Format, which is what the trailing colons exist to prevent (issue #10). |
+
+### node_detail
+
+```sh
+sinfo -h -N -O 'NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition:'
+```
+
+Per-node CPU and memory detail, one row per node.
+
+Owned by `node.go`.
+
+- The trailing colon on each field forces variable column widths. Without it node names longer than 20 characters — the default NodeList width — collide with the next column and produce fewer than six whitespace-separated tokens, silently dropping those nodes (issue #10).
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sinfo_mem.txt` | unrecorded | The nominal six-column per-node layout. |
+| `sinfo_default_partition.txt` | unrecorded | A node in the default partition, whose name carries the * marker that has to be stripped before it becomes a label value. |
+| `sinfo_long_names_fixed.txt` | unrecorded | A 25-character node name alongside short ones, in the variable-width output the trailing colons produce (_fixed meaning after the fix). Under the old fixed-width format that name collided with the next column and the node vanished from the metrics map; the regression net for issue #10. |
+
+### nodes_global
+
+```sh
+sinfo -h -o '%R|%D|%T|%b'
+```
+
+Node counts by partition, state and feature set, for every partition in one call. This replaced N per-partition calls (sinfo -p <partition>), cutting the RPC load on slurmctld on clusters with many partitions; the single-partition path was removed as unreachable in #100.
+
+Owned by `nodes.go`.
+
+**No fixture.** Still to do. test_data/sinfo.txt backed this command until d52d93f (#100, v1.8.4) deleted it, and nodes_test.go has worked on inline strings ever since. The most central command of the nodes collector has no captured cluster output at all. Capturing one is the first job of tools/fixture-capture.
+
+### scontrol_nodes
+
+```sh
+scontrol show nodes -o
+```
+
+Full node detail, one node per line. Read by two collectors — reservation_nodes for per-reservation node membership and state, nodes for the cluster-wide total — behind scontrolNodesCache, so the RPC is sent once per scrape rather than twice.
+
+Owned by `reservation_nodes.go`. Also read by `nodes.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `scontrol_nodes_reservation.txt` | unrecorded | Nodes carrying reservation membership, including the drained-but-up case that decides whether a reserved node counts as healthy. |
+
+### partitions_cpu
+
+```sh
+sinfo -h -o '%R,%C'
+```
+
+CPU states per partition.
+
+Owned by `partitions.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `slurm-25.11.1-1/sinfo_partitions_cpu.txt` | 25.11.1-1 | Per-partition A/I/O/T lines. |
+
+### partitions_gpu
+
+```sh
+sinfo -h '--Format=Nodes: ,Partition: ,Gres: ,GresUsed:' --state=idle,allocated
+```
+
+GPU totals and usage per partition, restricted to idle and allocated nodes.
+
+Owned by `partitions.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `slurm-25.11.1-1/sinfo_partitions_gpu.txt` | 25.11.1-1 | The nominal four-column per-partition GRES layout. |
+| `sinfo_partitions_gpu_long.txt` | unrecorded | GRES strings long enough to overflow a fixed-width column, the per-partition counterpart of the issue #10 trap. |
+
+### drain_reason
+
+```sh
+sinfo -h -N -o '%N|%E|%H|%T'
+```
+
+Drain or down reason per node, with the timestamp the state was set.
+
+Owned by `node_drain.go`.
+
+**No fixture.** Deliberate: the output depends entirely on which nodes happen to be drained when the capture is taken, so a capture would document one cluster's bad day rather than a format. The tests use inline inputs that pin the timestamp and reason shapes instead.
+
+### reservations
+
+```sh
+scontrol show reservation
+```
+
+Active reservation details as key=value blocks, one blank-line-separated block per reservation.
+
+Owned by `reservations.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sreservations.txt` | unrecorded | The nominal multi-reservation block layout. |
+| `sreservations_empty.txt` | unrecorded | What scontrol prints when no reservation exists, which is a sentence of prose rather than an empty file. The parser has to produce no metrics from it, rather than one bogus one. |
+| `sreservations_relative_time.txt` | unrecorded | Reservation timestamps in the relative form Slurm emits for near-term reservations, which the absolute-layout parser must not silently accept. |
+
+### licenses
+
+```sh
+scontrol show licenses -o
+```
+
+License total, used, free and reserved counts, one license per line.
+
+Owned by `licenses.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `slicense.txt` | unrecorded | Several licenses with distinct total/used/free splits. |
+
+### scheduler
+
+```sh
+sdiag
+```
+
+slurmctld internal scheduler statistics, including per-RPC counters.
+
+Owned by `scheduler.go`.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sdiag.txt` | unrecorded | The header counters (jobs submitted/started/completed/canceled/failed), the main schedule statistics block and the backfill block. It stops there: the Remote Procedure Call tables that scheduler.go also parses, per operation and per user, are absent from this capture, so the RPC metrics rest on TestSchedulerRPCLineRe_HyphenatedUsername alone: one inline line against one regexp, with no captured report behind them. |
+
+### binary_version
+
+```sh
+sinfo --version
+squeue --version
+sdiag --version
+scontrol --version
+sacct --version
+sbatch --version
+salloc --version
+srun --version
+```
+
+The version of each Slurm binary, probed once per process rather than on every scrape (issue #149): a Slurm upgrade under a running exporter is not a supported state, the process is restarted by whatever performed it.
+
+Owned by `slurm_binary_info.go`.
+
+- sinfo, squeue, sdiag, scontrol and sacct are required: a missing one is reported with version="not_found" and value 0 so operators can alert on it.
+- sbatch, salloc and srun are optional and emit nothing when absent. The exporter never invokes them, so requiring them would block monitoring-only deployments (issue #24).
+- sshare is executed by the fairshare collector but never version-probed.
+
+**No fixture.** Deliberate: the parser reads one field of a one-line output, and the value it reads is the Slurm version of whichever host runs the capture. A fixture would pin that host's version, not a format.
+
+### sacct_efficiency
+
+```sh
+sacct -P -n --starttime '<starttime>' --endtime '<endtime>' --format JobID,User,Account,AllocCPUS,Elapsed,TotalCPU,CPUTime,MaxRSS,ReqMem --state COMPLETED,FAILED,TIMEOUT,CANCELLED
+```
+
+Completed-job CPU and memory efficiency over the lookback window. Disabled by default because it queries SlurmDBD, which is expensive on a busy cluster; refreshed in the background on --collector.sacct.interval rather than on the scrape path.
+
+Owned by `sacct_efficiency.go`. Runs only with `--collector.sacct_efficiency`.
+
+- --endtime is mandatory: with --state and only --starttime, sacct returns no rows at all: Slurm bounds a state-filtered search to [starttime, endtime] and the default endtime does not cover the window. Without it the whole collector reported nothing, not just memory (issue #143).
+- No -X: MaxRSS is a step-level statistic and is empty on the allocation line, so the step lines (<jobid>.batch, <jobid>.0, …) are read and their peak MaxRSS attributed back to the job by JobID. JobID therefore leads --format.
+- Populating TotalCPU and MaxRSS requires a working JobAcctGatherType in slurm.conf.
+
+| Fixture | Slurm | What it protects |
+|---|---|---|
+| `sacct_efficiency.txt` | 25.11 | Allocation lines with their step lines, so the JobID correlation and the MaxRSS attribution are both exercised. The line format is a real capture; the MaxRSS values are representative rather than captured, because the containerised test cluster runs proctrack/linuxproc, which does not gather MaxRSS and leaves the column empty. A cluster with proctrack/cgroup fills it in exactly this shape (issue #143). |
+
+## Coverage gaps
+
+4 of the 17 commands run against no captured cluster output:
+
+| Command | Owned by | Why |
+|---|---|---|
+| [`queue_default_states`](#queue_default_states) | `queue.go` | Deliberate: the output is a subset of squeue.txt and the parser is the same one, so a second capture would protect nothing. What the flag changes is the query itself, which the contract test pins. |
+| [`nodes_global`](#nodes_global) | `nodes.go` | Still to do. test_data/sinfo.txt backed this command until d52d93f (#100, v1.8.4) deleted it, and nodes_test.go has worked on inline strings ever since. The most central command of the nodes collector has no captured cluster output at all. Capturing one is the first job of tools/fixture-capture. |
+| [`drain_reason`](#drain_reason) | `node_drain.go` | Deliberate: the output depends entirely on which nodes happen to be drained when the capture is taken, so a capture would document one cluster's bad day rather than a format. The tests use inline inputs that pin the timestamp and reason shapes instead. |
+| [`binary_version`](#binary_version) | `slurm_binary_info.go` | Deliberate: the parser reads one field of a one-line output, and the value it reads is the Slurm version of whichever host runs the capture. A fixture would pin that host's version, not a format. |
+
+## Versioned GPU fixtures
+
+GPU `sinfo` output changed shape between Slurm releases, so the GRES parsers
+are exercised against a matrix of captures rather than a single one. The
+matrix is discovered at run time by `gpus_test.go`, which asserts coverage in
+both directions: a declared version with no fixture fails, and a fixture no
+version claims fails too. That symmetry exists because the glob once resolved
+to a directory that did not exist, so every test body was skipped while the
+suite still reported a pass (#148, then #176 and #177).
+
+`Supported` follows the window in `CONTRIBUTING.md` § Releasing: the newest
+Slurm major plus the previous three. It rolls with every Slurm release, so a
+directory dropping out of the window is expected. Those captures are kept as
+free regression protection rather than as peers of the supported ones.
+
+| Directory | Slurm | Supported | Notes |
+|---|---|---|---|
+| `slurm-20.11.8/` | 20.11.8 | no (historical) | Classic GRES format. |
+| `slurm-21.08.5/` | 21.08.5 | no (historical) | IDX format. sinfo_gpus_allocated.txt is empty on purpose — a cluster with GPUs and none allocated — and gpus_test.go asserts a 0 result rather than skipping the case. |
+| `slurm-23.11.10/` | 23.11.10 | no (historical) | No idle fixture. The file was a two-column capture where IdleGPUsData emits three, so the idle and other counts derived from it were artefacts of the malformation; #177 deleted it. It cannot be recaptured — 23.11.10 is no longer published upstream — and the real three-column idle format is already covered by 23.11.10-2, so the gap is marked with idleUncovered in gpus_test.go rather than filled. |
+| `slurm-23.11.10-2/` | 23.11.10 patch 2 | no (historical) | — |
+| `slurm-25.05/` | 25.05.x | yes | nvidia_gb200 GPU type on a large machine: 1058 nodes on the total line, 1056 on the allocated one. Four-digit node counts are what overflow a fixed-width Nodes: column, so this is the capture that shows why the --Format fields end with colons. |
+| `slurm-25.11.1-1/` | 25.11.1-1 | yes | Also carries the per-partition CPU and GPU captures. |
+

--- a/tools/gen-fixture-doc/main.go
+++ b/tools/gen-fixture-doc/main.go
@@ -1,0 +1,296 @@
+// Command gen-fixture-doc regenerates test_data/readme.md from the command
+// registry in internal/collector.
+//
+// The readme used to be maintained by hand alongside the *Data() functions it
+// described, and drifted from them: a fixed-width sinfo format the code had
+// abandoned, a fixture deleted two releases earlier, a missing mandatory sacct
+// flag (issue #195). Generating it removes the copy. The registry is checked
+// against the real collectors by command_registry_test.go, and this file is
+// checked against the registry by CI.
+//
+// Usage:
+//
+//	go generate ./...          # from anywhere in the module
+//	go run ./tools/gen-fixture-doc -out test_data/readme.md
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sckyzo/slurm_exporter/internal/collector"
+)
+
+func main() {
+	out := flag.String("out", "test_data/readme.md", "path of the readme to write")
+	check := flag.Bool("check", false, "exit non-zero if the file on disk is stale, write nothing")
+	flag.Parse()
+
+	want := render()
+
+	if *check {
+		got, err := os.ReadFile(*out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gen-fixture-doc: %v\n", err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(got, want) {
+			fmt.Fprintf(os.Stderr,
+				"gen-fixture-doc: %s is stale.\nRun `make generate` (or `go generate ./...`) and commit the result.\n", *out)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := os.WriteFile(*out, want, 0o644); err != nil { //nolint:gosec // G306: documentation, world-readable on purpose
+		fmt.Fprintf(os.Stderr, "gen-fixture-doc: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// render builds the whole readme. Output is a pure function of the registry:
+// no map iteration, no timestamps, no host data, so regenerating on an
+// unchanged registry produces a byte-identical file and `git diff` stays a
+// reliable staleness signal.
+func render() []byte {
+	var b strings.Builder
+
+	// Written line by line rather than as one raw string: the prose is full of
+	// markdown code spans, and a backtick cannot appear inside a Go raw string.
+	writeLines(&b,
+		"<!--",
+		"GENERATED FILE. DO NOT EDIT.",
+		"",
+		"Source of truth: internal/collector/command_registry.go",
+		"Regenerate with:  make generate   (or: go generate ./...)",
+		"",
+		"Editing this file by hand is pointless: CI regenerates it and fails on the diff.",
+		"Change the registry instead. command_registry_test.go then proves that the",
+		"registry still matches what the collectors actually run.",
+		"-->",
+		"",
+		"# Slurm commands used by slurm_exporter",
+		"",
+		"Every Slurm CLI invocation the exporter makes, and the fixture under `test_data/`",
+		"that protects it.",
+		"",
+		"This mapping is derived from `internal/collector/command_registry.go`, which is",
+		"itself checked against the real collectors: `TestRegistryMatchesCollectors` invokes",
+		"each `*Data()` function with `Execute` stubbed and compares what it genuinely",
+		"passes to what the table declares. A command cannot change without this file",
+		"changing with it.",
+		"",
+		"All fixtures are anonymised: cluster, node, user, account and reservation names",
+		"are replaced with generic equivalents. See `CONTRIBUTING.md` § Test Data.",
+		"",
+		"",
+	)
+
+	renderIndex(&b)
+	renderCommands(&b)
+	renderCoverage(&b)
+	renderFixtureDirs(&b)
+
+	return []byte(b.String())
+}
+
+// writeLines appends each line followed by a newline.
+func writeLines(b *strings.Builder, lines ...string) {
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+}
+
+func renderIndex(b *strings.Builder) {
+	b.WriteString("## Index\n\n")
+	b.WriteString("| Command | Binary | Owned by | Fixtures |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for i := range collector.CommandRegistry {
+		c := &collector.CommandRegistry[i]
+		binary := c.Binary
+		if len(c.EachBinary) > 0 {
+			binary = fmt.Sprintf("%d binaries", len(c.EachBinary))
+		}
+		fixtures := "none"
+		if n := len(c.Fixtures); n > 0 {
+			fixtures = fmt.Sprintf("%d", n)
+		}
+		fmt.Fprintf(b, "| [`%s`](#%s) | `%s` | `%s` | %s |\n",
+			c.Name, anchor(c.Name), binary, c.Source, fixtures)
+	}
+	b.WriteString("\n")
+}
+
+func renderCommands(b *strings.Builder) {
+	b.WriteString("## Commands\n")
+	for i := range collector.CommandRegistry {
+		c := &collector.CommandRegistry[i]
+		fmt.Fprintf(b, "\n### %s\n\n", c.Name)
+
+		b.WriteString("```sh\n")
+		for _, line := range commandLines(c) {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("```\n\n")
+
+		fmt.Fprintf(b, "%s\n\n", c.Doc)
+
+		fmt.Fprintf(b, "Owned by `%s`.", c.Source)
+		if len(c.Consumers) > 0 {
+			fmt.Fprintf(b, " Also read by %s.", codeList(c.Consumers))
+		}
+		if c.OptIn != "" {
+			fmt.Fprintf(b, " Runs only with `%s`.", c.OptIn)
+		}
+		b.WriteString("\n")
+
+		if len(c.Notes) > 0 {
+			b.WriteString("\n")
+			for _, n := range c.Notes {
+				fmt.Fprintf(b, "- %s\n", n)
+			}
+		}
+
+		if len(c.Fixtures) == 0 {
+			fmt.Fprintf(b, "\n**No fixture.** %s\n", c.NoFixtureReason)
+			continue
+		}
+
+		b.WriteString("\n| Fixture | Slurm | What it protects |\n")
+		b.WriteString("|---|---|---|\n")
+		for _, f := range c.Fixtures {
+			version := f.Slurm
+			if version == "" {
+				version = "unrecorded"
+			}
+			fmt.Fprintf(b, "| `%s` | %s | %s |\n", f.File, version, f.Why)
+		}
+	}
+	b.WriteString("\n")
+}
+
+// renderCoverage names the commands running against no captured output. Left
+// implicit, a gap reads as coverage, which is the habit #177 broke for the GPU
+// matrix.
+func renderCoverage(b *strings.Builder) {
+	var gaps []*collector.Command
+	for i := range collector.CommandRegistry {
+		if c := &collector.CommandRegistry[i]; len(c.Fixtures) == 0 {
+			gaps = append(gaps, c)
+		}
+	}
+
+	b.WriteString("## Coverage gaps\n\n")
+	if len(gaps) == 0 {
+		b.WriteString("Every command in the registry has at least one captured fixture.\n\n")
+		return
+	}
+
+	fmt.Fprintf(b, "%d of the %d commands run against no captured cluster output:\n\n",
+		len(gaps), len(collector.CommandRegistry))
+	b.WriteString("| Command | Owned by | Why |\n")
+	b.WriteString("|---|---|---|\n")
+	for _, c := range gaps {
+		fmt.Fprintf(b, "| [`%s`](#%s) | `%s` | %s |\n", c.Name, anchor(c.Name), c.Source, c.NoFixtureReason)
+	}
+	b.WriteString("\n")
+}
+
+func renderFixtureDirs(b *strings.Builder) {
+	b.WriteString("## Versioned GPU fixtures\n\n")
+	b.WriteString("GPU `sinfo` output changed shape between Slurm releases, so the GRES parsers\n")
+	b.WriteString("are exercised against a matrix of captures rather than a single one. The\n")
+	b.WriteString("matrix is discovered at run time by `gpus_test.go`, which asserts coverage in\n")
+	b.WriteString("both directions: a declared version with no fixture fails, and a fixture no\n")
+	b.WriteString("version claims fails too. That symmetry exists because the glob once resolved\n")
+	b.WriteString("to a directory that did not exist, so every test body was skipped while the\n")
+	b.WriteString("suite still reported a pass (#148, then #176 and #177).\n\n")
+	b.WriteString("`Supported` follows the window in `CONTRIBUTING.md` § Releasing: the newest\n")
+	b.WriteString("Slurm major plus the previous three. It rolls with every Slurm release, so a\n")
+	b.WriteString("directory dropping out of the window is expected. Those captures are kept as\n")
+	b.WriteString("free regression protection rather than as peers of the supported ones.\n\n")
+
+	b.WriteString("| Directory | Slurm | Supported | Notes |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, d := range collector.FixtureDirs {
+		supported := "no (historical)"
+		if d.Supported {
+			supported = "yes"
+		}
+		notes := d.Notes
+		if notes == "" {
+			notes = "—"
+		}
+		fmt.Fprintf(b, "| `%s/` | %s | %s | %s |\n", d.Path, d.Slurm, supported, notes)
+	}
+	b.WriteString("\n")
+}
+
+// commandLines renders one entry as copy-pasteable shell. An EachBinary entry
+// becomes one line per binary, because that is what the exporter runs.
+func commandLines(c *collector.Command) []string {
+	binaries := c.EachBinary
+	if len(binaries) == 0 {
+		binaries = []string{c.Binary}
+	}
+
+	args := make([]string, 0, len(c.Args))
+	for _, a := range c.Args {
+		args = append(args, shellQuote(placeholderLabel(c, a)))
+	}
+
+	lines := make([]string, 0, len(binaries))
+	for _, bin := range binaries {
+		lines = append(lines, strings.TrimSpace(bin+" "+strings.Join(args, " ")))
+	}
+	return lines
+}
+
+// placeholderLabel turns a registry token into something a reader understands.
+// The exact value is computed at call time, so the docs show its shape rather
+// than a captured instant.
+func placeholderLabel(c *collector.Command, arg string) string {
+	for _, p := range c.Placeholders {
+		if arg == p.Token {
+			return "<" + strings.Trim(p.Token, "{}") + ">"
+		}
+	}
+	return arg
+}
+
+// shellQuote quotes an argument only when a shell would otherwise mangle it.
+// Slurm format strings are full of characters that need it: spaces in
+// `--Format=Nodes: ,Gres:`, pipes in `%N|%E`, percent signs, parentheses.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t|*?%()$&;<>'\"\\`") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// codeList renders a slice as `a`, `b` and `c`.
+func codeList(items []string) string {
+	quoted := make([]string, len(items))
+	for i, s := range items {
+		quoted[i] = "`" + s + "`"
+	}
+	if len(quoted) == 1 {
+		return quoted[0]
+	}
+	return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
+}
+
+// anchor is the GitHub heading slug for a command name. Registry names are
+// lowercase words joined by underscores, which GitHub keeps verbatim, so a name
+// is its own anchor. TestRegistryEntriesAreWellFormed pins that alphabet, so a
+// name that would break these links fails there rather than producing a readme
+// with dead internal links.
+func anchor(name string) string { return name }


### PR DESCRIPTION
## Summary

- `test_data/readme.md` documented commands the code no longer runs. A static audit found 8 drifts; one of them cost a contributor real work on #29, which followed the documented fixed-width `sinfo -O` format that `node.go` abandoned when #10 was fixed. This PR removes the possibility of that drift rather than just correcting it.
- `internal/collector/command_registry.go` declares every Slurm CLI invocation once, with its fixtures and the reason each capture exists. `TestRegistryMatchesCollectors` invokes each entry through its real `*Data()` path behind a stubbed `Execute` and compares what the collector genuinely passes to what the table claims, so the table is a verified mirror rather than a fourth copy of the list.
- `tools/gen-fixture-doc` renders `test_data/readme.md` from that table. `make generate` rewrites it; `make generate-check` (part of `make check`) and the CI test job fail on a stale one instead of regenerating it silently.

This is phase 1 of the plan in #195. It changes no production code path, so it carries no regression risk: `CommandRegistry` has no runtime caller, only the test and the generator reference it.

## Test plan

- [x] `make check` (containerised vet + lint + tests + vuln + actionlint + zizmor + deadcode + generate-check) passes, exit 0
- [x] `make report` stays at grade A+ (99.26%, unchanged)
- [x] New behavior covered by a unit test
- [x] `make race` passes
- [ ] `make docker-build` — not touched
- [ ] `docs/metrics.md` — no metric added, renamed or removed
- [ ] `CHANGELOG.md` — the changelog is written at release time and has no `[Unreleased]` section; this will be folded into the v1.9 entry
- [ ] Manual validation on a real cluster — see "Notes for reviewers"

Both safety nets were mutation-tested rather than merely written: reintroducing drift 1 (the fixed-width `-O NodeList,AllocMem,…`) turns `TestRegistryMatchesCollectors` red with the registry/code diff printed, and dropping an unclaimed file into `test_data/` turns `TestEveryFixtureIsClaimed` red.

## Related issue

Refs: #195 (phase 1 of 4). Unblocks the next review round on #29.

## Notes for reviewers

**Deviation from the plan in the issue.** #195 proposed putting the table in `tools/fixture-capture/registry.go`. That does not work: the contract test has to reset `scontrolNodesCache` and `squeueJobsCache` between entries, otherwise whichever of `scontrol_nodes` and `squeue_jobs` runs second never reaches `Execute` and silently stops being checked. Those cache vars are unexported, so a table in `tools/` would need the test in `package collector_test`, which cannot touch them, and importing the other way round is a cycle. The table therefore lives in `internal/collector`, and `tools/` imports it. Phase 2's capture generator consumes the same table unchanged.

**Two coverage gaps found while recording provenance, neither in the original audit.**

1. `sdiag.txt` stops after the backfill block. The Remote Procedure Call tables that `scheduler.go` parses (`ParseRPCStats`, per operation and per user) have no captured report behind them at all; the RPC metrics rest on `TestSchedulerRPCLineRe_HyphenatedUsername` alone, one inline line against one regexp.
2. `NodesDataGlobal` (`sinfo -h -o "%R|%D|%T|%b"`) has had no fixture since `d52d93f` (#100) deleted `test_data/sinfo.txt`. The most central command of the `nodes` collector runs against inline strings only.

Both are now written into the registry and appear in the generated readme's coverage-gap section instead of waiting to be rediscovered.

**Definition of Done, steps 4-9.** This touches `internal/collector/`, so the letter of CONTRIBUTING asks for the integration cluster. Nothing in the exporter's runtime path changed, and the grep backing that claim is in the summary above, so I did not run it. Say the word if you would rather have it anyway.

**What phase 1 deliberately leaves out.** Having the collectors read their arguments *from* the table is a sweep across 16 files. It should only be considered once the table has proven itself as a verified mirror, and never while a collector PR (#29) is open.
