### PR TITLE
fix(main): stop answering 200 on every path that is not a route

### DIFF
--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -145,14 +146,57 @@ var collectorConstructors = map[string]func(logger *logger.Logger) prometheus.Co
 	"sacct_efficiency": nil,
 }
 
-// indexHTML is the HTML content displayed on the root page
-const indexHTML = `<html>
-	<head><title>Slurm Exporter</title></head>
-	<body>
-		<h1>Slurm Exporter</h1>
-		<p>Welcome to the Slurm Exporter. Click <a href='/metrics'>here</a> to see the metrics.</p>
-	</body>
-</html>`
+// newMux builds the exporter's HTTP routes.
+//
+// The routes live on a mux of their own rather than on http.DefaultServeMux so
+// that the exposed surface is exactly what this function registers. Any package
+// that imports net/http/pprof, directly or several dependencies down, registers
+// /debug/pprof/* on the default mux from an init function, which would publish
+// goroutine dumps and a CPU profiler on the scrape port without that decision
+// ever being made here. Nothing does so today; the mux is what keeps it that
+// way.
+//
+// Returning the mux instead of serving from it keeps the route table testable
+// without binding a port.
+func newMux(reg *prometheus.Registry) (*http.ServeMux, error) {
+	// NewLandingPage answers 404 on every path but its route prefix. The
+	// hand-written page this replaces was registered on "/", which in
+	// http.ServeMux matches everything unclaimed: a Prometheus server pointed at
+	// a mistyped /metric was answered 200 with HTML, so the target scraped as up
+	// and the mistake surfaced as a parse error in Prometheus rather than as a
+	// 404 here.
+	landing, err := web.NewLandingPage(web.LandingConfig{
+		Name:        "Slurm Exporter",
+		Description: "Prometheus exporter for the Slurm workload manager",
+		Version:     version.Info(),
+		Links: []web.LandingLinks{
+			{Address: "/metrics", Text: "Metrics", Description: "Slurm metrics in Prometheus/OpenMetrics format"},
+			{Address: "/healthz", Text: "Health", Description: "Liveness of the exporter process itself"},
+		},
+		// The toolkit defaults this to "true" and renders links to
+		// /debug/pprof/heap and /debug/pprof/profile. The exporter does not
+		// import net/http/pprof, so those links would 404: advertising a
+		// profiler we do not serve is worse than not offering one.
+		Profiling: "false",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building landing page: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", landing)
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	}))
+	// /healthz returns 200 OK as long as the HTTP server is up.
+	// This allows orchestrators (Kubernetes, systemd watchdog) to distinguish
+	// "exporter process alive" from "Slurm commands reachable".
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux, nil
+}
 
 // registerCollectors registers enabled collectors with the Prometheus registry.
 // All enabled collectors are wrapped by a single StatusTracker that emits
@@ -258,26 +302,18 @@ func main() {
 	log.Info("Starting Slurm Exporter server...")
 	log.Info("Command timeout configured", "timeout", *commandTimeout)
 
-	// Configure HTTP routes
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(indexHTML))
-	})
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{
-		EnableOpenMetrics: true,
-	}))
-	// /healthz returns 200 OK as long as the HTTP server is up.
-	// This allows orchestrators (Kubernetes, systemd watchdog) to distinguish
-	// "exporter process alive" from "Slurm commands reachable".
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
+	mux, err := newMux(reg)
+	if err != nil {
+		log.Error("Failed to configure HTTP routes", "err", err)
+		stop()     // release signal handler explicitly before bypassing defer via os.Exit
+		os.Exit(1) //nolint:gocritic // stop() called explicitly above
+	}
 
 	// Start HTTP server with exporter toolkit (supports TLS, Basic Auth, etc.).
 	// serve is the blocking listen call; injecting it keeps runServer testable
 	// without binding the test to the exporter-toolkit listener.
 	server := &http.Server{
+		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second, // Mitigate Slowloris attack (G112)
 	}
 	serve := func() error { return web.ListenAndServe(server, toolkitFlags, log.Logger) }

--- a/cmd/slurm_exporter/main_test.go
+++ b/cmd/slurm_exporter/main_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sckyzo/slurm_exporter/internal/logger"
@@ -57,4 +59,73 @@ func TestRunServer_IgnoresServerClosed(t *testing.T) {
 	serve := func() error { return http.ErrServerClosed }
 	err := runServer(context.Background(), &http.Server{}, serve, nil, logger.NewTextLogger("error"))
 	require.NoError(t, err)
+}
+
+// TestNewMux_RouteStatuses is the regression test for the landing page claiming
+// every unmatched path. The page used to be registered with http.HandleFunc("/"),
+// and "/" in an http.ServeMux matches everything nothing else claims, so a
+// Prometheus server pointed at a mistyped /metric was answered 200 with an HTML
+// page. The target scraped as up and the mistake surfaced as a parse error in
+// Prometheus rather than as a 404 from the exporter.
+func TestNewMux_RouteStatuses(t *testing.T) {
+	mux, err := newMux(prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		path string
+		want int
+	}{
+		{"/", http.StatusOK},
+		{"/metrics", http.StatusOK},
+		{"/healthz", http.StatusOK},
+		{"/metric", http.StatusNotFound},           // the typo that motivated this
+		{"/metrics/", http.StatusNotFound},         // trailing slash is a different route
+		{"/debug/pprof/heap", http.StatusNotFound}, // never served; see newMux
+		{"/anything-else", http.StatusNotFound},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.path, nil))
+			require.Equal(t, tc.want, rec.Code)
+		})
+	}
+}
+
+// TestNewMux_LandingPage checks the two things the hand-written page got wrong
+// besides its status code: it never set a Content-Type, and it linked only to
+// /metrics.
+func TestNewMux_LandingPage(t *testing.T) {
+	mux, err := newMux(prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "text/html; charset=UTF-8", rec.Header().Get("Content-Type"))
+
+	body := rec.Body.String()
+	require.Contains(t, body, "Slurm Exporter")
+	require.Contains(t, body, "metrics")
+	require.Contains(t, body, "healthz")
+
+	// LandingConfig.Profiling defaults to "true", which renders links to
+	// /debug/pprof/*. The exporter does not import net/http/pprof, so leaving
+	// the default would advertise a profiler that answers 404. The assertion is
+	// on the links rather than on the word: the template emits a "#pprof" CSS
+	// rule whatever the flag says, so matching "pprof" alone fails on styling
+	// that has no route behind it.
+	require.NotContains(t, body, "debug/pprof")
+}
+
+// TestNewMux_HealthzBody pins the payload orchestrators match on.
+func TestNewMux_HealthzBody(t *testing.T) {
+	mux, err := newMux(prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ok", rec.Body.String())
 }


### PR DESCRIPTION
The landing page was registered with `http.HandleFunc("/")`. In an `http.ServeMux`, `"/"` is not the root path — it is the pattern that matches everything no other pattern claims. Every unrouted request got 200 and an HTML page.

### Measured on the running binary, before

| Path | Status | Content-Type |
|---|---|---|
| `/` | 200 | `text/html; charset=utf-8` |
| `/metrics` | 200 | `text/plain; version=0.0.4…` |
| `/healthz` | 200 | `text/plain` |
| `/metric` *(typo)* | **200** | `text/html` |
| `/nimportequoi` | **200** | `text/html` |

The `/metric` line is the one that costs time. A Prometheus server pointed at a mistyped path is answered 200 with HTML, so **the target scrapes as `up`** and the mistake surfaces as a parse error in Prometheus rather than as a 404 from the exporter. Nothing on this side says the path was wrong.

### After

| Path | Status |
|---|---|
| `/` | 200 `text/html; charset=UTF-8` |
| `/metric`, `/nimportequoi`, `/debug/pprof/heap`, `/metrics/` | **404** |

### What changed

`web.NewLandingPage` — shipped by exporter-toolkit for a long time, never adopted here. It answers `http.NotFound` on any path but its route prefix, sets an explicit `Content-Type` (the hand-written page never did), and gives the page the shape operators know from every other Prometheus exporter: build version, and a link per endpoint rather than only to `/metrics`.

**One trap in adopting it.** `LandingConfig.Profiling` defaults to `"true"` and renders links to `/debug/pprof/heap` and `/debug/pprof/profile`. This exporter does not import `net/http/pprof`, so those links would 404. It is set to `"false"` explicitly — advertising a profiler we do not serve is worse than not offering one.

**Routes also move off `http.DefaultServeMux`** onto their own mux, so the exposed surface is exactly what `newMux` registers. Any package importing `net/http/pprof`, directly or several dependencies down, registers `/debug/pprof/*` on the default mux from an `init()` function, which would publish goroutine dumps and a CPU profiler on the scrape port with no decision made here. Nothing does so today — verified with `go version -m` on the binary — and the mux is what keeps it that way.

### On the regression test

It could not be written to fail against the old code, because `newMux` did not exist to call. The before state is the measurement above, taken from the built binary. Three tests pin the behaviour going forward:

- `TestNewMux_RouteStatuses` — 7 paths, status each
- `TestNewMux_LandingPage` — Content-Type, per-endpoint links, no pprof links
- `TestNewMux_HealthzBody` — the `ok` body orchestrators match on

The pprof assertion is on `"debug/pprof"`, not `"pprof"`: the template emits a `#pprof` CSS rule whatever the flag says, and the first version of the test failed on styling with no route behind it.

### Verification

Containerised `make check` green: `go vet`, `golangci-lint` 0 issues, tests on all 3 packages, `govulncheck` 0 reachable, `actionlint`, `zizmor`, `deadcode`. Plus the live probes above against the rebuilt binary.

`/healthz` and `/metrics` behaviour is unchanged, so the docs referencing them stay accurate.