### PR TITLE
chore(deps): stop Dependabot drifting the tools image off the CI toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,12 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/scripts/docker/tools"
+    # The Go image in this directory is slaved to the toolchain CI pins, so a
+    # weekly bump here would silently make `make check` disagree with the
+    # merge gate. It moves by hand alongside .github/workflows/ and go.mod.
+    # The block itself stays so any other image added here is still watched.
+    ignore:
+      - dependency-name: "golang"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/scripts/docker/tools/Dockerfile
+++ b/scripts/docker/tools/Dockerfile
@@ -6,6 +6,13 @@
 #
 # Built locally on first use via `make tools-image`; rebuilds are
 # incremental thanks to the layer cache.
+#
+# The Go version below is not free to move on its own. `make check` lints and
+# tests inside this image while CI does it with setup-go, so if the two drift
+# a contributor can be told their branch is clean by a Go that is not the one
+# gating the merge. It tracks the `go-version` pinned in .github/workflows/
+# and the `toolchain` directive in go.mod; all three change together or none
+# do. Dependabot is told to leave this image alone in .github/dependabot.yml.
 
 FROM golang:1.26.8-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628
 


### PR DESCRIPTION
Closes #227.

Dependabot proposed moving `scripts/docker/tools` from `golang:1.26.8-alpine` to `1.27.1-alpine`. On its own that reads as a routine bump. Merging it would have been a mistake.

### Why

That image is what `make check`, `make lint` and `make report` run inside. CI uses `setup-go` with the version pinned in `.github/workflows/`. They are the same toolchain today only because the 1.26.8 bump moved every reference at once.

Let the image float and a contributor who follows the CONTRIBUTING Definition of Done is told their branch is clean by a Go that is not the one gating the merge — and the failure surfaces on their PR, not on the run they were asked to trust.

### What changes

- `.github/dependabot.yml` — the `/scripts/docker/tools` block gains `ignore: golang`. The block stays rather than being deleted, so a second image added to that directory is still watched.
- `scripts/docker/tools/Dockerfile` — a comment stating that the Go version tracks `.github/workflows/` and `go.mod`'s `toolchain` directive, and that all three move together.

That directory has exactly one `FROM`, so there is nothing else there for the weekly bump to be useful for.

**This is a policy change, not a version change.** The image stays on 1.26.8, identical to CI.

### On Go 1.27.x

Still possible, and this makes it what it should have been: one deliberate commit touching the workflows, `go.mod` and this image together, sized as part of the 2.0 scope rather than arriving as a weekly digest bump.

### Verification

- `.github/dependabot.yml` parses, and the rule resolves to `{'package-ecosystem': 'docker', 'directory': '/scripts/docker/tools', 'ignore': [{'dependency-name': 'golang'}]}`
- `make check` green in the containerised toolchain: `go vet`, `golangci-lint` 0 issues, tests pass on all 3 packages, `govulncheck` 0 reachable, `actionlint`, `zizmor` (no findings), `deadcode` (none)