### PR TITLE
feat(testing): add fake GPU workers so the cluster can produce GPU output

### DIFF
--- a/scripts/testing/Makefile
+++ b/scripts/testing/Makefile
@@ -117,6 +117,24 @@ workload:
 workload-gpu:
 	@$(LIB) workload-gpu
 
+# Fake GPU nodes: no NVIDIA hardware required. A dynamic slurmd declares its own
+# GRES against device nodes created in the container, so the cluster can produce
+# GPU output — including several GPU models at once, which no single-model
+# production cluster can.
+#   make gpu-workers            10 nodes: 4 model_a, 4 model_b, 2 carrying both
+#   make gpu-workers GPU_N=4    fewer
+#
+# Deliberately not N: that one already means "how many jobs" for the workload
+# target (N ?= 30 above), and reusing it made `make gpu-workers` quietly start
+# thirty nodes.
+GPU_N ?= 10
+.PHONY: gpu-workers gpu-workers-down
+gpu-workers:
+	@$(LIB) gpu-workers $(GPU_N)
+
+gpu-workers-down:
+	@$(LIB) gpu-workers-down
+
 
 # scancel --state takes one value: passing it twice cancelled RUNNING only and
 # left the pending jobs in place, silently (#167).

--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -80,6 +80,8 @@ make screenshots          Take Grafana dashboard screenshots
 make node-fail            Set 1-2 random nodes to down/drain
 make node-restore         Restore all degraded nodes
 make workload-gpu         Submit GPU jobs (requires GRES)
+make gpu-workers          Add 10 fake GPU nodes, two models, no hardware
+make gpu-workers-down     Remove them, node records included
 make cancel-all           Cancel all running/pending jobs
 make redeploy             Rebuild exporter + reimport dashboards
 make redeploy-dashboards  Reimport dashboards only
@@ -183,22 +185,53 @@ not through file provisioning — so they always reflect the latest JSON files.
 
 ---
 
-## GPU Support
-
-To test GPU metrics without real hardware, configure fake GRES resources
-in the running cluster:
+## GPU nodes, without a GPU
 
 ```bash
-docker exec slurmctld bash -c "
-grep -q GresTypes /etc/slurm/slurm.conf || echo 'GresTypes=gpu' >> /etc/slurm/slurm.conf
-cat > /etc/slurm/gres.conf << 'GRES'
-NodeName=c[1-2] Name=gpu Type=a100 File=/dev/null Count=2
-NodeName=c[3-4] Name=gpu Type=v100 File=/dev/null Count=4
-GRES
-scontrol reconfigure
-"
-make workload-gpu
+make gpu-workers            # 10 nodes: 4 model_a, 4 model_b, 2 carrying both
+make gpu-workers GPU_N=4    # fewer
+make gpu-workers-down       # remove them
+make workload-gpu           # submit jobs that request GPUs
 ```
+
+No NVIDIA hardware, no `nvidia-container-toolkit`, no change to the cluster
+clone. A dynamic `slurmd` (`-Z`) declares its own resources when it registers,
+and Slurm treats a GRES backed by an ordinary device node exactly like one
+backed by a real card.
+
+The layout is deliberate. Homogeneous nodes are what a site actually buys, so
+eight of the ten carry a single model; mixed-model nodes produce the GRES string
+that breaks naive parsers (`gpu:model_a:2,gpu:model_b:2` with a separate index
+list per model), so two of them carry both. One cluster covers the common case
+and the awkward one, and gives per-model aggregates that mean something:
+
+```
+gpu:model_a   total=20  used=8
+gpu:model_b   total=20  used=2
+```
+
+That is the question `slurm_node_gres_*` exists to answer — one model saturated
+while the other idles — and neither `slurm_gpus_*` (no labels) nor
+`slurm_partition_gpus_*` (stops at the partition) can express it.
+
+Four details are load-bearing, each of them a failure that was hit while
+building this:
+
+- **`--privileged --cgroupns private`**, or slurmd exits on `Unable to
+  initialize cgroup plugin` before it ever registers.
+- **`File=` is mandatory for a gpu-typed GRES**, one device per card. Without it
+  slurmd logs `Ignoring file-less GPU ... from final GRES list`, the resource
+  never reaches the usable list, and the node lands in `inval`.
+- **`/etc/slurm` is shared with the whole cluster.** Each fake node writes its
+  own `gres.conf` under a private `SLURM_CONF`; editing the shared volume would
+  reconfigure every other node and outlive the run.
+- **slurmctld remembers dynamic nodes.** `make gpu-workers-down` deletes the
+  node records as well as the containers, discovering them from `sinfo` rather
+  than assuming a range, so shrinking the cluster does not leave ghost nodes
+  still advertising GPUs.
+
+Captures taken this way live under `test_data/slurm-<version>/` like any other
+fixture, and are real `sinfo` output rather than hand-written lines.
 
 ---
 

--- a/scripts/testing/_lib.sh
+++ b/scripts/testing/_lib.sh
@@ -476,6 +476,11 @@ cmd_logs() {
 }
 
 # ── Dispatch ──────────────────────────────────────────────────────────────────
+# Fake GPU workers live in their own file: the recipe is long and its four
+# gotchas need explaining, and none of it is needed by any other target.
+# shellcheck source=fake-gpu-workers.sh
+source "$SCRIPT_DIR/fake-gpu-workers.sh"
+
 CMD="${1:-help}"
 case "$CMD" in
     check-deps)         cmd_check_deps ;;
@@ -505,6 +510,8 @@ case "$CMD" in
     node-fail)          cmd_node_fail ;;
     node-restore)       cmd_node_restore ;;
     workload-gpu)       cmd_workload_gpu ;;
+    gpu-workers)        cmd_gpu_workers_up "${2:-10}" ;;
+    gpu-workers-down)   cmd_gpu_workers_down ;;
     stop)               cmd_stop ;;
     clean)              cmd_clean ;;
     start)              cmd_start ;;

--- a/scripts/testing/fake-gpu-workers.sh
+++ b/scripts/testing/fake-gpu-workers.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Fake GPU workers for the integration cluster.
+#
+# The upstream clone can start GPU workers, but only against real NVIDIA
+# hardware: its entrypoint counts /dev/nvidia* and gres.conf uses AutoDetect=nvml.
+# That left every GPU-shaped capture depending on a production cluster, which
+# also happened to be single-model — so the shape that matters most to the
+# per-node GRES metrics, several GPU models on one cluster, could not be produced
+# at all.
+#
+# It can be. A dynamic slurmd (-Z) declares its own resources at registration,
+# and Slurm treats a GRES backed by an ordinary device node exactly like one
+# backed by a real card. Nothing here needs a GPU, nvidia-container-toolkit, or
+# a change to the clone's tracked files.
+#
+# Four things have to be right, each of them learned the hard way:
+#
+#   1. --privileged and --cgroupns private, or slurmd dies on "Unable to
+#      initialize cgroup plugin" before it ever registers.
+#   2. File= is mandatory for a gpu-typed GRES. Without it slurmd logs
+#      "Ignoring file-less GPU ... from final GRES list", the resource never
+#      reaches the usable list, and the node lands in inval.
+#   3. /etc/slurm is a volume shared with the whole cluster and carries its own
+#      gres.conf (AutoDetect=nvml, Type=nvidia). The node needs a private
+#      SLURM_CONF instead; editing the shared volume would reconfigure every
+#      other node.
+#   4. slurmctld remembers a dynamic node across restarts, so changing a node's
+#      GRES means deleting it first. Cleanup below does that.
+#
+# Layout: homogeneous nodes are what a real site buys, mixed-model nodes are what
+# breaks parsers. This makes both, so one cluster covers the common case and the
+# awkward one.
+
+# Sourced by _lib.sh before its command dispatch. Not executable on its own: it
+# relies on _lib.sh for cluster.conf, the colour helpers and slurm().
+
+GPU_NETWORK="${COMPOSE_PROJECT_NAME:-slurm}_slurm-network"
+GPU_IMAGE="slurm-docker-cluster:${SLURM_VERSION}"
+GPU_NAME_PREFIX="slurm-fake-gpu"
+
+# Node layout: <count>:<gres spec>:<gres.conf lines, ; separated>
+# GPUs per node is 4 throughout, so a mixed node splits its four devices two and
+# two rather than pretending to hold more cards than its homogeneous neighbours.
+GPU_MODEL_A="${GPU_MODEL_A:-model_a}"
+GPU_MODEL_B="${GPU_MODEL_B:-model_b}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# gpu_node_spec prints "gres_spec|gres_conf" for the Nth node of a 4+4+2 layout.
+gpu_node_spec() {
+    local n=$1
+    if [ "$n" -le 4 ]; then
+        printf '%s|%s' \
+            "gpu:${GPU_MODEL_A}:4" \
+            "Name=gpu Type=${GPU_MODEL_A} File=/dev/nvidia[0-3]"
+    elif [ "$n" -le 8 ]; then
+        printf '%s|%s' \
+            "gpu:${GPU_MODEL_B}:4" \
+            "Name=gpu Type=${GPU_MODEL_B} File=/dev/nvidia[0-3]"
+    else
+        printf '%s|%s' \
+            "gpu:${GPU_MODEL_A}:2,gpu:${GPU_MODEL_B}:2" \
+            "Name=gpu Type=${GPU_MODEL_A} File=/dev/nvidia[0-1]
+Name=gpu Type=${GPU_MODEL_B} File=/dev/nvidia[2-3]"
+    fi
+}
+
+gpu_container_names() {
+    docker ps -a --filter "name=^${GPU_NAME_PREFIX}-" --format '{{.Names}}' 2>/dev/null || true
+}
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+cmd_gpu_workers_up() {
+    local count="${1:-10}"
+
+    docker network inspect "$GPU_NETWORK" >/dev/null 2>&1 ||
+        die "network $GPU_NETWORK not found — start the cluster first (make setup)"
+    docker image inspect "$GPU_IMAGE" >/dev/null 2>&1 ||
+        die "image $GPU_IMAGE not found — run make setup first"
+
+    step "1/3" "Removing any previous fake GPU workers..."
+    cmd_gpu_workers_down >/dev/null
+
+    step "2/3" "Starting $count fake GPU workers..."
+    local i spec gres gres_conf name
+    for i in $(seq 1 "$count"); do
+        spec="$(gpu_node_spec "$i")"
+        gres="${spec%%|*}"
+        gres_conf="${spec#*|}"
+        name="${GPU_NAME_PREFIX}-${i}"
+
+        docker run -d --name "$name" --hostname "g${i}" \
+            --network "$GPU_NETWORK" --privileged --cgroupns private \
+            -v "${COMPOSE_PROJECT_NAME:-slurm}_etc_slurm:/etc/slurm:ro" \
+            -v "${COMPOSE_PROJECT_NAME:-slurm}_etc_munge:/etc/munge" \
+            -v "${COMPOSE_PROJECT_NAME:-slurm}_slurm_jobdir:/data" \
+            -v "${COMPOSE_PROJECT_NAME:-slurm}_var_log_slurm:/var/log/slurm" \
+            --entrypoint sh "$GPU_IMAGE" -c "
+                set -e
+                # Character devices under major 195, the NVIDIA major. mknod can
+                # fail on some storage drivers; a plain file satisfies Slurm's
+                # File= just as well, it only checks the path resolves.
+                for d in 0 1 2 3; do
+                    mknod /dev/nvidia\$d c 195 \$d 2>/dev/null || touch /dev/nvidia\$d
+                done
+                mkdir -p /tmp/sc && cp /etc/slurm/*.conf /tmp/sc/ 2>/dev/null || true
+                cat > /tmp/sc/gres.conf <<'GRESEOF'
+${gres_conf}
+GRESEOF
+                until 2>/dev/null >/dev/tcp/slurmctld/6817; do sleep 2; done
+                /usr/sbin/munged --force >/dev/null 2>&1 || true
+                sleep 2
+                export SLURM_CONF=/tmp/sc/slurm.conf
+                exec /usr/sbin/slurmd -Z -D --conf \"Feature=gpu Gres=${gres}\"
+            " >/dev/null || die "failed to start $name"
+    done
+
+    step "3/3" "Waiting for registration..."
+    local waited=0 registered=0
+    while [ "$waited" -lt 90 ]; do
+        registered=$(slurm sinfo -h -N -o "%N" 2>/dev/null | grep -c '^g[0-9]' || true)
+        [ "$registered" -ge "$count" ] && break
+        sleep 3
+        waited=$((waited + 3))
+    done
+
+    # A node that ever registered without usable GRES stays drained with
+    # "gres/gpu count reported lower than configured". Resuming is safe here:
+    # these nodes are disposable and were just created.
+    for i in $(seq 1 "$count"); do
+        slurm scontrol update "NodeName=g${i}" State=RESUME >/dev/null 2>&1 || true
+    done
+    sleep 3
+
+    if [ "$registered" -lt "$count" ]; then
+        warn "only $registered/$count GPU nodes registered — check: docker logs ${GPU_NAME_PREFIX}-1"
+    else
+        ok "$count fake GPU nodes registered (${GPU_MODEL_A} / ${GPU_MODEL_B})"
+    fi
+    slurm sinfo -h -N -o "%N %T %G" | grep '^g[0-9]' || true
+}
+
+cmd_gpu_workers_down() {
+    local names
+    names="$(gpu_container_names)"
+    if [ -n "$names" ]; then
+        # shellcheck disable=SC2086
+        docker rm -f $names >/dev/null 2>&1 || true
+    fi
+    # Delete the dynamic node records too: slurmctld keeps them, and a stale
+    # record with the old GRES would shadow a node relaunched with a new layout
+    # — a ghost node that still reports GPUs nothing is running on.
+    #
+    # The list is discovered rather than assumed. A fixed range only cleans up
+    # what the current layout would have created, so shrinking the cluster left
+    # the extra nodes behind, still advertising their GRES.
+    local node
+    for node in $(slurm sinfo -h -N -o "%N" 2>/dev/null | grep -E '^g[0-9]+$' | sort -u); do
+        slurm scontrol delete "NodeName=${node}" >/dev/null 2>&1 || true
+    done
+    ok "fake GPU workers removed"
+}

--- a/scripts/testing/monitoring/docker-compose.monitoring.yml
+++ b/scripts/testing/monitoring/docker-compose.monitoring.yml
@@ -29,7 +29,14 @@ services:
       # not file provisioning; the landing page is set with /api/org/preferences.
       # A provisioned home-dashboard path reintroduces the stale-copy race (#156).
     volumes:
-      - grafana_data:/var/lib/grafana
+      # No named volume on purpose. Grafana stays on :latest so dashboards are
+      # authored against the current release, and a floating tag over a
+      # persistent database is how a major bump corrupts it — the trap #187 hit
+      # with MariaDB. Nothing here is worth keeping: dashboards are imported
+      # through the API on every setup, not provisioned, so a fresh container
+      # starts clean and a stale dashboard from a previous run cannot linger
+      # (#156). Grafana's own filesystem holds the state for the container's
+      # lifetime, which is all a test run needs.
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
       - "3000:3000"
@@ -40,8 +47,10 @@ services:
     restart: unless-stopped
 
 volumes:
+  # prometheus_data is kept: the TSDB is worth having across a stop/start within
+  # a session, and Prometheus on :latest carries no dashboard-authoring reason to
+  # float, so a future break there is a pin away rather than a redesign.
   prometheus_data:
-  grafana_data:
 
 networks:
   slurm-network:


### PR DESCRIPTION
## Summary

- Every GPU-shaped fixture depended on a production cluster. The clone can start GPU workers, but only against real NVIDIA hardware (`AutoDetect=nvml`, entrypoint counting `/dev/nvidia*`), and the production cluster available here is single-model — so **several GPU models on one cluster, the shape that matters most to the per-node GRES metrics, could not be produced at all**.
- `make gpu-workers` adds 10 GPU nodes with no hardware. A dynamic `slurmd` (`-Z`) declares its own resources at registration, and Slurm treats a GRES backed by an ordinary device node exactly like one backed by a real card.
- Grafana's named volume is dropped, as discussed: it stays on `:latest` on purpose, and a floating tag over a persistent database is exactly how #187's MariaDB break happened.

```
make gpu-workers          10 nodes: 4 model_a, 4 model_b, 2 carrying both
make gpu-workers GPU_N=4  fewer
make gpu-workers-down     remove them, node records included
```

## Verified end to end, not just written

10 CPU nodes in `cpu*`, 10 GPU nodes in `gpu`, with two jobs holding GPUs:

```
gpu:model_a   total=20  used=8
gpu:model_b   total=20  used=2
slurm_gpus_total 40   slurm_gpus_alloc 10   slurm_gpus_idle 30
```

One model at 40% while the other sits at 10%, on the same cluster. That is the question `slurm_node_gres_*` exists to answer, and neither `slurm_gpus_*` (no labels) nor `slurm_partition_gpus_*` (stops at the partition) can express it.

The layout is not arbitrary: homogeneous nodes are what a site actually buys, so eight carry a single model; mixed-model nodes produce the GRES string that breaks naive parsers, so two carry both.

## Four details that are load-bearing

Each was a failure hit while building this, and each is commented where it matters:

1. `--privileged --cgroupns private`, or slurmd exits on `Unable to initialize cgroup plugin` before it ever registers.
2. `File=` is mandatory for a gpu-typed GRES, one device per card. Without it: `Ignoring file-less GPU ... from final GRES list`, and the node lands in `inval`.
3. `/etc/slurm` is a volume shared with the whole cluster. Each fake node writes its own `gres.conf` under a private `SLURM_CONF`; editing the shared volume reconfigures every other node and outlives the run.
4. slurmctld remembers dynamic nodes, so teardown deletes the node records too.

## Two bugs of my own, caught by running it

**Teardown assumed a range.** Deleting `g1..g20` only cleans up what the current layout would have created, so shrinking the cluster left ghost nodes still advertising GPUs. The first run left ten of them. It now discovers the records from `sinfo`.

**`N` was already taken.** `N ?= 30` means "how many jobs" for the workload target, so `make gpu-workers` quietly started thirty nodes. The variable is `GPU_N`.

## The README's manual recipe is replaced

The previous one edited the shared `/etc/slurm/gres.conf` (reconfiguring every other node, persistently), pointed several GPUs at a single `File=/dev/null`, and targeted static node names `c[1-2]` on a cluster whose workers are dynamic.

## Grafana volume

Dropped the named volume, kept `:latest`. Nothing in it is worth preserving — dashboards are imported through the API on every setup, not provisioned — so a fresh container starts clean, a major bump cannot corrupt a database written by the previous version, and a stale dashboard from an earlier run cannot linger (#156). `prometheus_data` is kept: the TSDB is worth having across a stop/start, and Prometheus has no dashboard-authoring reason to float, so a break there is a pin away rather than a redesign.

Verified: `make setup` still reports `10 dashboards imported, 0 failed`, and the Grafana container now mounts only the read-only provisioning bind.

## Test plan

- [x] `make gpu-workers` on a live cluster: 10/10 registered, layout as designed
- [x] GPU jobs scheduled against both models, per-model totals and usage correct
- [x] `make gpu-workers-down` leaves zero `g*` nodes behind
- [x] `make setup` unaffected by the Grafana change
- [x] `bash -n` on both scripts; Go suite untouched and green
- [ ] `golangci-lint` — no Go changed

## Related

Refs #195: this closes the gap A dependency on a production cluster, and combined with #189 makes multi-version GPU captures reproducible locally, which is gap B.
