### PR TITLE
feat(tools): generate the cluster fixture-capture script from the registry (#195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       # test_data/readme.md is generated from the command registry in
       # internal/collector. Regenerating it here would hide the drift; failing
       # is the point (issue #195).
-      - name: Derived docs are current
-        run: go run ./tools/gen-fixture-doc -check
+      - name: Derived docs and capture script are current
+        run: |
+          go run ./tools/gen-fixture-doc -check
+          go run ./tools/fixture-capture -check
       - name: Test (race + coverage)
         run: go test -race -count=1 -coverprofile=coverage.out ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,35 @@ All fixtures in `test_data/` must be anonymized:
 `make generate`, never the readme itself. `make check` and CI fail on a stale
 one, which is what stops the two from drifting apart again (issue #195).
 
+### Capturing fixtures from a cluster
+
+`scripts/capture.sh` collects every command in the registry and writes a tarball.
+It is generated from the same table, so it can only run commands the exporter
+runs, all of which are read-only.
+
+```sh
+scp scripts/capture.sh someone@login-node:
+ssh someone@login-node './capture.sh'            # add --with-sacct if you can spare SlurmDBD
+```
+
+**It anonymises on the cluster, before writing anything.** Node, user, account,
+reservation and GRES-model names are replaced there, and the mapping that would
+undo it stays behind — it is never in the tarball. That is what makes it safe to
+run on a production cluster and to ask a third party to run on theirs.
+
+The tarball carries a `provenance.txt` with the Slurm version, the date, and the
+exit status of every command, so a partial capture is visible rather than
+silent.
+
+Two rules when adding what comes back:
+
+- **Never re-anonymise an existing fixture.** Expected values in the tests are
+  tied to the current names; a fresh mapping would invalidate them everywhere at
+  once. New captures go into new files or new version directories.
+- **Record the Slurm version** in the registry entry's `Fixture.Slurm`. GRES and
+  timestamp formats have drifted between majors, and a fixture whose origin is
+  unknown cannot be reasoned about when one of them changes again.
+
 ---
 
 ## Performance Considerations

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ race: tools-image
 	@echo "Running tests with race detector (containerised)"
 	@$(IN_TOOLS) -c 'CGO_ENABLED=1 go test -race -count=1 ./...'
 
-# Regenerate the documentation derived from the command registry, currently
-# test_data/readme.md (in container). The registry in internal/collector is the
+# Regenerate everything derived from the command registry: test_data/readme.md
+# and scripts/capture.sh (in container). The registry in internal/collector is the
 # single source of truth for every Slurm CLI call the exporter makes; run this
 # after changing one.
 .PHONY: generate
@@ -121,7 +121,7 @@ generate: tools-image
 .PHONY: generate-check
 generate-check: tools-image
 	@echo "Checking derived docs are current (containerised)"
-	@$(IN_TOOLS) -c 'go run ./tools/gen-fixture-doc -check'
+	@$(IN_TOOLS) -c 'go run ./tools/gen-fixture-doc -check && go run ./tools/fixture-capture -check'
 
 # go vet (in container).
 .PHONY: vet

--- a/internal/collector/command_registry.go
+++ b/internal/collector/command_registry.go
@@ -124,6 +124,7 @@ var versionedBinaries = []string{
 // CommandRegistry lists every Slurm CLI invocation the exporter makes.
 //
 //go:generate go run ../../tools/gen-fixture-doc -out ../../test_data/readme.md
+//go:generate go run ../../tools/fixture-capture -out ../../scripts/capture.sh
 var CommandRegistry = []Command{
 	{
 		Name:   "squeue_jobs",

--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -1,0 +1,253 @@
+#!/bin/sh
+# GENERATED FILE. DO NOT EDIT.
+#
+# Source of truth: internal/collector/command_registry.go
+# Regenerate with:  make generate
+#
+# Collect Slurm fixtures for slurm_exporter, anonymised on this machine.
+#
+# What it does, and what it deliberately does not:
+#
+#   * Runs only the commands the exporter itself runs. The list is generated
+#     from the collector registry, so it cannot include a command the exporter
+#     does not use, and every one of them is read-only. There is no write
+#     command in the registry, so none can appear here.
+#   * Anonymises before writing anything. Node, user, account, reservation and
+#     GRES-model names are replaced on this machine; the tarball never contains
+#     them. That is what makes it safe to run on a production cluster and hand
+#     the result to someone else.
+#   * Records provenance: Slurm version, date, and the exit status of every
+#     command. A partial capture is visible rather than silent.
+#   * Leaves sacct alone unless asked. It queries SlurmDBD and is expensive on
+#     a busy cluster, so it is behind --with-sacct and bounded to one hour.
+#
+# Usage:  ./capture.sh [-o OUTDIR] [--with-sacct]
+
+set -eu
+
+OUTDIR=${OUTDIR:-slurm-fixtures-$(date +%Y%m%d-%H%M%S)}
+WITH_SACCT=0
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -o|--out)     OUTDIR=$2; shift 2 ;;
+        --with-sacct) WITH_SACCT=1; shift ;;
+        -h|--help)    sed -n '2,25p' "$0"; exit 0 ;;
+        *)            echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v sinfo >/dev/null 2>&1 || { echo 'sinfo not found in PATH' >&2; exit 1; }
+mkdir -p "$OUTDIR"
+
+# The exporter pins this on every command it runs (issue #158). Slurm renders
+# every timestamp according to it, and a capture taken under a different
+# setting comes back in a layout the parsers reject — so the fixture would
+# encode a format the exporter never sees.
+SLURM_TIME_FORMAT=standard
+export SLURM_TIME_FORMAT
+
+MAP="$OUTDIR/.anonymize.map"
+AWK="$OUTDIR/.anonymize.awk"
+PROV="$OUTDIR/provenance.txt"
+
+# ── Anonymisation map ────────────────────────────────────────────────────────
+#
+# Built by asking Slurm what exists, so only real names are rewritten and no
+# token is rewritten by resemblance. Node names map by alphabetic prefix, which
+# covers both the expanded form (c1) and the compressed hostlists Slurm writes
+# elsewhere (c[1-10,14]) without parsing range syntax.
+
+build_map() {
+    : > "$MAP"
+
+    # The replacement must not end in a digit: a node prefix is immediately
+    # followed by the node number, so mapping c -> n1 turns c1 into n11, which
+    # reads as node eleven. Letters keep the numbering intact: c1 -> na1.
+    sinfo -h -N -o '%N' 2>/dev/null | sed 's/[0-9].*$//' | sort -u | grep -v '^$' |
+        awk '{ printf "prefix\t%s\tn%c\n", $1, 96 + NR }' >> "$MAP"
+
+    { squeue -a -h -o '%u' 2>/dev/null; sshare -a -P -n -o User 2>/dev/null; } |
+        tr -d ' ' | sort -u | grep -v '^$' |
+        awk '{ printf "word\t%s\tuser%d\n", $1, NR }' >> "$MAP"
+
+    sshare -a -P -n -o Account 2>/dev/null | tr -d ' ' | sort -u | grep -v '^$' |
+        awk '{ printf "word\t%s\taccount%d\n", $1, NR }' >> "$MAP"
+
+    scontrol show reservation 2>/dev/null |
+        sed -n 's/.*ReservationName=\([^ ]*\).*/\1/p' | sort -u | grep -v '^$' |
+        awk '{ printf "word\t%s\tresv%d\n", $1, NR }' >> "$MAP"
+
+    # GRES models: the part between the type and the count in gpu:<model>:<n>.
+    # A model name identifies the hardware a site bought, which is site data.
+    sinfo -h -N -O 'Gres: ,GresUsed:' 2>/dev/null |
+        tr ' ,' '\n\n' | sed -n 's/^[a-z]*:\([A-Za-z][A-Za-z0-9_.-]*\):[0-9].*/\1/p' |
+        sort -u | grep -v '^$' |
+        awk '{ printf "word\t%s\tmodel_%c\n", $1, 96 + NR }' >> "$MAP"
+
+    printf 'entities to rewrite: %s\n' "$(wc -l < "$MAP" | tr -d ' ')"
+}
+
+# ── Embedded anonymiser ──────────────────────────────────────────────────────
+write_awk() {
+    cat > "$AWK" <<'ANONEOF'
+# anonymize.awk — rewrite site-identifying names in captured Slurm output.
+#
+# Runs on the cluster, before anything is written to the tarball, so raw names
+# never leave the machine. POSIX awk only: a login node has the Slurm client and
+# little else, and requiring a Go toolchain there would defeat the point.
+#
+# The rule that makes this safe: it replaces names it was *told about*, read
+# from a mapping file built by querying Slurm itself. It never guesses from
+# shape. A pattern-matching anonymiser eventually eats "(null)", "N/A",
+# "drained*", a GRES model or a timestamp, and the damage is silent — the
+# fixture still looks plausible, and the expected values derived from it are
+# wrong forever.
+#
+# Node names are mapped by their alphabetic prefix rather than whole. Slurm
+# writes hostlists compressed ("kairosgh[0-3]", "c[1-10,14]") and expanded
+# ("kairosgh0") in different commands, and mapping the prefix handles both
+# without having to parse range syntax: kairosgh[0-3] becomes g[0-3], keeping
+# the structure a parser under test needs to see.
+#
+# Usage:  awk -v mapfile=<map> -f anonymize.awk <capture>
+#
+# The map is one "kind<TAB>from<TAB>to" per line:
+#   prefix   kairosgh    g          node-name prefixes, applied first
+#   word     alice       user1      whole words: users, accounts, reservations
+#   word     gh200       model_a    GRES models
+
+BEGIN {
+    FS = "\t"
+    npfx = 0
+    nword = 0
+    while ((getline line < mapfile) > 0) {
+        n = split(line, f, "\t")
+        if (n < 3 || f[1] ~ /^#/) continue
+        if (f[1] == "prefix") { pfx_from[++npfx] = f[2]; pfx_to[npfx] = f[3] }
+        else if (f[1] == "word") { word_from[++nword] = f[2]; word_to[nword] = f[3] }
+    }
+    close(mapfile)
+}
+
+# is_word_char reports whether c can appear inside a Slurm name. Underscore and
+# hyphen count: "tesla_v100-sxm3-32gb" is one name, and matching "v100" inside
+# it would corrupt a GRES model rather than anonymise a node.
+function is_word_char(c) {
+    return c ~ /[A-Za-z0-9_.-]/
+}
+
+# replace_word swaps every standalone occurrence of `from` with `to`. Standalone
+# means not glued to another name character on either side, so mapping node "c1"
+# leaves "c10" and "gpu:c1model" untouched. Done by hand rather than with gsub
+# because the replacement text may contain characters gsub treats specially.
+function replace_word(s, from, to,   out, i, before, after, flen) {
+    out = ""
+    flen = length(from)
+    while ((i = index(s, from)) > 0) {
+        before = (i == 1) ? "" : substr(s, i - 1, 1)
+        after  = substr(s, i + flen, 1)
+        if ((before == "" || !is_word_char(before)) &&
+            (after  == "" || !is_word_char(after))) {
+            out = out substr(s, 1, i - 1) to
+        } else {
+            out = out substr(s, 1, i + flen - 1)
+        }
+        s = substr(s, i + flen)
+    }
+    return out s
+}
+
+# replace_prefix swaps a node-name prefix wherever it starts a name. The prefix
+# must be followed by a digit or "[", which is what distinguishes the node
+# "kairosgh0" and the hostlist "kairosgh[0-3]" from an unrelated word that
+# merely starts with the same letters.
+function replace_prefix(s, from, to,   out, i, before, after, flen) {
+    out = ""
+    flen = length(from)
+    while ((i = index(s, from)) > 0) {
+        before = (i == 1) ? "" : substr(s, i - 1, 1)
+        after  = substr(s, i + flen, 1)
+        if ((before == "" || !is_word_char(before)) && after ~ /[0-9[]/) {
+            out = out substr(s, 1, i - 1) to
+        } else {
+            out = out substr(s, 1, i + flen - 1)
+        }
+        s = substr(s, i + flen)
+    }
+    return out s
+}
+
+{
+    line = $0
+    # Prefixes first: a node prefix can be a substring of nothing else, while a
+    # word mapping applied first could split a hostname and leave the prefix
+    # rule unable to see it.
+    for (i = 1; i <= npfx; i++)  line = replace_prefix(line, pfx_from[i], pfx_to[i])
+    for (i = 1; i <= nword; i++) line = replace_word(line, word_from[i], word_to[i])
+    print line
+}
+ANONEOF
+}
+
+# ── Capture ──────────────────────────────────────────────────────────────────
+
+# run_step executes one command, anonymises its output and records whether it
+# worked. A command that fails writes an empty file and a FAILED line rather
+# than aborting: a partial capture is still useful, as long as it says so.
+run_step() {
+    name=$1; shift
+    if "$@" > "$OUTDIR/.raw" 2>"$OUTDIR/.err"; then
+        status=ok
+    else
+        status=FAILED
+    fi
+    awk -v mapfile="$MAP" -f "$AWK" < "$OUTDIR/.raw" > "$OUTDIR/$name.txt"
+    printf '%-22s %-8s %s\n' "$name" "$status" "$*" >> "$PROV"
+    [ "$status" = ok ] || printf '    stderr: %s\n' "$(head -1 "$OUTDIR/.err")" >> "$PROV"
+}
+
+write_awk
+build_map
+
+{
+    echo 'slurm_exporter fixture capture'
+    echo "date:    $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "slurm:   $(sinfo --version 2>/dev/null)"
+    echo "host:    $(hostname | cksum | cut -d' ' -f1)  (hashed)"
+    echo "sacct:   $([ "$WITH_SACCT" = 1 ] && echo included || echo skipped)"
+    echo
+    echo 'command                status   invocation'
+} > "$PROV"
+
+run_step squeue_jobs            squeue '-a' '-r' '-h' '-O' 'JobID:|,Account:|,UserName:|,Partition:|,State:|,NumNodes:|,NumCPUs:|,tres-alloc:'
+run_step queue_all_states       squeue '-h' '-o' '%P|%T|%C|%r|%u' '--states=all'
+run_step queue_default_states   squeue '-h' '-o' '%P|%T|%C|%r|%u'
+run_step cpus                   sinfo '-h' '-o' '%C'
+run_step fairshare              sshare '-a' '-P' '-n' '-o' 'Account,User,RawShares,NormShares,RawUsage,NormUsage,FairShare'
+run_step gpus_snapshot          sinfo '-a' '-h' '--Format=Nodes: ,StateLong: ,Gres: ,GresUsed:'
+run_step node_detail            sinfo '-h' '-N' '-O' 'NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong: ,Partition: ,Gres: ,GresUsed:'
+run_step nodes_global           sinfo '-h' '-o' '%R|%D|%T|%b'
+run_step scontrol_nodes         scontrol 'show' 'nodes' '-o'
+run_step partitions_cpu         sinfo '-h' '-o' '%R,%C'
+run_step partitions_gpu         sinfo '-h' '--Format=Nodes: ,Partition: ,Gres: ,GresUsed:' '--state=idle,allocated'
+run_step drain_reason           sinfo '-h' '-N' '-o' '%N|%E|%H|%T'
+run_step reservations           scontrol 'show' 'reservation'
+run_step licenses               scontrol 'show' 'licenses' '-o'
+run_step scheduler              sdiag
+
+if [ "$WITH_SACCT" = 1 ]; then
+    run_step sacct_efficiency       sacct '-P' '-n' '--starttime' "$(date -d "-1 hour" +%Y-%m-%dT%H:%M:%S)" '--endtime' "$(date +%Y-%m-%dT%H:%M:%S)" '--format' 'JobID,User,Account,AllocCPUS,Elapsed,TotalCPU,CPUTime,MaxRSS,ReqMem' '--state' 'COMPLETED,FAILED,TIMEOUT,CANCELLED'
+fi
+
+rm -f "$OUTDIR/.raw" "$OUTDIR/.err" "$AWK"
+
+# The mapping stays on the cluster. It is the one file that could undo the
+# anonymisation, so it never goes in the tarball.
+mv "$MAP" "./$(basename "$OUTDIR").map" 2>/dev/null || rm -f "$MAP"
+
+tar czf "$OUTDIR.tar.gz" "$OUTDIR"
+echo
+echo "captured: $OUTDIR.tar.gz"
+echo "mapping kept locally, not in the tarball: $(basename "$OUTDIR").map"
+cat "$PROV"

--- a/tools/fixture-capture/anonymize.awk
+++ b/tools/fixture-capture/anonymize.awk
@@ -1,0 +1,96 @@
+# anonymize.awk — rewrite site-identifying names in captured Slurm output.
+#
+# Runs on the cluster, before anything is written to the tarball, so raw names
+# never leave the machine. POSIX awk only: a login node has the Slurm client and
+# little else, and requiring a Go toolchain there would defeat the point.
+#
+# The rule that makes this safe: it replaces names it was *told about*, read
+# from a mapping file built by querying Slurm itself. It never guesses from
+# shape. A pattern-matching anonymiser eventually eats "(null)", "N/A",
+# "drained*", a GRES model or a timestamp, and the damage is silent — the
+# fixture still looks plausible, and the expected values derived from it are
+# wrong forever.
+#
+# Node names are mapped by their alphabetic prefix rather than whole. Slurm
+# writes hostlists compressed ("kairosgh[0-3]", "c[1-10,14]") and expanded
+# ("kairosgh0") in different commands, and mapping the prefix handles both
+# without having to parse range syntax: kairosgh[0-3] becomes g[0-3], keeping
+# the structure a parser under test needs to see.
+#
+# Usage:  awk -v mapfile=<map> -f anonymize.awk <capture>
+#
+# The map is one "kind<TAB>from<TAB>to" per line:
+#   prefix   kairosgh    g          node-name prefixes, applied first
+#   word     alice       user1      whole words: users, accounts, reservations
+#   word     gh200       model_a    GRES models
+
+BEGIN {
+    FS = "\t"
+    npfx = 0
+    nword = 0
+    while ((getline line < mapfile) > 0) {
+        n = split(line, f, "\t")
+        if (n < 3 || f[1] ~ /^#/) continue
+        if (f[1] == "prefix") { pfx_from[++npfx] = f[2]; pfx_to[npfx] = f[3] }
+        else if (f[1] == "word") { word_from[++nword] = f[2]; word_to[nword] = f[3] }
+    }
+    close(mapfile)
+}
+
+# is_word_char reports whether c can appear inside a Slurm name. Underscore and
+# hyphen count: "tesla_v100-sxm3-32gb" is one name, and matching "v100" inside
+# it would corrupt a GRES model rather than anonymise a node.
+function is_word_char(c) {
+    return c ~ /[A-Za-z0-9_.-]/
+}
+
+# replace_word swaps every standalone occurrence of `from` with `to`. Standalone
+# means not glued to another name character on either side, so mapping node "c1"
+# leaves "c10" and "gpu:c1model" untouched. Done by hand rather than with gsub
+# because the replacement text may contain characters gsub treats specially.
+function replace_word(s, from, to,   out, i, before, after, flen) {
+    out = ""
+    flen = length(from)
+    while ((i = index(s, from)) > 0) {
+        before = (i == 1) ? "" : substr(s, i - 1, 1)
+        after  = substr(s, i + flen, 1)
+        if ((before == "" || !is_word_char(before)) &&
+            (after  == "" || !is_word_char(after))) {
+            out = out substr(s, 1, i - 1) to
+        } else {
+            out = out substr(s, 1, i + flen - 1)
+        }
+        s = substr(s, i + flen)
+    }
+    return out s
+}
+
+# replace_prefix swaps a node-name prefix wherever it starts a name. The prefix
+# must be followed by a digit or "[", which is what distinguishes the node
+# "kairosgh0" and the hostlist "kairosgh[0-3]" from an unrelated word that
+# merely starts with the same letters.
+function replace_prefix(s, from, to,   out, i, before, after, flen) {
+    out = ""
+    flen = length(from)
+    while ((i = index(s, from)) > 0) {
+        before = (i == 1) ? "" : substr(s, i - 1, 1)
+        after  = substr(s, i + flen, 1)
+        if ((before == "" || !is_word_char(before)) && after ~ /[0-9[]/) {
+            out = out substr(s, 1, i - 1) to
+        } else {
+            out = out substr(s, 1, i + flen - 1)
+        }
+        s = substr(s, i + flen)
+    }
+    return out s
+}
+
+{
+    line = $0
+    # Prefixes first: a node prefix can be a substring of nothing else, while a
+    # word mapping applied first could split a hostname and leave the prefix
+    # rule unable to see it.
+    for (i = 1; i <= npfx; i++)  line = replace_prefix(line, pfx_from[i], pfx_to[i])
+    for (i = 1; i <= nword; i++) line = replace_word(line, word_from[i], word_to[i])
+    print line
+}

--- a/tools/fixture-capture/anonymize_test.go
+++ b/tools/fixture-capture/anonymize_test.go
@@ -24,7 +24,7 @@ func runAnonymize(t *testing.T, mapping, input string) string {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("awk", "-v", "mapfile="+mapPath, "-f", "anonymize.awk")
+	cmd := exec.CommandContext(t.Context(), "awk", "-v", "mapfile="+mapPath, "-f", "anonymize.awk")
 	cmd.Stdin = strings.NewReader(input)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tools/fixture-capture/anonymize_test.go
+++ b/tools/fixture-capture/anonymize_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runAnonymize pipes input through anonymize.awk with the given mapping and
+// returns the result. The awk program is the artifact that actually ships
+// inside capture.sh, so the tests exercise it directly rather than a Go
+// reimplementation that could drift from it.
+func runAnonymize(t *testing.T, mapping, input string) string {
+	t.Helper()
+	if _, err := exec.LookPath("awk"); err != nil {
+		t.Skip("awk not available")
+	}
+
+	dir := t.TempDir()
+	mapPath := filepath.Join(dir, "map.tsv")
+	if err := os.WriteFile(mapPath, []byte(mapping), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("awk", "-v", "mapfile="+mapPath, "-f", "anonymize.awk")
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("awk failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+const testMap = "prefix\tkairosgh\tg\n" +
+	"prefix\tkairoscomp\tc\n" +
+	"word\talice\tuser1\n" +
+	"word\thpc_team\taccount_a\n" +
+	"word\tgh200\tmodel_a\n" +
+	"word\tmaint_window\tresv1\n"
+
+func TestAnonymizeRewritesNames(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			"expanded node name",
+			"kairosgh0 425000 876896 144/144/0/288 mixed gpu",
+			"g0 425000 876896 144/144/0/288 mixed gpu",
+		},
+		{
+			// Slurm compresses node lists in scontrol output. Mapping the
+			// prefix handles the compressed form without parsing range syntax.
+			"compressed hostlist",
+			"Nodes=kairosgh[0-3,7] NodeCnt=5",
+			"Nodes=g[0-3,7] NodeCnt=5",
+		},
+		{
+			"two prefixes on one line",
+			"kairoscomp12,kairosgh4",
+			"c12,g4",
+		},
+		{
+			"GRES model",
+			"gpu:gh200:4(S:0-3) gpu:gh200:2(IDX:0,3)",
+			"gpu:model_a:4(S:0-3) gpu:model_a:2(IDX:0,3)",
+		},
+		{
+			"user and account",
+			"1234|hpc_team|alice|gpu|RUNNING",
+			"1234|account_a|user1|gpu|RUNNING",
+		},
+		{
+			"reservation name",
+			"ReservationName=maint_window StartTime=2026-07-30T16:45:06",
+			"ReservationName=resv1 StartTime=2026-07-30T16:45:06",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.TrimRight(runAnonymize(t, testMap, tc.in+"\n"), "\n")
+			if got != tc.want {
+				t.Errorf("\n in:   %s\n got:  %s\n want: %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnonymizeLeavesSlurmTokensAlone is the test that matters most. A naive
+// anonymiser eats a token that merely looks like a name, and the damage is
+// silent: the fixture still parses, and every expected value derived from it is
+// wrong from then on.
+func TestAnonymizeLeavesSlurmTokensAlone(t *testing.T) {
+	// "alice" is a mapped user, so the sentinels here deliberately include
+	// strings that contain a mapped name as a substring.
+	mapping := testMap + "word\tc1\tn1\n"
+
+	untouched := []string{
+		"(null)",
+		"N/A",
+		"drained*",
+		"allocated+DRAIN",
+		"idle mixed down maint reserved inval",
+		"2026-07-30T16:45:06",
+		"192/0/0/192",
+		"gpu:tesla_v100-sxm3-32gb:16(IDX:0-15)",
+		"Reason=Not responding",
+		// c1 is mapped, c10 and c1x are not: a name must not be rewritten when
+		// it is only the start of a longer one.
+		"c10 c1x xc1",
+		// alice is mapped; these are different names that contain it.
+		"alice2 malice alice_backup",
+	}
+
+	for _, in := range untouched {
+		got := strings.TrimRight(runAnonymize(t, mapping, in+"\n"), "\n")
+		if got != in {
+			t.Errorf("rewrote a token it should not have:\n got:  %s\n want: %s", got, in)
+		}
+	}
+}
+
+// TestAnonymizeIsDeterministic pins the property the whole scheme rests on: the
+// same input and mapping produce the same output every time, and across files.
+// Fixtures from different commands have to agree on what a node is called, or
+// they stop describing the same cluster.
+func TestAnonymizeIsDeterministic(t *testing.T) {
+	in := "kairosgh0 alice hpc_team gpu:gh200:4\n"
+	first := runAnonymize(t, testMap, in)
+	for i := 0; i < 5; i++ {
+		if got := runAnonymize(t, testMap, in); got != first {
+			t.Fatalf("run %d differed:\n got:  %s want: %s", i, got, first)
+		}
+	}
+}
+
+// TestAnonymizeHandlesRealCaptures runs every committed fixture through the
+// anonymiser with an empty mapping. Nothing should change: the fixtures are
+// already anonymised, and a mapping that names nothing must be a no-op. This
+// catches an anonymiser that mangles input on its own, independently of what it
+// was asked to rewrite.
+func TestAnonymizeHandlesRealCaptures(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "test_data", "*.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	versioned, err := filepath.Glob(filepath.Join("..", "..", "test_data", "slurm-*", "*.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths = append(paths, versioned...)
+	if len(paths) < 20 {
+		t.Fatalf("expected the fixture corpus, found %d files", len(paths))
+	}
+
+	for _, p := range paths {
+		data, err := os.ReadFile(p) //nolint:gosec // G304: path from a glob under test_data/
+		if err != nil {
+			t.Fatal(err)
+		}
+		in := string(data)
+		got := runAnonymize(t, "# empty mapping\n", in)
+		// awk's print adds a trailing newline to a final line that lacked one.
+		if strings.TrimRight(got, "\n") != strings.TrimRight(in, "\n") {
+			t.Errorf("%s: an empty mapping changed the content", filepath.Base(p))
+		}
+	}
+}

--- a/tools/fixture-capture/main.go
+++ b/tools/fixture-capture/main.go
@@ -1,0 +1,304 @@
+// Command fixture-capture generates capture.sh, the script that collects Slurm
+// fixtures on a cluster.
+//
+// The script is generated rather than written by hand for the same reason
+// test_data/readme.md is: a hand-maintained list of Slurm commands drifts from
+// the collectors that run them, and that drift is what issue #195 is about. The
+// command list comes from collector.CommandRegistry, which a test already pins
+// against the real *Data() functions.
+//
+// The generated script is committed. CI regenerates it and fails on a diff, so
+// adding a collector without regenerating cannot land.
+//
+// Usage:
+//
+//	go generate ./...
+//	go run ./tools/fixture-capture -out scripts/capture.sh
+//	go run ./tools/fixture-capture -check
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sckyzo/slurm_exporter/internal/collector"
+)
+
+// anonymizeAWK is embedded so the generated script is self-contained. A capture
+// script that needs a second file alongside it is a capture script someone
+// eventually runs without that file.
+//
+//go:embed anonymize.awk
+var anonymizeAWK string
+
+func main() {
+	out := flag.String("out", "scripts/capture.sh", "path of the script to write")
+	check := flag.Bool("check", false, "exit non-zero if the file on disk is stale, write nothing")
+	flag.Parse()
+
+	want := render()
+
+	if *check {
+		got, err := os.ReadFile(*out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixture-capture: %v\n", err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(got, want) {
+			fmt.Fprintf(os.Stderr,
+				"fixture-capture: %s is stale.\nRun `make generate` and commit the result.\n", *out)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := os.WriteFile(*out, want, 0o755); err != nil { //nolint:gosec // G306: it is a script, it has to be executable
+		fmt.Fprintf(os.Stderr, "fixture-capture: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// shQuote wraps a value in single quotes for POSIX sh. Slurm format strings are
+// full of characters a shell would otherwise act on: spaces in
+// "--Format=Nodes: ,Gres:", pipes in "%N|%E", percent signs, parentheses.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// captureStep is one command as the generated script sees it.
+type captureStep struct {
+	Name   string
+	Binary string
+	Args   string // already shell-quoted, empty when the command takes none
+	// Expensive marks a command that queries SlurmDBD. Not "has an opt-in
+	// flag": queue_default_states carries one too, but it is a *disable* flag
+	// on a cheap controller query, and grouping on the flag's presence put it
+	// behind --with-sacct where it does not belong.
+	Expensive bool
+}
+
+// steps flattens the registry into what the script needs. Placeholders become
+// their shell expression, which is the whole reason Placeholder carries one.
+func steps() []captureStep {
+	var out []captureStep
+	for i := range collector.CommandRegistry {
+		c := &collector.CommandRegistry[i]
+
+		// A per-binary version probe tells you the version of whichever host
+		// runs the capture, not a format. It is recorded in the provenance file
+		// instead, where it belongs.
+		if len(c.EachBinary) > 0 {
+			continue
+		}
+
+		shell := make(map[string]string, len(c.Placeholders))
+		for _, p := range c.Placeholders {
+			shell[p.Token] = p.Shell
+		}
+
+		parts := make([]string, 0, len(c.Args))
+		for _, a := range c.Args {
+			if expr, ok := shell[a]; ok {
+				parts = append(parts, `"`+expr+`"`)
+				continue
+			}
+			parts = append(parts, shQuote(a))
+		}
+
+		out = append(out, captureStep{
+			Name:      c.Name,
+			Binary:    c.Binary,
+			Args:      strings.Join(parts, " "),
+			Expensive: c.Binary == "sacct",
+		})
+	}
+	return out
+}
+
+func render() []byte {
+	var b strings.Builder
+	w := func(lines ...string) {
+		for _, l := range lines {
+			b.WriteString(l)
+			b.WriteString("\n")
+		}
+	}
+
+	all := steps()
+	var expensive, always []captureStep
+	for _, s := range all {
+		if s.Expensive {
+			expensive = append(expensive, s)
+		} else {
+			always = append(always, s)
+		}
+	}
+
+	w(
+		"#!/bin/sh",
+		"# GENERATED FILE. DO NOT EDIT.",
+		"#",
+		"# Source of truth: internal/collector/command_registry.go",
+		"# Regenerate with:  make generate",
+		"#",
+		"# Collect Slurm fixtures for slurm_exporter, anonymised on this machine.",
+		"#",
+		"# What it does, and what it deliberately does not:",
+		"#",
+		"#   * Runs only the commands the exporter itself runs. The list is generated",
+		"#     from the collector registry, so it cannot include a command the exporter",
+		"#     does not use, and every one of them is read-only. There is no write",
+		"#     command in the registry, so none can appear here.",
+		"#   * Anonymises before writing anything. Node, user, account, reservation and",
+		"#     GRES-model names are replaced on this machine; the tarball never contains",
+		"#     them. That is what makes it safe to run on a production cluster and hand",
+		"#     the result to someone else.",
+		"#   * Records provenance: Slurm version, date, and the exit status of every",
+		"#     command. A partial capture is visible rather than silent.",
+		"#   * Leaves sacct alone unless asked. It queries SlurmDBD and is expensive on",
+		"#     a busy cluster, so it is behind --with-sacct and bounded to one hour.",
+		"#",
+		"# Usage:  ./capture.sh [-o OUTDIR] [--with-sacct]",
+		"",
+		"set -eu",
+		"",
+		"OUTDIR=${OUTDIR:-slurm-fixtures-$(date +%Y%m%d-%H%M%S)}",
+		"WITH_SACCT=0",
+		"",
+		"while [ $# -gt 0 ]; do",
+		"    case $1 in",
+		"        -o|--out)     OUTDIR=$2; shift 2 ;;",
+		"        --with-sacct) WITH_SACCT=1; shift ;;",
+		"        -h|--help)    sed -n '2,25p' \"$0\"; exit 0 ;;",
+		"        *)            echo \"unknown option: $1\" >&2; exit 2 ;;",
+		"    esac",
+		"done",
+		"",
+		"command -v sinfo >/dev/null 2>&1 || { echo 'sinfo not found in PATH' >&2; exit 1; }",
+		"mkdir -p \"$OUTDIR\"",
+		"",
+		"# The exporter pins this on every command it runs (issue #158). Slurm renders",
+		"# every timestamp according to it, and a capture taken under a different",
+		"# setting comes back in a layout the parsers reject — so the fixture would",
+		"# encode a format the exporter never sees.",
+		"SLURM_TIME_FORMAT=standard",
+		"export SLURM_TIME_FORMAT",
+		"",
+		"MAP=\"$OUTDIR/.anonymize.map\"",
+		"AWK=\"$OUTDIR/.anonymize.awk\"",
+		"PROV=\"$OUTDIR/provenance.txt\"",
+		"",
+		"# ── Anonymisation map ────────────────────────────────────────────────────────",
+		"#",
+		"# Built by asking Slurm what exists, so only real names are rewritten and no",
+		"# token is rewritten by resemblance. Node names map by alphabetic prefix, which",
+		"# covers both the expanded form (c1) and the compressed hostlists Slurm writes",
+		"# elsewhere (c[1-10,14]) without parsing range syntax.",
+		"",
+		"build_map() {",
+		"    : > \"$MAP\"",
+		"",
+		"    # The replacement must not end in a digit: a node prefix is immediately",
+		"    # followed by the node number, so mapping c -> n1 turns c1 into n11, which",
+		"    # reads as node eleven. Letters keep the numbering intact: c1 -> na1.",
+		"    sinfo -h -N -o '%N' 2>/dev/null | sed 's/[0-9].*$//' | sort -u | grep -v '^$' |",
+		"        awk '{ printf \"prefix\\t%s\\tn%c\\n\", $1, 96 + NR }' >> \"$MAP\"",
+		"",
+		"    { squeue -a -h -o '%u' 2>/dev/null; sshare -a -P -n -o User 2>/dev/null; } |",
+		"        tr -d ' ' | sort -u | grep -v '^$' |",
+		"        awk '{ printf \"word\\t%s\\tuser%d\\n\", $1, NR }' >> \"$MAP\"",
+		"",
+		"    sshare -a -P -n -o Account 2>/dev/null | tr -d ' ' | sort -u | grep -v '^$' |",
+		"        awk '{ printf \"word\\t%s\\taccount%d\\n\", $1, NR }' >> \"$MAP\"",
+		"",
+		"    scontrol show reservation 2>/dev/null |",
+		"        sed -n 's/.*ReservationName=\\([^ ]*\\).*/\\1/p' | sort -u | grep -v '^$' |",
+		"        awk '{ printf \"word\\t%s\\tresv%d\\n\", $1, NR }' >> \"$MAP\"",
+		"",
+		"    # GRES models: the part between the type and the count in gpu:<model>:<n>.",
+		"    # A model name identifies the hardware a site bought, which is site data.",
+		"    sinfo -h -N -O 'Gres: ,GresUsed:' 2>/dev/null |",
+		"        tr ' ,' '\\n\\n' | sed -n 's/^[a-z]*:\\([A-Za-z][A-Za-z0-9_.-]*\\):[0-9].*/\\1/p' |",
+		"        sort -u | grep -v '^$' |",
+		"        awk '{ printf \"word\\t%s\\tmodel_%c\\n\", $1, 96 + NR }' >> \"$MAP\"",
+		"",
+		"    printf 'entities to rewrite: %s\\n' \"$(wc -l < \"$MAP\" | tr -d ' ')\"",
+		"}",
+		"",
+		"# ── Embedded anonymiser ──────────────────────────────────────────────────────",
+		"write_awk() {",
+		"    cat > \"$AWK\" <<'ANONEOF'",
+	)
+
+	for _, l := range strings.Split(strings.TrimRight(anonymizeAWK, "\n"), "\n") {
+		w(l)
+	}
+
+	w(
+		"ANONEOF",
+		"}",
+		"",
+		"# ── Capture ──────────────────────────────────────────────────────────────────",
+		"",
+		"# run_step executes one command, anonymises its output and records whether it",
+		"# worked. A command that fails writes an empty file and a FAILED line rather",
+		"# than aborting: a partial capture is still useful, as long as it says so.",
+		"run_step() {",
+		"    name=$1; shift",
+		"    if \"$@\" > \"$OUTDIR/.raw\" 2>\"$OUTDIR/.err\"; then",
+		"        status=ok",
+		"    else",
+		"        status=FAILED",
+		"    fi",
+		"    awk -v mapfile=\"$MAP\" -f \"$AWK\" < \"$OUTDIR/.raw\" > \"$OUTDIR/$name.txt\"",
+		"    printf '%-22s %-8s %s\\n' \"$name\" \"$status\" \"$*\" >> \"$PROV\"",
+		"    [ \"$status\" = ok ] || printf '    stderr: %s\\n' \"$(head -1 \"$OUTDIR/.err\")\" >> \"$PROV\"",
+		"}",
+		"",
+		"write_awk",
+		"build_map",
+		"",
+		"{",
+		"    echo 'slurm_exporter fixture capture'",
+		"    echo \"date:    $(date -u +%Y-%m-%dT%H:%M:%SZ)\"",
+		"    echo \"slurm:   $(sinfo --version 2>/dev/null)\"",
+		"    echo \"host:    $(hostname | cksum | cut -d' ' -f1)  (hashed)\"",
+		"    echo \"sacct:   $([ \"$WITH_SACCT\" = 1 ] && echo included || echo skipped)\"",
+		"    echo",
+		"    echo 'command                status   invocation'",
+		"} > \"$PROV\"",
+		"",
+	)
+
+	for _, s := range always {
+		w(strings.TrimRight(fmt.Sprintf("run_step %-22s %s %s", s.Name, s.Binary, s.Args), " "))
+	}
+	w("")
+	if len(expensive) > 0 {
+		w("if [ \"$WITH_SACCT\" = 1 ]; then")
+		for _, s := range expensive {
+			w(strings.TrimRight(fmt.Sprintf("    run_step %-22s %s %s", s.Name, s.Binary, s.Args), " "))
+		}
+		w("fi", "")
+	}
+
+	w(
+		"rm -f \"$OUTDIR/.raw\" \"$OUTDIR/.err\" \"$AWK\"",
+		"",
+		"# The mapping stays on the cluster. It is the one file that could undo the",
+		"# anonymisation, so it never goes in the tarball.",
+		"mv \"$MAP\" \"./$(basename \"$OUTDIR\").map\" 2>/dev/null || rm -f \"$MAP\"",
+		"",
+		"tar czf \"$OUTDIR.tar.gz\" \"$OUTDIR\"",
+		"echo",
+		"echo \"captured: $OUTDIR.tar.gz\"",
+		"echo \"mapping kept locally, not in the tarball: $(basename \"$OUTDIR\").map\"",
+		"cat \"$PROV\"",
+	)
+
+	return []byte(b.String())
+}


### PR DESCRIPTION
Phase 2 of #195.

## Summary

- Fixtures had to be captured by hand: know which commands to run, remember to anonymise, get the anonymisation right. Three chances to produce a fixture that looks fine and encodes something wrong.
- `scripts/capture.sh` is **generated from `CommandRegistry`**, so it runs exactly the commands the exporter runs and cannot drift from them. Every one is read-only — there is no write command in the registry, so none can appear in the script. `sacct` sits behind `--with-sacct`, bounded to an hour.
- **It anonymises on the cluster and keeps the mapping behind.** The tarball cannot contain a node, user, account, reservation or GPU-model name, and the one file that could undo that never leaves. That is what makes it usable on someone else's production system.

```sh
scp scripts/capture.sh someone@login-node:
ssh someone@login-node './capture.sh'
```

## The anonymiser only rewrites names it was told about

It reads a mapping built by querying Slurm, and never matches on shape. A pattern-based anonymiser eventually eats `(null)`, `N/A`, `drained*`, a GRES model or a timestamp — and the damage is silent: the fixture still parses, and every expected value derived from it is wrong from then on.

`anonymize_test.go` runs the awk program itself, the one that ships inside the script, not a Go reimplementation that could drift from it. It covers the rewrites, the tokens that must survive, determinism across runs, and a no-op sweep over the whole committed fixture corpus. Mutation-tested: dropping the word-boundary check turns `c10` into `n10`, `alice2` into `user12`, `malice` into `muser1` — and the test fails on each.

Node names map by alphabetic prefix, which covers both the expanded form and the compressed hostlists Slurm writes elsewhere (`c[1-10,14]`) without parsing range syntax.

## Two bugs found by running it, not by reading it

**Prefix replacements ended in a digit.** `c` → `n1` turns `c1` into `n11`, which reads as node eleven. The numbering was silently corrupted in the first capture. Replacements are letters now: `c1` → `na1`.

**Opt-in grouping was on the wrong signal.** Grouping by "has an opt-in flag" put `queue_default_states` behind `--with-sacct`; its flag is a *disable* flag on a cheap controller query. The grouping is on the binary being `sacct`, which is what expensive actually means here.

## Verified end to end on the integration cluster

15 commands, all `ok`, with both CPU and fake GPU nodes present so two node prefixes and two GRES models are exercised:

```
prefix  c  na          c1  → na1
prefix  g  nb          g1  → nb1
nb1 0 15867 0/32/0/32 idle gpu gpu:model_a:4 gpu:model_a:0(IDX:N/A)
```

`provenance.txt` records the Slurm version, the date, a hashed host identity and the exit status of every command, so a partial capture is visible rather than silent (the #177 principle). Confirmed the mapping file is absent from the tarball.

## Test plan

- [x] `capture.sh` runs clean on the integration cluster, 15/15 commands ok
- [x] `sh -n` on the generated script; POSIX sh only, no bashisms
- [x] Anonymiser tests pass and are mutation-tested
- [x] `make generate` / `-check` and the CI step now cover both generated artifacts
- [x] Full Go suite green, `gofmt` clean
- [ ] `--with-sacct` on a real SlurmDBD — the test cluster's accounting is thin; the path is generated from the same table and syntax-checked, but it has not run against a busy database

## Notes for reviewers

`SLURM_TIME_FORMAT=standard` is exported before any command. The exporter pins it on everything it runs (#158), and a capture taken under a different setting comes back in a layout the parsers reject — the fixture would encode a format the exporter never sees.

`CONTRIBUTING` documents the procedure and the two rules that matter when a capture comes back: never re-anonymise an existing fixture, since expected values are tied to the current names; and record the Slurm version in `Fixture.Slurm`, because GRES and timestamp formats have drifted between majors before.

Phases 3 (capture both ends of the support window) and 4 (`make fixture-diff`) remain.
