### PR TITLE
docs: remove the references to a 1.9 that will not exist

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,7 +89,7 @@ docker_signs:
 # entries (per-arch builds + manifest combinations × variants × registries)
 # into 2 entries. GoReleaser handles multi-arch + multi-registry transparently.
 #
-# Floating tags (latest, vX.Y, vX) are skipped on pre-release tags (v1.9.0-rc1)
+# Floating tags (latest, vX.Y, vX) are skipped on pre-release tags (v2.0.0-rc1)
 # so they always point at a stable release.
 dockers_v2:
   - id: standard

--- a/cmd/slurm_exporter/main.go
+++ b/cmd/slurm_exporter/main.go
@@ -78,7 +78,7 @@ var (
 	queueTerminalStates = kingpin.Flag(
 		"collector.queue.terminal-states",
 		"Ask squeue for terminal job states (FAILED, TIMEOUT, CANCELLED, COMPLETED, ...) "+
-			"in addition to pending and running ones. Disable to restore the pre-1.9 query "+
+			"in addition to pending and running ones. Disable to restore the pre-2.0 query "+
 			"if the extra slurmctld work is measurable on your cluster.",
 	).Default("true").Bool()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ For details on the `web-config.yml` format, see the [Exporter Toolkit documentat
 | `--collector.node.gres` | Expose `slurm_node_gres_total` and `slurm_node_gres_used`, broken down by `gres_type`. Disable on clusters with many GPU models or MIG profiles to reduce cardinality. | `true` |
 | `--collector.fairshare.user-metrics` | Collect per-user fairshare metrics (`slurm_user_fairshare_*`). Disable on clusters with many users to reduce cardinality. | `true` |
 | `--collector.queue.user-label` | Include `user` label in `slurm_queue_*` metrics. Disable on clusters with many users to reduce cardinality. | `true` |
-| `--collector.queue.terminal-states` | Ask `squeue` for terminal job states (`FAILED`, `TIMEOUT`, `CANCELLED`, `COMPLETED`, ...) on top of pending and running ones. Disable to restore the pre-1.9 query. | `true` |
+| `--collector.queue.terminal-states` | Ask `squeue` for terminal job states (`FAILED`, `TIMEOUT`, `CANCELLED`, `COMPLETED`, ...) on top of pending and running ones. Disable to restore the pre-2.0 query. | `true` |
 | `--collector.sacct_efficiency` | Enable the sacct_efficiency collector (disabled by default — queries SlurmDBD). | `false` |
 | `--collector.sacct.interval` | Background refresh interval for sacct_efficiency. | `5m` |
 | `--collector.sacct.lookback` | Time window for sacct_efficiency queries. | `1h` |

--- a/docs/metrics-examples.md
+++ b/docs/metrics-examples.md
@@ -421,7 +421,7 @@ minutes and fall back to zero by themselves. Alert on a rate, never on
 
 ### With `--no-collector.queue.terminal-states`
 
-The pre-1.9 query comes back and the same six totals sit at zero, as do the
+The pre-2.0 query comes back and the same six totals sit at zero, as do the
 `slurm_queue_*` and `slurm_cores_*` series behind them. Only pending and running
 jobs are reported.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -277,7 +277,7 @@ default), so `slurm_jobs_failed` answers "how many jobs failed in the last
 
 Set `--no-collector.queue.terminal-states` to go back to the pending-and-running
 query if the extra work is measurable on your `slurmctld`. The six totals then
-stay at zero, which is the pre-1.9 behaviour.
+stay at zero, which is the pre-2.0 behaviour.
 
 ### `reservations` Collector
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,7 +51,7 @@ For each item, decide:
 
 - **In scope** for this release — note the PR/issue number in your scratchpad.
 - **Out of scope** but actionable — comment on the issue/PR with the planned
-  release (e.g. "tracked for v1.9").
+  release (e.g. "tracked for v2.1").
 - **Stale** — close with a polite explanation.
 
 Aim for a release that ships **one theme** (e.g. v1.8.2 was "silent metric
@@ -506,7 +506,7 @@ Comment on the PR with:
    opinions).
 3. **What the plan is** — which release you'll integrate it in, what you'll
    adapt or add (tests, flags, dashboard panel).
-4. **A concrete signal of intent** — e.g. "I'll adapt and ship in v1.9 this
+4. **A concrete signal of intent** — e.g. "I'll adapt and ship in v2.1 this
    month. You'll be credited via Co-authored-by."
 5. **Concrete preview** — when relevant, show an example of the metrics
    that would be exposed, or a snippet of dashboard PromQL.
@@ -607,7 +607,7 @@ For context, v1.8.2 (the release that codified this process) was made of:
 - 8 integrated community PRs (#12/#13, #14/#15, #16/#17, #18/#19, #20/#21,
   #22/#23 — breaking —, #24/#25, and PR #28).
 - 1 issue-driven bug fix (#26, reservation phantom row).
-- 2 follow-up responses on issues planned for v1.9 (#27, PR #29).
+- 2 follow-up responses on issues deferred to a later release (#27, PR #29).
 - 4 docs updates (metrics, metrics-examples, CHANGELOG, this file).
 - 25 commits, all conventional, all atomic.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,13 +11,17 @@ in PR/issue comments, and internal observations during recent releases.
 
 ---
 
-## v1.9
+## 2.0
 
 > Tracked in [#61](https://github.com/SckyzO/slurm_exporter/issues/61) — the
 > authoritative scope and per-PR breakdown for this milestone. Each item below
-> maps to one atomic PR against `master`. v1.9 is cut once the public-feature
+> maps to one atomic PR against `master`. 2.0 is cut once the public-feature
 > checklist there is complete; internal-hygiene items are welcome but slide to
-> v1.9.1 if they are not ready in time.
+> a later release if they are not ready in time.
+>
+> There is no 1.9. 1.8 is the last of the v1 line — it lives on `release-1.8`
+> under the support window in [SECURITY.md](../SECURITY.md) — and everything
+> since is 2.0, whose Go module path is `github.com/sckyzo/slurm_exporter/v2`.
 
 ### Commitments made publicly
 
@@ -28,13 +32,9 @@ in PR/issue comments, and internal observations during recent releases.
   `--collector.sacct.lookback` window. Reuses the single `sacct` call
   already made for efficiency stats — no extra load on Slurm.
 
-- **Per-node GRES metrics** *(adapts [PR #29](https://github.com/SckyzO/slurm_exporter/pull/29) from @ncreddine)*
-  Land `slurm_node_gres_total{node, partition, status, gres_type}` and
-  `slurm_node_gres_used{...}`. Adapt to the variable-width `sinfo -O`
-  format introduced in v1.8.2 (the original PR uses fixed widths and
-  would regress issue #10). Add a `--collector.node.gres` flag and a
-  `--collector.node.gres-types` filter for cardinality control on
-  multi-type / MIG clusters. Includes a new dashboard panel.
+  `--collector.queue.terminal-states` already answers the *"my failure
+  counters read zero"* half of #27 from `squeue`, but only within `MinJobAge`.
+  This item is what makes the same question answerable over hours.
 
 - **Dashboard uniformity — `$instance`** *(prerequisite for multi-cluster, tracked in [#61](https://github.com/SckyzO/slurm_exporter/issues/61))*
   Only `04-slurm-usage.json` currently carries an `$instance` template
@@ -51,39 +51,28 @@ in PR/issue comments, and internal observations during recent releases.
 
 ### Internal hygiene (welcome but not promised)
 
-- Convert `tmp/issue_collector_constructor_context.md` into a GitHub
-  issue and ship the refactor (constructor signature gets `context.Context`
-  as first parameter, eliminating the `nil`+override pattern in `main.go`).
-- Convert `tmp/issue_gpus_single_sinfo.md` into a GitHub issue and
-  consolidate the three `sinfo` calls in `internal/collector/gpus.go`
-  into a single atomic snapshot. The v1.8.2 clamp on `slurm_gpus_other`
-  becomes redundant once this lands.
-- **`Makefile` container-first cleanup** *([#114](https://github.com/SckyzO/slurm_exporter/issues/114))*
-  The "Docker-only, no host Go toolchain" contract only half-holds — `build`,
-  `setup`, `run`, `clean` still use the host `go`. Also a stale `GO_VERSION`
-  fallback (`1.22.2` at `Makefile:6`, vs `go 1.26.0` in `go.mod`) and a stale
-  slurm-client comment (`23.11` at `Makefile:186`, vs the `25.11` the
-  Dockerfile actually ships). Either containerise `build` or soften the claim,
-  and derive the Go version from a single source. Splittable: the
-  comment/version fixes can land ahead of the larger containerise-`build`
-  change.
+- **Constructor refactor — `context.Context` first** *(tracked in [#61](https://github.com/SckyzO/slurm_exporter/issues/61))*
+  All 17 constructors still take `*logger.Logger` first, so the one collector
+  that needs a context gets it through the `nil`-then-override pattern
+  `main.go` still carries a comment about. Non-blocking by #61's own criteria:
+  it changes no metric and no flag.
 
 ---
 
-## v2.0 (uncommitted, open-ended)
+## After 2.0 (uncommitted, open-ended)
 
-- **Refondre le panel "Terminal Job States Over Time"** on
+- **Rework the "Terminal Job States Over Time" panel** on
   `monitoring/grafana/dashboards/04-slurm-usage.json` once
-  `sacct_efficiency` exposes the per-state counts (see v1.9). Today
-  the panel uses queue-collector metrics that stay at zero because
-  `squeue` doesn't surface terminal states.
+  `sacct_efficiency` exposes the per-state counts (see 2.0 above). Today
+  the panel uses queue-collector metrics that only carry values inside
+  `MinJobAge`, so anything older than a few minutes reads as zero.
 
 ---
 
 ## Requested, not yet scheduled
 
 Open feature requests that are not committed to a milestone yet — surfaced here
-so they are visible during v1.9 planning.
+so they are visible during 2.0 planning.
 
 - **Job wait-time metrics** *([#118](https://github.com/SckyzO/slurm_exporter/issues/118))*
   Median / histogram wait times (submit → start) broken down by cluster,
@@ -116,7 +105,7 @@ A new item is added to this roadmap when **any** of the following is
 true:
 
 1. A maintainer publicly commits to it in a PR or issue comment
-   (e.g. *"I'll ship X in v1.9"*).
+   (e.g. *"I'll ship X in v2.1"*).
 2. A draft issue exists in `tmp/` (gitignored scratch) that captures the
    problem and the proposed direction, waiting for a GitHub issue.
 3. A change came up during a release validation pass and is too large to

--- a/internal/collector/command_registry.go
+++ b/internal/collector/command_registry.go
@@ -192,7 +192,7 @@ var CommandRegistry = []Command{
 			"The window is bounded by MinJobAge (slurm.conf, 300s by default): slurmctld " +
 				"forgets a terminated job once it is older than that.",
 			"Dropped by --no-collector.queue.terminal-states, which restores the " +
-				"pre-1.9 query, the queue_default_states entry below.",
+				"pre-2.0 query, the queue_default_states entry below.",
 		},
 		Fixtures: []Fixture{
 			{
@@ -213,7 +213,7 @@ var CommandRegistry = []Command{
 		Args:   []string{"-h", "-o", "%P|%T|%C|%r|%u"},
 		Source: "queue.go",
 		OptIn:  "--no-collector.queue.terminal-states",
-		Doc: "The same query without --states=all, restoring the pre-1.9 behaviour for " +
+		Doc: "The same query without --states=all, restoring the pre-2.0 behaviour for " +
 			"sites that would rather not ask slurmctld for the terminal states.",
 		NoFixtureReason: "Deliberate: the output is a subset of queue_all_states.txt and the parser is the " +
 			"same one, so a second capture would protect nothing. What the flag changes is " +

--- a/test_data/readme.md
+++ b/test_data/readme.md
@@ -79,7 +79,7 @@ Job states, cores, reason and user, pipe-delimited so commas inside the reason f
 Owned by `queue.go`.
 
 - The window is bounded by MinJobAge (slurm.conf, 300s by default): slurmctld forgets a terminated job once it is older than that.
-- Dropped by --no-collector.queue.terminal-states, which restores the pre-1.9 query, the queue_default_states entry below.
+- Dropped by --no-collector.queue.terminal-states, which restores the pre-2.0 query, the queue_default_states entry below.
 
 | Fixture | Slurm | What it protects |
 |---|---|---|
@@ -91,7 +91,7 @@ Owned by `queue.go`.
 squeue -h -o '%P|%T|%C|%r|%u'
 ```
 
-The same query without --states=all, restoring the pre-1.9 behaviour for sites that would rather not ask slurmctld for the terminal states.
+The same query without --states=all, restoring the pre-2.0 behaviour for sites that would rather not ask slurmctld for the terminal states.
 
 Owned by `queue.go`. Runs only with `--no-collector.queue.terminal-states`.
 


### PR DESCRIPTION
1.8 is the last release of the v1 line — it lives on `release-1.8` under the
support window in `SECURITY.md` — and `master` is 2.0, with the Go module path
already moved to `/v2` (#238). A 1.9 will never be tagged, but eleven places in
the repository still promised one.

## What changed

**Flag and registry text** (`command_registry.go`, `main.go`, and the generated
`test_data/readme.md`). `--collector.queue.terminal-states` told the reader that
disabling it "restores the pre-1.9 query". The behaviour it reverts to is the
one that shipped in 1.8, and the release that changes it is 2.0, so the text now
says pre-2.0. `test_data/readme.md` is generated from the registry and follows
via `make generate`.

**Prose** — `docs/metrics.md`, `docs/configuration.md`,
`docs/metrics-examples.md` carried the same phrase.

**Templates that get copied.** `.goreleaser.yaml` illustrated a pre-release tag
with `v1.9.0-rc1`; the next pre-release this repo will actually cut is
`v2.0.0-rc1`. `docs/release-process.md` offered *"tracked for v1.9"* and *"I'll
adapt and ship in v1.9"* as wording to reuse when answering contributors —
promising a release that does not exist is the one thing those templates must
not teach.

The v1.8.2 retrospective keeps its history: #27 and PR #29 genuinely were
deferred at the time, so the line says that rather than naming the milestone
they were deferred to.

**`docs/roadmap.md`** needed more than a rename, because it also listed work
that had already landed. `## v1.9` becomes `## 2.0`, and the old
`## v2.0 (uncommitted)` becomes `## After 2.0` — its single item depends on a
2.0 item, so two sections named 2.0 would have read as a contradiction. Three of
the seven entries came out:

| Entry | Why it left |
|---|---|
| Per-node GRES metrics | Shipped — `--collector.node.gres` exists, documented in the CHANGELOG |
| Consolidate the three `sinfo` calls in `gpus.go` | Shipped — the registry declares one `gpus_snapshot`, `gpus.go` makes one `Execute` |
| Makefile container-first cleanup (#114) | Issue closed |

What stayed is what is genuinely open: the three public commitments (#27
per-state counts, `$instance`, `$cluster`) and the `context.Context` constructor
refactor, still non-blocking by #61's own criteria. One French bullet left in a
public English document was translated on the way past.

## Non-regression

No test can express "a version number in a comment is wrong", so this is proven
by measurement instead, per step 4 of the DoD:

- `docs/metric-surface.md` is **byte-identical** to `master` — no metric, label
  or help string moved.
- The registry diff touches only `Doc` and `Notes`; no `Name`, `Binary` or
  `Args` line changed, so every Slurm command the exporter issues is unchanged.
- `make check` exits 0 (vet + golangci-lint + actionlint + zizmor + deadcode +
  tests + derived-docs freshness), and the working tree is clean afterwards,
  which is what proves `test_data/readme.md` was regenerated rather than
  hand-edited.

Closes nothing; follow-up to #238.


