### PR TITLE
test(collector): benchmark the parse path

### DIFF
--- a/internal/collector/parsers_bench_test.go
+++ b/internal/collector/parsers_bench_test.go
@@ -1,0 +1,160 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Benchmarks for the parse path.
+//
+// Every Parse* function below runs on each scrape, on output whose size grows
+// with the cluster: node_detail emits a line per node per partition, queue a
+// line per job. A regression here is paid on every scrape of every deployment,
+// and until now nothing measured it — the 2.0 line claims four performance
+// changes (#144, #149, #150, #181) with no numbers behind them.
+//
+// The functions take []byte and return a struct, so the fixtures are the
+// natural input. Fixture bytes are read once, outside the measured loop: the
+// point is to measure parsing, not os.ReadFile.
+
+func benchInput(b *testing.B, name string) []byte {
+	b.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "test_data", name))
+	if err != nil {
+		b.Skipf("fixture %s unavailable: %v", name, err)
+	}
+	return raw
+}
+
+func BenchmarkParseQueueMetrics(b *testing.B) {
+	in := benchInput(b, "queue_all_states.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseQueueMetrics(in)
+	}
+}
+
+func BenchmarkParseAccountsMetrics(b *testing.B) {
+	in := benchInput(b, "squeue_jobs_accounts_view.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseAccountsMetrics(in)
+	}
+}
+
+func BenchmarkParseUsersMetrics(b *testing.B) {
+	in := benchInput(b, "squeue_jobs_users_view.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseUsersMetrics(in)
+	}
+}
+
+func BenchmarkParseNodeMetrics(b *testing.B) {
+	in := benchInput(b, "node_detail.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseNodeMetrics(in)
+	}
+}
+
+func BenchmarkParseCPUsMetrics(b *testing.B) {
+	in := benchInput(b, "cpus.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseCPUsMetrics(in)
+	}
+}
+
+func BenchmarkParseFairShareMetrics(b *testing.B) {
+	in := benchInput(b, "fairshare.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseFairShareMetrics(in)
+	}
+}
+
+func BenchmarkParseSchedulerMetrics(b *testing.B) {
+	in := benchInput(b, "scheduler.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseSchedulerMetrics(in)
+	}
+}
+
+func BenchmarkParseLicenseMetrics(b *testing.B) {
+	in := benchInput(b, "licenses.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseLicenseMetrics(in)
+	}
+}
+
+func BenchmarkParseReservationNodesMetrics(b *testing.B) {
+	in := benchInput(b, "scontrol_nodes.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseReservationNodesMetrics(in)
+	}
+}
+
+func BenchmarkParseSacctEfficiency(b *testing.B) {
+	in := benchInput(b, "sacct_efficiency.txt")
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseSacctEfficiency(in)
+	}
+}
+
+// The three GPU counters do not take the raw snapshot: they take the three
+// column layouts splitGPUViews projects it into. Feeding them the 4-column
+// snapshot makes every line fail the field-count check, so the benchmark would
+// measure the reject path and report a speedup that says nothing about parsing
+// GRES. The projection is reproduced here rather than called, so this file
+// builds against a tree that predates splitGPUViews and both sides parse
+// byte-identical input.
+func gpuViews(b *testing.B) (total, alloc, idle []byte) {
+	b.Helper()
+	var tv, av, iv strings.Builder
+	for _, line := range strings.Split(string(benchInput(b, "gpus_snapshot.txt")), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 4 {
+			continue
+		}
+		nodes, state, gres, used := f[0], f[1], f[2], f[3]
+		tv.WriteString(nodes + " " + gres + "\n")
+		// Mirrors isAvailableGPUState: only nodes that can hold a job.
+		switch state {
+		case "allocated", "mixed", "idle", "completing", "reserved":
+			av.WriteString(nodes + " " + used + "\n")
+			iv.WriteString(nodes + " " + gres + " " + used + "\n")
+		}
+	}
+	return []byte(tv.String()), []byte(av.String()), []byte(iv.String())
+}
+
+func BenchmarkParseTotalGPUs(b *testing.B) {
+	in, _, _ := gpuViews(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseTotalGPUs(in)
+	}
+}
+
+func BenchmarkParseAllocatedGPUs(b *testing.B) {
+	_, in, _ := gpuViews(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseAllocatedGPUs(in)
+	}
+}
+
+func BenchmarkParseIdleGPUs(b *testing.B) {
+	_, _, in := gpuViews(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ParseIdleGPUs(in)
+	}
+}


### PR DESCRIPTION
The 2.0 line claims four performance changes — #144, #149, #150, #181 — and the
repository contains **zero benchmarks**. None of those claims had a number
behind it, and a regression on the parse path, which runs on every scrape of
every deployment, had nothing to fail against.

Thirteen benchmarks, one per `Parse*` function taking `[]byte`, each on the
fixture the registry declares for it. Fixture bytes read outside the measured
loop; `b.Loop()` rather than a `b.N` loop.

## What the numbers say

Measured against `v1.8.5`, six runs each, `benchstat` (all p=0.002, CI ±0–1%):

| Parser | time | B/op | allocs/op |
|---|---|---|---|
| ParseTotalGPUs | **−46.6%** | −68.5% | −54.6% |
| ParseAllocatedGPUs | **−46.2%** | −69.5% | −54.6% |
| ParseIdleGPUs | **−23.3%** | −48.2% | −30.8% |
| ParseCPUsMetrics | −2.4% | ~ | ~ |
| ParseUsersMetrics | −1.5% | ~ | ~ |
| ParseAccountsMetrics | −0.7% | ~ | ~ |
| ParseFairShareMetrics | ~ | ~ | ~ |
| ParseLicenseMetrics | +1.4% | ~ | ~ |
| ParseNodeMetrics | +4.3% | +1.7% | ~ |
| ParseSchedulerMetrics | +4.3% | ~ | ~ |
| ParseReservationNodesMetrics | +4.7% | +2.5% | −20% |

The three GPU parsers are #150's unified GRES parsing, and it is a large win.
The four parsers that got slower have **byte-identical output**, so the
comparison is honest; at ~7.5 µs against roughly twenty process forks per
scrape, 4% is not worth chasing — but it is now visible if it grows.

## Two things the first draft got wrong

Both found by checking what the parsers *returned*, not by trusting the timings.

**The GPU benchmarks were measuring the reject path.** The three counters do not
take the raw `gpus_snapshot`: they take the three column layouts
`splitGPUViews` projects it into. Fed the 4-column snapshot, every line fails
the field-count check. The benchmark reported 962 B/op where real parsing costs
2596, and a −62% "speedup" that described nothing. The projection is reproduced
inside the benchmark rather than called, so the file also builds against a tree
that predates `splitGPUViews` — which is what makes the A/B run possible.

**Two parsers are not comparable across versions and are excluded from the
table above:**

- `ParseQueueMetrics` emits **60 map entries against 44** on the same input,
  because `--states=all` is the entire point of #161. Its +24% is the cost of
  36% more output, not a regression.
- `ParseSacctEfficiency`: the fixture went from **8 to 9 columns** when `JobID`
  was added for #180, so the 1.8.5 parser returns **zero records** from the 2.0
  fixture. A timing that compares work against no work is worse than no timing.

## Verification

`make check` exits 0. The benchmarks are `go test -bench` only — no production
code changed, and `docs/metric-surface.md` is untouched.