### PR TITLE
build: move the module path to /v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,7 +89,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/sckyzo/slurm_exporter
+        - github.com/sckyzo/slurm_exporter/v2
 
 issues:
   max-issues-per-linter: 0

--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -33,8 +33,8 @@ import (
 	"github.com/prometheus/exporter-toolkit/web"
 	webflag "github.com/prometheus/exporter-toolkit/web/kingpinflag"
 
-	"github.com/sckyzo/slurm_exporter/internal/collector"
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/collector"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 var (

--- a/cmd/slurm_exporter/main_test.go
+++ b/cmd/slurm_exporter/main_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/collector"
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/collector"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // TestRunServer_ShutsDownOnContextCancel is the regression test for issue #139:

--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -651,7 +651,7 @@ All `go_*` and `process_*` metrics are absent from `/metrics`. Only `build_info`
 ```
 # HELP go_build_info Build information about the main Go module.
 # TYPE go_build_info gauge
-go_build_info{checksum="",path="github.com/sckyzo/slurm_exporter",version="(devel)"} 1
+go_build_info{checksum="",path="github.com/sckyzo/slurm_exporter/v2",version="(devel)"} 1
 
 # HELP slurm_cpus_alloc Allocated CPUs
 ...

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sckyzo/slurm_exporter
+module github.com/sckyzo/slurm_exporter/v2
 
 go 1.26.0
 

--- a/internal/collector/accounts.go
+++ b/internal/collector/accounts.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 var (

--- a/internal/collector/accounts_collector_test.go
+++ b/internal/collector/accounts_collector_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestAccountsCollector_Collect(t *testing.T) {

--- a/internal/collector/command_registry.go
+++ b/internal/collector/command_registry.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // ── The command contract ─────────────────────────────────────────────────────

--- a/internal/collector/command_registry_test.go
+++ b/internal/collector/command_registry_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // testDataDir is where the fixtures live, relative to this package.

--- a/internal/collector/cpus.go
+++ b/internal/collector/cpus.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 type CPUsMetrics struct {

--- a/internal/collector/cpus_collector_test.go
+++ b/internal/collector/cpus_collector_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestCPUsCollector_Collect(t *testing.T) {

--- a/internal/collector/execute.go
+++ b/internal/collector/execute.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 var (

--- a/internal/collector/execute_env_test.go
+++ b/internal/collector/execute_env_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // echoEnvBinary installs a fake Slurm binary that prints one environment

--- a/internal/collector/execute_test.go
+++ b/internal/collector/execute_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestExecuteWithBinPath(t *testing.T) {

--- a/internal/collector/fairshare.go
+++ b/internal/collector/fairshare.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // FairShareData executes the sshare command to retrieve fairshare information.

--- a/internal/collector/fairshare_test.go
+++ b/internal/collector/fairshare_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // ── ParseFairShareMetrics ──────────────────────────────────────────────────────

--- a/internal/collector/gpus.go
+++ b/internal/collector/gpus.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // GPUsMetrics holds GPU utilization statistics from Slurm

--- a/internal/collector/gpus_collector_test.go
+++ b/internal/collector/gpus_collector_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestGPUsCollector_Collect(t *testing.T) {

--- a/internal/collector/gpus_snapshot_test.go
+++ b/internal/collector/gpus_snapshot_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // TestGPUsSnapshotSingleCall pins the issue #145 fix: the gpus collector must

--- a/internal/collector/helpers_test.go
+++ b/internal/collector/helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // stubExecute makes every Slurm command return the given output for the rest of

--- a/internal/collector/licenses.go
+++ b/internal/collector/licenses.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // licenseLineRe parses one line of "scontrol show licenses -o" output.

--- a/internal/collector/licenses_collector_test.go
+++ b/internal/collector/licenses_collector_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestLicensesCollector_Collect(t *testing.T) {

--- a/internal/collector/metric_surface.go
+++ b/internal/collector/metric_surface.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // The metric surface is the set of series this exporter can publish: every

--- a/internal/collector/metric_surface_test.go
+++ b/internal/collector/metric_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // TestParseDescHandlesAwkwardHelp is the guard on the one fragile part of this

--- a/internal/collector/metrics_doc_test.go
+++ b/internal/collector/metrics_doc_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // docMetricPattern pulls metric names out of docs/metrics.md.

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // NodeMetrics stores metrics for each node

--- a/internal/collector/node_drain.go
+++ b/internal/collector/node_drain.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // DrainReasonMetrics holds the drain/down reason for a single node.

--- a/internal/collector/node_drain_since_test.go
+++ b/internal/collector/node_drain_since_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // TestDrainReasonSeriesIdentityIsStableAcrossRedrains is the non-regression test

--- a/internal/collector/node_drain_test.go
+++ b/internal/collector/node_drain_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestParseDrainReasonMetrics_Basic(t *testing.T) {

--- a/internal/collector/node_gres_test.go
+++ b/internal/collector/node_gres_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // newTestLogger returns the WARN-level logger the other collector tests use.

--- a/internal/collector/nodes.go
+++ b/internal/collector/nodes.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // Pre-compiled regexes for node state matching — avoids re-compilation on every loop iteration.

--- a/internal/collector/nodes_collector_test.go
+++ b/internal/collector/nodes_collector_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestNodesCollector_Collect(t *testing.T) {

--- a/internal/collector/partitions.go
+++ b/internal/collector/partitions.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 /*

--- a/internal/collector/partitions_test.go
+++ b/internal/collector/partitions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // pickPartitionFixturePath maps a (command, args) pair from the partitions

--- a/internal/collector/queue.go
+++ b/internal/collector/queue.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 type NNVal map[string]map[string]map[string]float64

--- a/internal/collector/queue_collector_test.go
+++ b/internal/collector/queue_collector_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestQueueCollector_Collect(t *testing.T) {

--- a/internal/collector/queue_terminal_states_test.go
+++ b/internal/collector/queue_terminal_states_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // captureExecuteArgs replaces Execute with a stub recording the command line it

--- a/internal/collector/queue_test.go
+++ b/internal/collector/queue_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestParseQueueMetrics(t *testing.T) {

--- a/internal/collector/reservation_nodes.go
+++ b/internal/collector/reservation_nodes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // Pre-compiled regexes for parsing scontrol show nodes -o output.

--- a/internal/collector/reservation_nodes_collector_test.go
+++ b/internal/collector/reservation_nodes_collector_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestReservationNodesCollector_Collect(t *testing.T) {

--- a/internal/collector/reservations.go
+++ b/internal/collector/reservations.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // reservationKVRe matches key=value pairs in scontrol show reservation output.

--- a/internal/collector/reservations_timestamp_test.go
+++ b/internal/collector/reservations_timestamp_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // relativeTimeReservation is real `scontrol show reservation` output, captured on

--- a/internal/collector/sacct_efficiency.go
+++ b/internal/collector/sacct_efficiency.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // SacctJobRecord holds the raw fields parsed from one sacct line.

--- a/internal/collector/sacct_efficiency_test.go
+++ b/internal/collector/sacct_efficiency_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // ── parseSacctDuration ────────────────────────────────────────────────────────

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // Pre-compiled regex patterns for sdiag output line matching.

--- a/internal/collector/scheduler_collector_test.go
+++ b/internal/collector/scheduler_collector_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestSchedulerCollector_Collect(t *testing.T) {

--- a/internal/collector/slurm_binary_info.go
+++ b/internal/collector/slurm_binary_info.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // infoSeries is one resolved slurm_info series, held in memory so the versions

--- a/internal/collector/slurm_binary_info_test.go
+++ b/internal/collector/slurm_binary_info_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // TestSlurmInfoCollector_VersionsResolvedOnce is the non-regression test for

--- a/internal/collector/squeue_jobs.go
+++ b/internal/collector/squeue_jobs.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"strings"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // squeueJobsColumns is the consolidated squeue layout that feeds the accounts,

--- a/internal/collector/squeue_jobs_test.go
+++ b/internal/collector/squeue_jobs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // resetSqueueJobsCache clears the shared snapshot so a warm cache left by an

--- a/internal/collector/status.go
+++ b/internal/collector/status.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // StatusTracker is a single Prometheus collector that runs a set of inner

--- a/internal/collector/status_execute_failure_test.go
+++ b/internal/collector/status_execute_failure_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // collectorSuccessValues gathers reg and returns

--- a/internal/collector/status_test.go
+++ b/internal/collector/status_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 // mockCollector is a simple collector for testing StatusTracker

--- a/internal/collector/users.go
+++ b/internal/collector/users.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 var (

--- a/internal/collector/users_test.go
+++ b/internal/collector/users_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sckyzo/slurm_exporter/internal/logger"
+	"github.com/sckyzo/slurm_exporter/v2/internal/logger"
 )
 
 func TestParseUsersMetrics_Basic(t *testing.T) {

--- a/tools/fixture-capture/main.go
+++ b/tools/fixture-capture/main.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sckyzo/slurm_exporter/internal/collector"
+	"github.com/sckyzo/slurm_exporter/v2/internal/collector"
 )
 
 // anonymizeAWK is embedded so the generated script is self-contained. A capture

--- a/tools/gen-fixture-doc/main.go
+++ b/tools/gen-fixture-doc/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sckyzo/slurm_exporter/internal/collector"
+	"github.com/sckyzo/slurm_exporter/v2/internal/collector"
 )
 
 func main() {

--- a/tools/gen-metric-surface/main.go
+++ b/tools/gen-metric-surface/main.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sckyzo/slurm_exporter/internal/collector"
+	"github.com/sckyzo/slurm_exporter/v2/internal/collector"
 )
 
 func main() {


### PR DESCRIPTION
Go requires the major version in the module path from v2 onward, so tagging `v2.0.0` against `github.com/sckyzo/slurm_exporter` would produce a tag the module system does not recognise as a version of this module.

**The failure is silent, not loud** — which is why this has to land before the tag. The module is already in the proxy index:

```
$ curl proxy.golang.org/github.com/sckyzo/slurm_exporter/@latest
{"Version":"v1.8.5", …}
```

An unsuffixed `v2.0.0` would simply not be added to the version list, and `go install …@latest` would keep serving **v1.8.5 indefinitely**, with nothing reporting an error.

### The reach is narrower than 58 files suggests

- **55 Go files** — import lines only
- **2 genuine module-path references**: the `goimports` `local-prefixes` rule in `.golangci.yml`, and a sample `go_build_info` line in `docs/metrics-examples.md`

Everything else mentioning the repository is a **URL** — `git clone` targets, the Go Report Card badge. A URL is not a module path, so those stay as they are.

### Nothing observable changes, and that is measured

All three generated artefacts are **byte-identical** afterwards:

| Artefact | Result |
|---|---|
| `docs/metric-surface.md` | identical — every metric name and label where it was |
| `test_data/readme.md` | identical |
| `scripts/capture.sh` | identical |

That first one exists for exactly this kind of change, where no red-then-green test can express the difference. It is the measurement the release process now asks for in place of a test.

### Verification

`make check` exit 0 · `make report` **grade A+ (99.14%)** · `make race` clean, 0 data races · `go build` clean.

And on the built artifact:

```
$ go version -m bin/slurm_exporter
	path	github.com/sckyzo/slurm_exporter/v2/cmd/slurm_exporter
```

### Note

`CLAUDE.md` names the module path too, but it is gitignored, so it stays out of this PR. Worth updating locally.