### PR TITLE
ci: run CI on release branches and stop a badge refresh failing a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,26 @@
-# CI — lint + test on every pull request and on push to master.
+# CI — lint + test on every pull request and on push to master or a release
+# branch.
 #
 # This is the gate that the CONTRIBUTING.md "Definition of Done" (steps 1-3)
 # expects on every change. The release workflow only runs on tags, so without
 # this nothing ran the test suite or the linter on PRs. Integration tests
 # (the Slurm test cluster in scripts/testing/) remain a manual step.
+#
+# release-* is listed because a maintenance branch is where a security backport
+# lands, and merging one used to run nothing at all: the pull request was gated,
+# the branch it merged into was not, and the state that actually gets tagged had
+# no automated check behind it. Found tagging v1.8.5, whose branch had to be
+# validated by hand.
+#
+# GitHub runs the copy of this file that lives on the branch being pushed, so
+# adding release-* here covers release branches cut from master in future. An
+# existing maintenance branch needs the same change applied to its own copy.
 
 name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'release-*']
   pull_request:
 
 permissions:

--- a/.github/workflows/goreportcard.yml
+++ b/.github/workflows/goreportcard.yml
@@ -6,7 +6,11 @@ name: Refresh Go Report Card
 # https://goreportcard.com/report/github.com/sckyzo/slurm_exporter
 #
 # Kept as a dedicated workflow (rather than a step inside release.yml) so a
-# goreportcard.com outage cannot fail the GoReleaser pipeline.
+# goreportcard.com outage cannot fail the GoReleaser pipeline, and marked
+# continue-on-error so it cannot fail this workflow either. The two together are
+# what that intent actually requires: on the v1.8.5 tag the endpoint answered
+# 404, GoReleaser was untouched as designed, and the tag still carried a red
+# cross that read like a failed release.
 
 on:
   push:
@@ -21,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: POST to goreportcard.com
+        # A badge refresh is not a quality gate. Whether goreportcard.com is
+        # reachable says nothing about the release, and the score itself is
+        # already enforced offline by `make report` as a release blocker.
+        continue-on-error: true
         # REPO is sourced from the GitHub context; passing it via env keeps
         # the run: block free of templated values, which is the recommended
         # pattern for workflow injection protection.


### PR DESCRIPTION
Two gaps found while releasing v1.8.5. Neither affected that release; both made it harder to trust.

### Nothing ran on `release-1.8` when the backport merged

`ci.yml` triggers on `pull_request` and on push to `master`. So #234 was gated as a pull request, and the branch it merged into was not — **the state that actually gets tagged had no automated check behind it.** It had to be validated by hand (`make check`, `make report`, `make race`, `govulncheck`) before tagging.

`release-*` now triggers it too.

GitHub runs the copy of the workflow that lives on **the branch being pushed**, so this covers release branches cut from `master` in future and does nothing for `release-1.8` itself, which would need the same change on its own copy. That is a separate decision: `SECURITY.md` limits that branch to security fixes, and CI configuration is not one. Raising it rather than deciding it here.

### The Go Report Card refresh failed the v1.8.5 tag

```
POST https://goreportcard.com/checks → HTTP 404
```

The workflow's own header says it is kept separate from `release.yml` *"so a goreportcard.com outage cannot fail the GoReleaser pipeline"*. That held — and it was only half the intent. GoReleaser was untouched, and the tag still carried a red cross that read like a failed release until someone opened the logs.

`continue-on-error: true` completes it. A badge refresh is not a quality gate: whether that site is reachable says nothing about the release, and the score it displays is already enforced offline by `make report`, which blocks below grade B.

### Verification

Both files parse. `make check` exit 0, including **actionlint** and **zizmor** — the two checks that actually read these files, and the two I had skipped entirely back when Docker was unreachable here.