### PR TITLE
docs(process): make non-regression a release step, not a contributor step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,21 +45,33 @@ This applies equally to PRs from contributors and to internal development.
 3. golangci-lint run ./...
    → 0 issues
 
-4. make -C scripts/testing setup
+4. Proof of non-regression
+   → A test that fails before the change and passes after. Run it against
+     the unfixed code first: a test that was green all along protects
+     nothing.
+   → When the change cannot be expressed that way — a toolchain or
+     dependency bump, a rewiring that replaces code which did not exist
+     before — the proof is a measurement compared against the previous
+     release, written into the pull request. What counts as one is listed
+     in docs/release-process.md, "Prove non-regression".
+   → Steps 1-3 passing is not a proof. They say the new code is
+     self-consistent, not that it behaves like the old one.
+
+5. make -C scripts/testing setup
    → Test cluster starts cleanly (10 nodes by default)
    → All 10 Grafana dashboards imported successfully
    → slurm_exporter running on slurmctld:9341
 
-5. make -C scripts/testing workload N=20
+6. make -C scripts/testing workload N=20
    → Jobs submitted across alice/bob/carol/dave/eve/frank
    → Running jobs visible in: docker exec slurmctld squeue --state=RUNNING
 
-6. Prometheus validation (wait one scrape cycle ~35s)
+7. Prometheus validation (wait one scrape cycle ~35s)
    → For each new metric, verify it exists and has a sensible value:
      curl -s http://localhost:9090/api/v1/query?query=<new_metric> | python3 -m json.tool
    → Must return at least one series with a non-NaN value
 
-7. Log check
+8. Log check
    → Scrape once so every collector runs, then read the exporter's own log:
      docker exec slurmctld curl -s http://localhost:9341/metrics > /dev/null
      make -C scripts/testing exporter-logs | grep -E 'level=(ERROR|WARN)'
@@ -68,15 +80,15 @@ This applies equally to PRs from contributors and to internal development.
    → slurmctld must not show increased error rate:
      docker exec slurmctld cat /var/log/slurm/slurmctld.log | grep -c ERROR
 
-8. Dashboard validation (if dashboards were modified)
+9. Dashboard validation (if dashboards were modified)
    → make -C scripts/testing screenshots OUTPUT=/tmp/pr-screenshots
    → All panels show data, no "No data" on panels that should have values
    → No PromQL errors visible
 
-9. make -C scripts/testing stop
+10. make -C scripts/testing stop
    → Cluster stops cleanly, no dangling containers
 
-10. act push (CI simulation)
+11. act push (CI simulation)
     → act push --workflows .github/workflows/release.yml --job test \
         --platform ubuntu-latest=catthehacker/ubuntu:act-latest --no-cache-server
     → All CI jobs pass
@@ -90,7 +102,7 @@ For small changes (docs, comments, minor fixes):
 make build && make test && golangci-lint run ./...
 ```
 
-Integration tests (steps 4-9) are required for any change to:
+Integration tests (steps 5-10) are required for any change to:
 - Collector code (`internal/collector/`)
 - Main entrypoint (`cmd/slurm_exporter/`)
 - Grafana dashboards (`monitoring/grafana/dashboards/`)
@@ -282,18 +294,21 @@ The quick summary:
 1. Branch off `master` as `fix/vX.Y.Z` (patch) or `feat/vX.Y` (minor).
 2. Triage open PRs/issues; pick a coherent release theme.
 3. Integrate community PRs as local commits with `Co-authored-by:` — one
-   commit per logical change, each with a non-regression test.
-4. Run the defensive audit (same bug class elsewhere?).
-5. `make check` (containerised) + `make report` (offline goreportcard
+   commit per logical change.
+4. Prove non-regression for every change in the release, whoever wrote it:
+   a red-then-green test, or a measurement against the previous release when
+   a test cannot express the change.
+5. Run the defensive audit (same bug class elsewhere?).
+6. `make check` (containerised) + `make report` (offline goreportcard
    grade, must stay ≥ B) + `make race` continuously; full end-to-end via
    `scripts/testing`.
-6. Diff the exporter's `/metrics` output against `docs/metrics.md`.
-7. Update `CHANGELOG.md`, `docs/metrics.md`, `docs/metrics-examples.md`,
+7. Diff the exporter's `/metrics` output against `docs/metrics.md`.
+8. Update `CHANGELOG.md`, `docs/metrics.md`, `docs/metrics-examples.md`,
    dashboards, and the companion alerting rules if applicable.
-8. Open the release PR with the v1.8.2 template structure.
-9. After merge: close integrated community PRs with a thank-you and respond
+9. Open the release PR with the v1.8.2 template structure.
+10. After merge: close integrated community PRs with a thank-you and respond
    to acknowledged-but-deferred issues.
-10. **Diff the fixture formats across the support window.** `make fixture-diff`
+11. **Diff the fixture formats across the support window.** `make fixture-diff`
     compares the two ends and reports what Slurm started or stopped emitting
     between them. A shape change is not a failure by itself, but every parser
     reading those files needs a look before the tag. Recapture the ends with

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -106,25 +106,75 @@ If a PR fixes two distinct bugs (e.g. PR #28 fixed both a regex hyphen issue
 *and* a GRES separator issue), split it into two commits. Each commit must:
 
 - Compile and pass `go test` on its own (so `git bisect` works).
-- Have its own non-regression test if applicable.
+- Carry its own proof of non-regression — see step 4.
 - Carry the `Co-authored-by:` trailer.
-
-### 3.4 Test of non-regression
-
-Every code change must come with a test that:
-
-- Fails before the fix (you should briefly verify this — write the test
-  first, run it, see it fail).
-- Passes after the fix.
-- Uses the project's existing test fixtures in `test_data/` when possible.
-
-If the PR doesn't come with a test, write one. If a fix is purely defensive
-(e.g. log on empty parse), a unit test that exercises the empty path is
-enough.
 
 ---
 
-## 4. Defensive audit
+## 4. Prove non-regression
+
+This step used to live under "Integrate community PRs", which meant it only
+applied to changes that arrived as a contributor's PR. A maintainer-authored
+fix, a toolchain bump or a security backport walked past it, and the release
+shipped on the reviewer's judgement rather than on evidence.
+
+**Every change in a release carries a proof of non-regression.** The default
+proof is a test:
+
+- It fails before the fix. Write it first, run it, watch it fail — a test
+  that was green all along protects nothing.
+- It passes after.
+- It uses the fixtures in `test_data/` when it can, so it keeps testing
+  against output Slurm actually produced.
+
+A purely defensive fix (log on empty parse, say) is covered by a unit test
+that exercises the path being defended.
+
+### Which net covers what
+
+Most of the work is already automated. Reach for the one that matches the
+change instead of writing a new kind of test:
+
+| What changed | Proof |
+|---|---|
+| A parser or a collector's arithmetic | Unit test against a `test_data/` fixture |
+| The arguments of a Slurm command | `TestRegistryMatchesCollectors` — it invokes the real `*Data()` behind a stubbed `Execute` and fails when the table and the code disagree |
+| A fixture | `TestRegistryFixturesExist` and `TestEveryFixtureIsClaimed` |
+| Behaviour across Slurm majors | `make fixture-diff` over the versioned fixture directories |
+| An HTTP route or handler | `httptest` against the mux, asserting status and content type |
+
+### When a test cannot express it
+
+Some changes are real and cannot be written as a red-then-green test: a Go
+toolchain bump, a dependency bump, a rewiring that replaces a function that
+did not exist before. Declaring those untestable and moving on is how a
+regression ships.
+
+For those, **the proof is a measurement compared against the previous
+release, written into the pull request.** Name what you measured, on what,
+and what the previous release produced. A `make check` that passes is not a
+measurement: it says the new code is self-consistent, not that it behaves
+like the old one.
+
+What counts as a measurement, in descending order of preference:
+
+1. The exposed metric surface is unchanged — same names, same labels, same
+   types.
+2. The integration cluster produces the same observable result: every
+   collector at `success=1`, the same set of Slurm commands issued, no
+   `ERROR` or `WARN` across the run.
+3. The specific subsystem the change touches is exercised end to end. A
+   change to the TLS or HTTP stack means running the exporter with
+   `--web.config.file` and scraping over HTTPS, which the validation
+   checklist does not do on its own.
+
+If none of the three is possible, say so in the PR and say why. An
+unmeasurable change is a decision to accept risk, and it should be visible
+as one.
+
+---
+
+## 5. Defensive audit
 
 For each bug you fix, ask: **is the same class of bug present anywhere
 else in the codebase?**
@@ -153,7 +203,7 @@ summary, no `Co-authored-by:`.
 
 ---
 
-## 5. Validate continuously
+## 6. Validate continuously
 
 **Every command below runs inside a containerised toolchain** — Docker is
 the only requirement on the developer machine, the result is identical on
@@ -196,7 +246,7 @@ with `//nolint:gocyclo` and a rationale comment.
 
 ---
 
-## 6. End-to-end test on a live cluster
+## 7. End-to-end test on a live cluster
 
 Spin up the test cluster and validate the actual `/metrics` output, with
 every collector enabled, debug logs captured, and release-specific
@@ -270,7 +320,7 @@ declaring the doc clean.
 
 ---
 
-## 7. Update documentation
+## 8. Update documentation
 
 For every change that affects user-visible behavior:
 
@@ -294,7 +344,7 @@ For breaking changes, include a **migration table** in CHANGELOG:
 
 ---
 
-## 8. Push and open the PR
+## 9. Push and open the PR
 
 ```bash
 git push -u origin fix/vX.Y.Z
@@ -331,7 +381,7 @@ Self-review the diff on GitHub before requesting outside review.
 
 ---
 
-## 9. Post-merge cleanup
+## 10. Post-merge cleanup
 
 Once the PR is merged to `master`:
 
@@ -443,7 +493,7 @@ GitHub release page.
 
 ---
 
-## 10. Handle PRs that don't ship in this release
+## 11. Handle PRs that don't ship in this release
 
 When you receive a PR that has the right idea but doesn't fit the current
 release (wrong scope, missing tests, conflicts with in-flight work), the
@@ -469,7 +519,7 @@ The PRs #29 / issue #27 responses from the v1.8.2 cycle are good templates.
 
 ---
 
-## 11. Security backport onto `release-1.8`
+## 12. Security backport onto `release-1.8`
 
 Everything above describes cutting a release from `master`. A security
 backport is a different, much shorter flow, and it is the only reason to


### PR DESCRIPTION
`### 3.4 Test of non-regression` was nested under `## 3. Integrate community PRs`. The requirement was attached to **where a change came from** rather than to the change itself, so a maintainer-authored fix, a toolchain bump or a security backport reached the tag without any step asking for evidence. `CONTRIBUTING.md` repeated the shape, hanging non-regression off the "integrate community PRs" line of the release summary.

It showed up twice this week:

- **#233** — the regression test could not fail before the fix, because `newMux` did not exist to call. The before-state had to be a measurement on the running binary instead.
- **#234** (v1.8.5) — no new test at all; it is a toolchain bump. The evidence is the cluster run.

Both shipped with evidence, but because that call got made in the moment, not because anything asked for it.

### What changes

Non-regression becomes **step 4 of the release process** and **step 4 of the Definition of Done**, applying to every change whoever wrote it. The default is unchanged: a test that fails before and passes after, run against the unfixed code so it is *known* to have been red.

**A table maps a kind of change to the net that already covers it**, so "what test do I write" is usually answered with "none, run the one that exists":

| What changed | Proof |
|---|---|
| A parser or a collector's arithmetic | Unit test against a `test_data/` fixture |
| The arguments of a Slurm command | `TestRegistryMatchesCollectors` |
| A fixture | `TestRegistryFixturesExist` / `TestEveryFixtureIsClaimed` |
| Behaviour across Slurm majors | `make fixture-diff` |
| An HTTP route or handler | `httptest` against the mux |

**And there is now an answer for changes a test cannot express.** A toolchain bump has no red-then-green form, and calling it untestable is how a regression ships. The proof is a measurement against the previous release, written into the PR, ranked:

1. The exposed metric surface is unchanged — same names, labels, types.
2. The integration cluster produces the same observable result: every collector at `success=1`, the same Slurm commands issued, no `ERROR`/`WARN`.
3. The touched subsystem exercised end to end — a TLS or HTTP change means running with `--web.config.file` and scraping over HTTPS, which the validation checklist does not do on its own.

It states explicitly that **passing `make check` is not a measurement**: it says the new code is self-consistent, not that it behaves like the old one. If none of the three is possible, the PR has to say so — an unmeasurable change is a decision to accept risk and should read as one.

### Renumbering

Release process sections 4–11 shift to 5–12; Definition of Done steps 4–10 shift to 5–11, and the "integration tests (steps 4-9)" note moves with them to 5–10.

No anchor links break: the only anchored cross-reference in the tree points at a named subsection, not a numbered one. Every step-number reference in `CONTRIBUTING.md`, `docs/` and `.github/workflows/` was re-checked against the new numbering — `ci.yml`'s "(steps 1-3)" is still correct.

### Verification

`make check` exit 0 in the containerised toolchain.

### Follow-up

The measurement ranking's first item — "the exposed metric surface is unchanged" — has no automated backing today. It is checked by hand at release time with the `comm` diff in the validation checklist. A golden file of the metric surface, generated from the command registry the way `test_data/readme.md` and `scripts/capture.sh` already are, would turn it into a CI gate and cover most of the toolchain-bump case on its own. That is the next PR, not this one.