### PR TITLE
ci(release): refuse a tag whose version has no CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,41 @@ permissions:
   contents: read
 
 jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: The tagged version must have a CHANGELOG section
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="${version%%-*}"          # v2.0.0-rc1 -> 2.0.0
+          # Dots are wildcards in a regex, so 1.8.5 would also match [1x8x5].
+          esc=$(printf '%s' "$base" | sed 's/\./\\./g')
+          if [ "$version" != "$base" ]; then
+            # Pre-release: the section may still be [Unreleased] at this point.
+            if grep -qE "^## \[($esc|Unreleased)\]" CHANGELOG.md; then
+              echo "ok: pre-release $TAG has a section to ship under"
+              exit 0
+            fi
+            echo "::error::CHANGELOG.md has neither a [$base] nor an [Unreleased] section for $TAG."
+            exit 1
+          fi
+          if grep -qE "^## \[$esc\]" CHANGELOG.md; then
+            echo "ok: CHANGELOG.md documents $base"
+            exit 0
+          fi
+          echo "::error::CHANGELOG.md has no '## [$base]' section on the commit being tagged."
+          echo "A release with no changelog entry is invisible to everyone who did not"
+          echo "write it. Rename the [Unreleased] heading to [$base] with today's date,"
+          echo "and if this tag is cut from a maintenance branch, carry the section back"
+          echo "to master as well."
+          exit 1
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +74,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs:
+      - changelog
       - lint
       - test
     permissions:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -480,7 +480,25 @@ shorter window (~30 min) before tagging.
 
 ### Tag the final release
 
-Once you're confident on a real cluster:
+**The version must be documented in `CHANGELOG.md` on the commit you tag.**
+Rename the `[Unreleased]` heading to `[X.Y.Z]` with today's date before tagging
+— a release with no changelog entry is invisible to everyone who did not write
+it, and the omission is only noticed once the next release closes the section
+above it.
+
+This is enforced: the `changelog` job in `.github/workflows/release.yml` runs
+on every `v*` tag and `release` depends on it, so a tag with no matching
+section fails before GoReleaser publishes anything. A pre-release tag
+(`vX.Y.Z-rc1`) is allowed to ship under `[Unreleased]`, since the section is
+usually still being written at that point; a final tag is not.
+
+To check before pushing:
+
+```bash
+grep -n "^## \[X.Y.Z\]" CHANGELOG.md
+```
+
+Then:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z — <short headline>"
@@ -556,8 +574,13 @@ Then the parts that are not optional:
 2. Confirm the vulnerability is actually gone rather than merely bumped:
    `govulncheck ./...` for reachability, `trivy` for the image gate. They
    disagree on purpose, and the release is gated on Trivy.
-3. Add a `CHANGELOG.md` entry **on the branch**. It does not come back to
-   `master`, where the same fix already appears in the 2.x history.
+3. Add a `CHANGELOG.md` entry **on the branch**. The *fix* does not come back
+   to `master` — it already appears there in the 2.x history — but the
+   **released version section does**. Once the tag is cut, port the whole
+   `## [1.8.z]` section onto `master` in a separate commit, so `master`'s
+   changelog does not skip a release that shipped. This is how the 1.8.5
+   section came to be missing from `master`: it was written on the branch and
+   nothing said to carry it back.
 4. Open a PR against `release-1.8`, never against `master`.
 
 Tag from the branch once merged:


### PR DESCRIPTION
v1.8.5 was tagged, published, and served as the latest release while `master`'s
changelog still ended at 1.8.4. Nothing caught it, because nothing looked: the
process asked for a changelog entry in a table cell under *"update
documentation"*. That is an intention, not a gate — and the omission is the kind
that is only noticed once the next release closes the section above it, by which
point the history has a permanent hole.

## The gate

`.github/workflows/release.yml` gains a `changelog` job that runs on every `v*`
tag, and `release` now `needs` it, so GoReleaser cannot publish a version the
changelog does not document.

A pre-release (`vX.Y.Z-rc1`) is allowed to ship under `[Unreleased]` — the
section is usually still being written when the RC goes out. A final tag is not.

## Verified, not reasoned about

Run against the tree as it stands on `master`:

| Tag | exit | |
|---|---|---|
| `v1.8.5` | **1** | the actual defect, caught |
| `v2.0.0` | **1** | only `[Unreleased]` exists |
| `v2.0.0-rc1` | 0 | pre-release, allowed |
| `v1.8.4` | 0 | |
| `v1.8.3` | 0 | |
| `v1.7.0` | 0 | |

The version is escaped before it reaches `grep`: dots are wildcards in a regex,
so an unescaped `1.8.4` would also match a heading reading `[1x8x4]`. Confirmed
by rewriting that heading in a copy and watching the gate reject the tag —
without the escape it passed.

`make check` exits 0, which runs actionlint and zizmor over the modified
workflow.

## The instruction that made the hole

`docs/release-process.md` §12 told the maintainer that a 1.8.z changelog entry
*"does not come back to `master`"*. That is true of the **fix** — it already
exists in the 2.x history — and false of the **released version section**, which
is the only record that the release happened at all. Corrected, with the
missing step spelled out: port the whole `## [1.8.z]` section onto `master`
after tagging.

The tagging section also now states the requirement and gives the one-line check
to run before pushing a tag.

## Related

#240 fixes the instance of this defect (1.8.5 absent from `master`). This PR
stops the next one. They are independent and can merge in either order — the
gate does not fire until a tag is pushed.