### PR TITLE
fix(drain_reason): stop hiding the nodes slurmctld downed for silence (#198)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -373,6 +373,13 @@ and why:
   * on(node) group_left(reason) slurm_node_drain_reason_info
 ```
 
+A node is reported whenever Slurm gives it a reason, including the ones
+`slurmctld` writes itself rather than an operator. `Not responding`, set when the
+controller loses contact with a node, is the common one: it is the only place the
+difference between an unreachable node and an admin-drained one shows up. Only
+the empty reasons are skipped (`none`, `unknown`, or a blank field), since Slurm
+prints those for every healthy node.
+
 `slurm_node_drain_since_timestamp_seconds` is absent for a node whose reason
 carries no timestamp, rather than zero, so the subtraction above never reports a
 drain that started in 1970. The exporter pins `SLURM_TIME_FORMAT=standard` on

--- a/internal/collector/node_drain.go
+++ b/internal/collector/node_drain.go
@@ -50,7 +50,8 @@ func drainTimeIsUnset(since string) bool {
 }
 
 // ParseDrainReasonMetrics parses "sinfo -h -N -o '%N|%E|%H|%T'" output.
-// Only nodes with a non-empty, non-"none" reason are returned.
+// Nodes whose reason is empty, "none" or "unknown" are skipped; every other
+// reason is returned, including the ones slurmctld sets itself (issue #198).
 func ParseDrainReasonMetrics(input []byte) []DrainReasonMetrics {
 	var results []DrainReasonMetrics
 	seen := make(map[string]bool) // deduplicate by node (node can appear in multiple partitions)
@@ -68,8 +69,18 @@ func ParseDrainReasonMetrics(input []byte) []DrainReasonMetrics {
 		since := strings.TrimSpace(fields[2])
 		state := strings.TrimSpace(fields[3])
 
+		// Drop the rows that carry no information. sinfo prints "none" or
+		// "unknown" for every healthy node, so exporting them would publish one
+		// series per node in the cluster to say nothing.
+		//
+		// "not responding" is deliberately NOT in this list. slurmctld writes it
+		// itself when it loses contact with a node, which makes it the opposite
+		// of empty: it is the only place the difference between an unreachable
+		// node and an admin-drained one shows up. Filtering it meant a node
+		// slurmctld had downed produced no series at all, which is exactly the
+		// case an operator wants to alert on (issue #198).
 		reasonLower := strings.ToLower(reason)
-		if node == "" || reason == "" || reasonLower == "none" || reasonLower == "not responding" || reasonLower == "unknown" {
+		if node == "" || reason == "" || reasonLower == "none" || reasonLower == "unknown" {
 			continue
 		}
 		// Only interested in degraded node states
@@ -114,7 +125,9 @@ func NewDrainReasonCollector(log *logger.Logger) *DrainReasonCollector {
 	return &DrainReasonCollector{
 		info: prometheus.NewDesc(
 			"slurm_node_drain_reason_info",
-			"Information about why a node is in drain or down state. "+
+			"Information about why a node is in a drain or down state, including "+
+				"the reasons slurmctld sets itself such as \"Not responding\". Nodes "+
+				"whose reason is empty, \"none\" or \"unknown\" produce no series. "+
 				"Always 1; the reason label carries the text and "+
 				"slurm_node_drain_since_timestamp_seconds carries the time it was set.",
 			[]string{"node", "reason"},

--- a/internal/collector/node_drain_not_responding_test.go
+++ b/internal/collector/node_drain_not_responding_test.go
@@ -1,0 +1,50 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseDrainReasonNotResponding is the non-regression test for issue #198.
+//
+// slurmctld sets Reason="Not responding" itself when it loses contact with a
+// node, and the parser used to drop that row alongside the genuinely empty
+// "none" and "unknown". The node went down, the reason existed, and
+// slurm_node_drain_reason_info stayed silent about it — the one case the
+// reporter needed it for.
+//
+// The fixture is the sinfo -h -N -o "%N|%E|%H|%T" rendering of the node in the
+// report: State=DOWN+NOT_RESPONDING, which sinfo prints as "down*".
+func TestParseDrainReasonNotResponding(t *testing.T) {
+	input := []byte(
+		"gpu02|Not responding|2026-07-25T11:54:03|down*\n" +
+			"gpu03|Not responding|2026-07-25T11:54:03|down\n")
+
+	got := ParseDrainReasonMetrics(input)
+
+	require.Len(t, got, 2, "a node slurmctld downed for not responding must be reported")
+	require.Equal(t, "gpu02", got[0].Node)
+	require.Equal(t, "Not responding", got[0].Reason,
+		"the reason text is the only place the distinction between an unreachable node "+
+			"and an admin-drained one shows up")
+	require.Equal(t, unixLocal(t, "2026-07-25T11:54:03"), got[0].SinceUnix)
+	require.Equal(t, "gpu03", got[1].Node)
+}
+
+// TestParseDrainReasonEmptyReasons pins the rows that stay filtered. These carry
+// no information: sinfo prints them for every healthy node, so exporting them
+// would publish one series per node in the cluster to say nothing.
+func TestParseDrainReasonEmptyReasons(t *testing.T) {
+	input := []byte(
+		"c1|none|Unknown|idle\n" +
+			"c2|None|Unknown|down\n" +
+			"c3|Unknown|Unknown|down\n" +
+			"c4||Unknown|down\n" +
+			"c5|Hardware fault|2026-07-25T11:54:03|down\n")
+
+	got := ParseDrainReasonMetrics(input)
+
+	require.Len(t, got, 1, "only the node with a real reason is exported")
+	require.Equal(t, "c5", got[0].Node)
+}

--- a/internal/collector/node_drain_test.go
+++ b/internal/collector/node_drain_test.go
@@ -24,8 +24,12 @@ c5|not responding|2026-04-01T11:00:00|down
 	// c2 down with reason → included
 	// c3 reason="none" → excluded
 	// c4 empty reason → excluded
-	// c5 "not responding" → excluded (built-in Slurm reason, not admin-set)
-	require.Len(t, metrics, 2)
+	// c5 "not responding" → included since #198. v1.8 excluded it on the
+	// grounds that Slurm sets it rather than an admin, which turned out to be
+	// the wrong test: what matters is whether the reason carries information,
+	// not who wrote it. A node slurmctld downed for silence produced no series
+	// at all, so the metric was silent about the outage it exists to describe.
+	require.Len(t, metrics, 3)
 
 	nodes := make(map[string]DrainReasonMetrics)
 	for _, m := range metrics {


### PR DESCRIPTION
## Summary

- `slurm_node_drain_reason_info` dropped any row whose reason was `not responding`, alongside the genuinely empty `none` and `unknown`. `slurmctld` writes that reason itself when it loses contact with a node, so a node the controller had downed produced **no series at all**.
- The reporter read it as a missing DOWN state. It was not: `nodeStateDown` is `^down` and already matched their `down*`. The reason blocklist in `node_drain.go` was what filtered the row.
- Only the empty reasons stay filtered. Slurm prints those for every healthy node, so exporting them would publish one series per node to say nothing.

## This reverses a deliberate v1.8 choice

The original test spelled the intent out: `c5 "not responding" → excluded (built-in Slurm reason, not admin-set)`. The distinction it drew — who wrote the reason — turned out to be the wrong test. What matters is whether the reason carries information, and `not responding` is the only place the difference between an unreachable node and an admin-drained one shows up.

Worth flagging for the next release notes rather than leaving in a commit body.

## Operator-visible impact

Nodes down for not responding start producing a `slurm_node_drain_reason_info` series where they produced none. Any alert counting that metric will see them. Cardinality is unchanged in shape, still bounded by the node count.

## Test plan

- [x] `TestParseDrainReasonNotResponding` — new, fails before the change and passes after, on the exact `sinfo` rendering of the reported node
- [x] `TestParseDrainReasonEmptyReasons` — new, pins the rows that must stay filtered so this does not drift into exporting one series per healthy node
- [x] `TestParseDrainReasonMetrics_Basic` — updated to the new intent, with the reasoning in place of the old comment
- [x] `make check` passes, `golangci-lint` at 0 issues
- [x] `docs/metrics.md` updated in lockstep
- [ ] `CHANGELOG.md` — written at release time, no `[Unreleased]` section

## Related issue

Fixes #198.

## Notes for reviewers

The help text claimed to cover "drain or down state" and said nothing about the dropped reasons, which is what sent the reporter looking at the state filter instead of the blocklist. It now names which reasons produce no series.

I asked the reporter whether `not responding` is signal or noise on their cluster before writing this. Should they come back preferring it filtered, the natural follow-up is a configurable blocklist rather than a revert, though I would rather not add a flag for something most sites would never touch.
